### PR TITLE
[Feat]#33 그룹 신청목록 조회 기능 신청수락거절 기능 구현

### DIFF
--- a/src/main/java/com/example/bookiibookii/domain/group/controller/ApplicationController.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/controller/ApplicationController.java
@@ -1,5 +1,6 @@
 package com.example.bookiibookii.domain.group.controller;
 
+import com.example.bookiibookii.domain.group.dto.req.ApplicationRequestDTO;
 import com.example.bookiibookii.domain.group.dto.res.ApplicationResponseDTO;
 import com.example.bookiibookii.domain.group.enums.ApplicationStatus;
 import com.example.bookiibookii.domain.group.service.ApplicationService;
@@ -46,15 +47,16 @@ public class ApplicationController {
     @Operation(summary = "참여요청 수락/거절 API", description = "신청자의 참여 요청을 수락하거나 거절합니다.")
     @Parameters({
             @Parameter(name = "applyId", description = "신청(Application) ID", example = "10"),
-            @Parameter(name = "userId", description = "현재 로그인한 유저의 ID (방장 확인용)", example = "1"),
-            @Parameter(name = "status", description = "변경할 상태 (ACCEPTED/REJECTED)", example = "ACCEPTED")
+            @Parameter(name = "userId", description = "현재 로그인한 유저의 ID (방장 확인용)", example = "1"),//로그인 연동전까지 유지
+
     })
     public ApiResponse<ApplicationResponseDTO.UpdateResultDTO> updateApplicationStatus(
             @PathVariable(name = "applyId") Long applyId,
             @RequestParam(name = "userId") Long userId,
-            @RequestParam(name = "status") ApplicationStatus status
+            @RequestBody ApplicationRequestDTO.UpdateStatusDTO request
     ) {
-        ApplicationResponseDTO.UpdateResultDTO result = applicationService.updateApplicationStatus(applyId, userId, status);
+        ApplicationResponseDTO.UpdateResultDTO result =
+                applicationService.updateApplicationStatus(applyId, userId, request.getStatus());
         return ApiResponse.onSuccess(GeneralSuccessCode.REQUEST_OK, result);
     }
 }

--- a/src/main/java/com/example/bookiibookii/domain/group/controller/ApplicationController.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/controller/ApplicationController.java
@@ -1,0 +1,60 @@
+package com.example.bookiibookii.domain.group.controller;
+
+import com.example.bookiibookii.domain.group.dto.res.ApplicationResponseDTO;
+import com.example.bookiibookii.domain.group.enums.ApplicationStatus;
+import com.example.bookiibookii.domain.group.service.ApplicationService;
+import com.example.bookiibookii.global.apiPayload.ApiResponse;
+import com.example.bookiibookii.global.apiPayload.code.GeneralSuccessCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "그룹 관련 API", description = "그룹 및 신청 관리 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/groups")
+public class ApplicationController {
+
+    private final ApplicationService applicationService;
+
+    @GetMapping("/{groupId}/applylist")
+    @Operation(summary = "신청자 명단 조회 API", description = "방장이 그룹 신청자 목록을 조회합니다. (토큰 대신 userId를 파라미터로 받음)")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "성공입니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "GROUP4001", description = "해당 그룹을 찾을 수 없습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "MEMBER4002", description = "방장 권한이 없습니다.")
+    })
+    @Parameters({
+            @Parameter(name = "groupId", description = "조회할 그룹 ID", example = "1"),
+            @Parameter(name = "userId", description = "현재 로그인한 유저의 ID (방장 확인용)", example = "1")
+    })
+    public ApiResponse<ApplicationResponseDTO.ApplicationListDTO> getApplicantList(
+            @PathVariable(name = "groupId") Long groupId,
+            @RequestParam(name = "userId") Long userId // 토큰 대신 직접 유저 ID를 받음
+    ) {
+        // 서비스 로직에 전달
+        ApplicationResponseDTO.ApplicationListDTO response = applicationService.getApplicantList(groupId, userId);
+
+        return ApiResponse.onSuccess(GeneralSuccessCode.REQUEST_OK, response);
+    }
+
+    @PatchMapping("/apply/{applyId}")
+    @Operation(summary = "참여요청 수락/거절 API", description = "신청자의 참여 요청을 수락하거나 거절합니다.")
+    @Parameters({
+            @Parameter(name = "applyId", description = "신청(Application) ID", example = "10"),
+            @Parameter(name = "userId", description = "현재 로그인한 유저의 ID (방장 확인용)", example = "1"),
+            @Parameter(name = "status", description = "변경할 상태 (ACCEPTED/REJECTED)", example = "ACCEPTED")
+    })
+    public ApiResponse<ApplicationResponseDTO.UpdateResultDTO> updateApplicationStatus(
+            @PathVariable(name = "applyId") Long applyId,
+            @RequestParam(name = "userId") Long userId,
+            @RequestParam(name = "status") ApplicationStatus status
+    ) {
+        ApplicationResponseDTO.UpdateResultDTO result = applicationService.updateApplicationStatus(applyId, userId, status);
+        return ApiResponse.onSuccess(GeneralSuccessCode.REQUEST_OK, result);
+    }
+}

--- a/src/main/java/com/example/bookiibookii/domain/group/dto/req/ApplicationRequestDTO.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/dto/req/ApplicationRequestDTO.java
@@ -1,0 +1,13 @@
+package com.example.bookiibookii.domain.group.dto.req;
+
+import com.example.bookiibookii.domain.group.enums.ApplicationStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+public class ApplicationRequestDTO {
+    @Getter
+    public static class UpdateStatusDTO {
+        @Schema(description = "변경할 상태 (ACCEPTED/REJECTED)", example = "ACCEPTED")
+        private ApplicationStatus status;
+    }
+}

--- a/src/main/java/com/example/bookiibookii/domain/group/dto/res/ApplicationResponseDTO.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/dto/res/ApplicationResponseDTO.java
@@ -2,6 +2,7 @@ package com.example.bookiibookii.domain.group.dto.res;
 
 
 import com.example.bookiibookii.domain.group.enums.ApplicationStatus;
+import com.example.bookiibookii.domain.group.enums.GroupStatus;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -45,6 +46,7 @@ public class ApplicationResponseDTO {
     public static class UpdateResultDTO {
         private Long applicationId;      // 수정된 신청 ID
         private ApplicationStatus status; // 변경된 상태
+        private GroupStatus groupStatus; //그룹상태(RECRUTING, MATCHED)
         private String updatedAt;         // 변경된 시간 (포맷팅된 문자열)
     }
 

--- a/src/main/java/com/example/bookiibookii/domain/group/dto/res/ApplicationResponseDTO.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/dto/res/ApplicationResponseDTO.java
@@ -1,0 +1,51 @@
+package com.example.bookiibookii.domain.group.dto.res;
+
+
+import com.example.bookiibookii.domain.group.enums.ApplicationStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class ApplicationResponseDTO {
+
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class ApplicationListDTO{
+        @Builder.Default
+        private List<ApplicationDetailDTO> applicationList = new ArrayList<>();
+        private Integer totalCount;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class ApplicationDetailDTO {
+        private Long applicationId;
+        private Long userId;
+        private String name;
+        //private String profileImageUrl; //유저 프로필 이미지
+        //@Builder.Default
+        //private List<String> tags = new ArrayList<>(); // "#메모환영", "#인사이트" 등?
+        private String createdAt;
+        private String applyMsg;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class UpdateResultDTO {
+        private Long applicationId;      // 수정된 신청 ID
+        private ApplicationStatus status; // 변경된 상태
+        private String updatedAt;         // 변경된 시간 (포맷팅된 문자열)
+    }
+
+}

--- a/src/main/java/com/example/bookiibookii/domain/group/entity/Application.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/entity/Application.java
@@ -23,16 +23,18 @@ public class Application extends BaseEntity {
     @JoinColumn(name = "group_id", nullable = false)
     private Groups group;
 
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "guest_id", nullable = false)
     private User guest;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "application_status",nullable = false)
-    private ApplicationStatus applicationStatus;
+    private ApplicationStatus applicationStatus; //PENDING, ACCEPTED, REJECTED
 
-    @Column(name = "apply_msg", length = 500)
+
+    @Column(name = "apply_msg", length = 200)
     private String applyMsg;
+
+
 
 }

--- a/src/main/java/com/example/bookiibookii/domain/group/entity/Application.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/entity/Application.java
@@ -35,6 +35,9 @@ public class Application extends BaseEntity {
     @Column(name = "apply_msg", length = 200)
     private String applyMsg;
 
-
+    //신청 상태 변경 메서드
+    public void updateStatus(ApplicationStatus status) {
+        this.applicationStatus = status;
+    }
 
 }

--- a/src/main/java/com/example/bookiibookii/domain/group/entity/Groups.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/entity/Groups.java
@@ -24,9 +24,9 @@ public class Groups extends BaseEntity {
     @Column(name = "group_id")
     private Long groupId;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @Column(name = "book_id")
-    private Book bookId;
+    //@ManyToOne(fetch = FetchType.LAZY)
+    //@Column(name = "book_id")
+    //private Book bookId;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "host_id") // 방장(Host) FK 매핑
@@ -47,6 +47,10 @@ public class Groups extends BaseEntity {
 
     @Column(name = "group_comment", length = 200)
     private String groupComment;
+
+    //@Builder.Default
+    //@OneToMany(mappedBy = "group", cascade = CascadeType.ALL)
+    //private List<GroupTag> groupTags = new ArrayList<>()
 
     @Builder.Default
     @OneToMany(mappedBy = "group", cascade = CascadeType.ALL)

--- a/src/main/java/com/example/bookiibookii/domain/group/entity/Groups.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/entity/Groups.java
@@ -24,9 +24,9 @@ public class Groups extends BaseEntity {
     @Column(name = "group_id")
     private Long groupId;
 
-    //@ManyToOne(fetch = FetchType.LAZY)
-    //@Column(name = "book_id")
-    //private Book bookId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @Column(name = "book_id")
+    private Book bookId;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "host_id") // 방장(Host) FK 매핑
@@ -45,7 +45,7 @@ public class Groups extends BaseEntity {
     @Column(name = "group_status")
     private GroupStatus status; // RECRUITING, MATCHED, COMPLETED
 
-    @Column(name = "group_comment")
+    @Column(name = "group_comment", length = 200)
     private String groupComment;
 
     @Builder.Default
@@ -54,6 +54,6 @@ public class Groups extends BaseEntity {
 
     @Builder.Default
     @OneToMany(mappedBy = "group", cascade = CascadeType.ALL)
-    private List<MatchedGroup> matchedGroups = new ArrayList<>();
+    private List<MatchedMember> matchedMember = new ArrayList<>();
 
 }

--- a/src/main/java/com/example/bookiibookii/domain/group/entity/Groups.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/entity/Groups.java
@@ -43,7 +43,7 @@ public class Groups extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     @Column(name = "group_status")
-    private GroupStatus status; // RECRUITING, MATCHED, COMPLETED
+    private GroupStatus groupStatus; // RECRUITING, MATCHED, COMPLETED
 
     @Column(name = "group_comment", length = 200)
     private String groupComment;
@@ -60,4 +60,7 @@ public class Groups extends BaseEntity {
     @OneToMany(mappedBy = "group", cascade = CascadeType.ALL)
     private List<MatchedMember> matchedMember = new ArrayList<>();
 
+    public void updateStatus(GroupStatus status) {
+        this.groupStatus = status;
+    }
 }

--- a/src/main/java/com/example/bookiibookii/domain/group/entity/MatchedMember.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/entity/MatchedMember.java
@@ -8,7 +8,7 @@ import lombok.*;
 
 
 @Entity
-@Table(name = "matchedgroup")
+@Table(name = "matchedmember")
 @Getter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/example/bookiibookii/domain/group/entity/MatchedMember.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/entity/MatchedMember.java
@@ -1,5 +1,6 @@
 package com.example.bookiibookii.domain.group.entity;
 
+import com.example.bookiibookii.domain.group.enums.RoleStatus;
 import com.example.bookiibookii.domain.user.entity.User;
 import com.example.bookiibookii.global.entity.BaseEntity;
 import jakarta.persistence.*;
@@ -12,12 +13,12 @@ import lombok.*;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class MatchedGroup extends BaseEntity {
+public class MatchedMember extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "groupmatched_id")
-    private Long groupMatchedId;
+    @Column(name = "matchedmember_id")
+    private Long matchedMember;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "group_id")
@@ -25,5 +26,12 @@ public class MatchedGroup extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
-    private User groupGuest; //최종 승인된 멤버
+    private User userId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "role")
+    private RoleStatus role;
+
+    @Column(name = "reading_order", nullable = false)
+    private Integer readingOrder; // 1, 2, 3... 순서 저장
 }

--- a/src/main/java/com/example/bookiibookii/domain/group/enums/ApplicationStatus.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/enums/ApplicationStatus.java
@@ -1,5 +1,5 @@
 package com.example.bookiibookii.domain.group.enums;
 
 public enum ApplicationStatus {
-    SUBMITTED, WITHDRAW
+    ACCEPTED, PENDING, REJECTED
 }

--- a/src/main/java/com/example/bookiibookii/domain/group/enums/RoleStatus.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/enums/RoleStatus.java
@@ -1,0 +1,5 @@
+package com.example.bookiibookii.domain.group.enums;
+
+public enum RoleStatus {
+    HOST, GUEST
+}

--- a/src/main/java/com/example/bookiibookii/domain/group/exception/code/GroupErrorCode.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/exception/code/GroupErrorCode.java
@@ -1,0 +1,23 @@
+package com.example.bookiibookii.domain.group.exception.code;
+
+import com.example.bookiibookii.global.apiPayload.code.BaseCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum GroupErrorCode implements BaseCode {
+    // 404 Not Found
+    GROUP_NOT_FOUND(HttpStatus.NOT_FOUND,"GROUP4001", "해당 그룹을 찾을 수 없습니다."),
+    APPLICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "GROUP4002", "신청 내역을 찾을 수 없습니다."),
+
+    // 403 Forbidden
+    MEMBER_NOT_HOST(HttpStatus.FORBIDDEN, "GROUP4003", "Host만 접근 가능한 메뉴입니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+
+}
+

--- a/src/main/java/com/example/bookiibookii/domain/group/exception/code/GroupErrorCode.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/exception/code/GroupErrorCode.java
@@ -12,6 +12,7 @@ public enum GroupErrorCode implements BaseCode {
     GROUP_NOT_FOUND(HttpStatus.NOT_FOUND,"GROUP4001", "해당 그룹을 찾을 수 없습니다."),
     APPLICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "GROUP4002", "신청 내역을 찾을 수 없습니다."),
     ALREADY_PROCESSED_APPLICATION(HttpStatus.BAD_REQUEST, "GROUP4005", "이미 처리된 신청 내역입니다."),
+    GROUP_FULL(HttpStatus.BAD_REQUEST, "GROUP4006", "이미 정원이 가득 찬 그룹입니다."),
 
     // 403 Forbidden
     MEMBER_NOT_HOST(HttpStatus.FORBIDDEN, "GROUP4003", "Host만 접근 가능한 메뉴입니다.");

--- a/src/main/java/com/example/bookiibookii/domain/group/exception/code/GroupErrorCode.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/exception/code/GroupErrorCode.java
@@ -11,6 +11,7 @@ public enum GroupErrorCode implements BaseCode {
     // 404 Not Found
     GROUP_NOT_FOUND(HttpStatus.NOT_FOUND,"GROUP4001", "해당 그룹을 찾을 수 없습니다."),
     APPLICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "GROUP4002", "신청 내역을 찾을 수 없습니다."),
+    ALREADY_PROCESSED_APPLICATION(HttpStatus.BAD_REQUEST, "GROUP4005", "이미 처리된 신청 내역입니다."),
 
     // 403 Forbidden
     MEMBER_NOT_HOST(HttpStatus.FORBIDDEN, "GROUP4003", "Host만 접근 가능한 메뉴입니다.");

--- a/src/main/java/com/example/bookiibookii/domain/group/repository/ApplicationRepository.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/repository/ApplicationRepository.java
@@ -1,6 +1,7 @@
 package com.example.bookiibookii.domain.group.repository;
 
 import com.example.bookiibookii.domain.group.entity.Application;
+import com.example.bookiibookii.domain.group.enums.ApplicationStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -17,4 +18,11 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
             //"LEFT JOIN FETCH ut.tag " +
             "WHERE a.group.id = :groupId AND a.applicationStatus = 'PENDING'")
     List<Application> findAllWithGuestAndTagsByGroupId(@Param("groupId") Long groupId);
+
+    // 특정 그룹의 현재 수락된 인원수를 세기 위한 메서드
+    long countByGroupGroupIdAndApplicationStatus(Long groupId, ApplicationStatus status);
+
+    //특정 그룹의 '대기 중'인 신청서들만 조회 (Fetch Join으로 Guest 정보까지 한 번에)
+    @Query("SELECT a FROM Application a JOIN FETCH a.guest WHERE a.group.id = :groupId AND a.applicationStatus = 'PENDING'")
+    List<Application> findAllPendingByGroupId(@Param("groupId") Long groupId);
 }

--- a/src/main/java/com/example/bookiibookii/domain/group/repository/ApplicationRepository.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/repository/ApplicationRepository.java
@@ -2,8 +2,19 @@ package com.example.bookiibookii.domain.group.repository;
 
 import com.example.bookiibookii.domain.group.entity.Application;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface ApplicationRepository extends JpaRepository<Application, Long> {
+    // N+1 문제 해결: 신청서 + 신청자(User) + 유저의 태그들까지
+    @Query("SELECT a FROM Application a " +
+            "JOIN FETCH a.guest g " +
+            //"LEFT JOIN FETCH g.userTags ut " +
+            //"LEFT JOIN FETCH ut.tag " +
+            "WHERE a.group.id = :groupId AND a.applicationStatus = 'PENDING'")
+    List<Application> findAllWithGuestAndTagsByGroupId(@Param("groupId") Long groupId);
 }

--- a/src/main/java/com/example/bookiibookii/domain/group/repository/MatchedGroupRepository.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/repository/MatchedGroupRepository.java
@@ -1,9 +1,9 @@
 package com.example.bookiibookii.domain.group.repository;
 
-import com.example.bookiibookii.domain.group.entity.MatchedGroup;
+import com.example.bookiibookii.domain.group.entity.MatchedMember;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface MatchedGroupRepository extends JpaRepository<MatchedGroup, Long> {
+public interface MatchedGroupRepository extends JpaRepository<MatchedMember, Long> {
 }

--- a/src/main/java/com/example/bookiibookii/domain/group/service/ApplicationService.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/service/ApplicationService.java
@@ -20,6 +20,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.stream.Collectors;
 
+
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -71,12 +72,43 @@ public class ApplicationService {
             throw new GeneralException(GroupErrorCode.ALREADY_PROCESSED_APPLICATION);
         }
 
-        // 4. 상태 업데이트 (JPA Dirty Checking으로 자동 반영)
+        // 4. 수락(ACCEPTED) 시도 시 정원 초과 여부 사전 체크
+        if (status == ApplicationStatus.ACCEPTED) {
+            Groups groups = application.getGroup();
+
+            // 현재 이미 수락된 인원수 계산
+            long currentAcceptedCount = applicationRepository.countByGroupGroupIdAndApplicationStatus(groups.getGroupId(), ApplicationStatus.ACCEPTED);
+
+            // 이미 정원이 찼는데 또 수락하려는 경우 예외 발생
+            if (currentAcceptedCount >= groups.getMaxCapacity()) {
+                throw new GeneralException(GroupErrorCode.GROUP_FULL);
+            }
+        }
+
+        // 4. 상태 업데이트
         application.updateStatus(status);
 
         // 5. 수락 시: 그룹 상태를 진행중으로 변경(MATCHED)
         if (status == ApplicationStatus.ACCEPTED) {
-            application.getGroup().updateStatus(GroupStatus.MATCHED);
+            Groups groups = application.getGroup();
+            // 현재 수락된 총 인원수 계산
+            long currentAcceptedCount = applicationRepository.countByGroupGroupIdAndApplicationStatus(groups.getGroupId(), ApplicationStatus.ACCEPTED);
+
+            // 정원이 다 찼을 경우만
+            if (currentAcceptedCount >= groups.getMaxCapacity()) {
+                groups.updateStatus(GroupStatus.MATCHED);
+
+                // 나머지 PENDING 인원들 조회 및 일괄 거절
+                List<Application> pendingApplications = applicationRepository.findAllPendingByGroupId(groups.getGroupId());
+
+                for (Application pendingApp : pendingApplications) {
+                    pendingApp.updateStatus(ApplicationStatus.REJECTED);
+
+                    //시스템 알람 발송 (알람 파트 구현 시 주석 해제)
+                    // notificationService.sendAutoRejectNotification(pendingApp.getGuest(), group);
+                }
+            }
+
         }
 
         // 6. 거절 시: 알람 발송
@@ -84,7 +116,7 @@ public class ApplicationService {
         //    notificationService.sendRejectNotification(application.getGuest(), application.getGroup());
         //}
 
-        // 7. 결과 DTO 반환
+        //  결과 DTO 반환
         return ApplicationResponseDTO.UpdateResultDTO.builder()
                 .applicationId(application.getApplicationId())
                 .status(application.getApplicationStatus())

--- a/src/main/java/com/example/bookiibookii/domain/group/service/ApplicationService.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/service/ApplicationService.java
@@ -65,20 +65,26 @@ public class ApplicationService {
             throw new GeneralException(GroupErrorCode.MEMBER_NOT_HOST);
         }
 
-        // 3. 상태 업데이트 (JPA Dirty Checking으로 자동 반영)
+        //3. 이미 처리된 신청인지 확인
+        // 상태가 PENDING(대기 중)이 아닐 때 수락/거절을 시도하면 예외 발생
+        if (application.getApplicationStatus() != ApplicationStatus.PENDING) {
+            throw new GeneralException(GroupErrorCode.ALREADY_PROCESSED_APPLICATION);
+        }
+
+        // 4. 상태 업데이트 (JPA Dirty Checking으로 자동 반영)
         application.updateStatus(status);
 
-        // 3. 수락 시: 그룹 상태를 진행중으로 변경(MATCHED)
+        // 5. 수락 시: 그룹 상태를 진행중으로 변경(MATCHED)
         if (status == ApplicationStatus.ACCEPTED) {
             application.getGroup().updateStatus(GroupStatus.MATCHED);
         }
 
-        // 4. 거절 시: 알람 발송
+        // 6. 거절 시: 알람 발송
         //if (status == ApplicationStatus.REJECTED) {
         //    notificationService.sendRejectNotification(application.getGuest(), application.getGroup());
         //}
 
-        // 4. 결과 DTO 반환
+        // 7. 결과 DTO 반환
         return ApplicationResponseDTO.UpdateResultDTO.builder()
                 .applicationId(application.getApplicationId())
                 .status(application.getApplicationStatus())

--- a/src/main/java/com/example/bookiibookii/domain/group/service/ApplicationService.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/service/ApplicationService.java
@@ -1,0 +1,95 @@
+package com.example.bookiibookii.domain.group.service;
+
+
+import com.example.bookiibookii.domain.group.dto.res.ApplicationResponseDTO;
+import com.example.bookiibookii.domain.group.entity.Application;
+import com.example.bookiibookii.domain.group.entity.Groups;
+import com.example.bookiibookii.domain.group.enums.ApplicationStatus;
+import com.example.bookiibookii.domain.group.exception.code.GroupErrorCode;
+import com.example.bookiibookii.domain.group.repository.ApplicationRepository;
+import com.example.bookiibookii.domain.group.repository.GroupsRepository;
+import com.example.bookiibookii.domain.user.entity.User;
+import com.example.bookiibookii.global.apiPayload.exception.GeneralException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ApplicationService {
+    private final ApplicationRepository applicationRepository;
+    private final GroupsRepository groupsRepository;
+
+    // 신청 조회 로직
+    public ApplicationResponseDTO.ApplicationListDTO getApplicantList(Long groupId, Long currentUserId) {
+        // 1. 그룹 존재 여부 확인
+        Groups group = groupsRepository.findById(groupId)
+                .orElseThrow(() -> new GeneralException(GroupErrorCode.GROUP_NOT_FOUND));
+
+        // 2. 권한 체크: 현재 로그인한 유저가 이 그룹의 방장(Host)인지 확인
+        if (!group.getHost().getId().equals(currentUserId)) {
+            throw new GeneralException(GroupErrorCode.MEMBER_NOT_HOST);
+        }
+
+        // 3. 신청자 명단 조회 (Fetch Join으로 User와 Tag까지 한 번에!)
+        List<Application> applications = applicationRepository.findAllWithGuestAndTagsByGroupId(groupId);
+
+        // 4. 엔티티 리스트를 DTO 리스트로 변환
+        List<ApplicationResponseDTO.ApplicationDetailDTO> detailDTOs = applications.stream()
+                .map(this::toDetailDTO)
+                .collect(Collectors.toList());
+
+        return ApplicationResponseDTO.ApplicationListDTO.builder()
+                .applicationList(detailDTOs)
+                .totalCount(detailDTOs.size())
+                .build();
+    }
+
+    //참가 수락 거절 로직
+    @Transactional(readOnly = false) // 쓰기 작업이므로 readOnly = false (기본값)로 덮어씌움
+    public ApplicationResponseDTO.UpdateResultDTO updateApplicationStatus(Long applyId, Long userId, ApplicationStatus status) {
+
+        // 1. 신청 내역 존재 여부 확인
+        Application application = applicationRepository.findById(applyId)
+                .orElseThrow(() -> new GeneralException(GroupErrorCode.APPLICATION_NOT_FOUND));
+
+        // 2. 권한 체크: 이 신청이 들어온 그룹의 방장이 요청자(userId)와 일치하는지 확인
+        if (!application.getGroup().getHost().getId().equals(userId)) {
+            throw new GeneralException(GroupErrorCode.MEMBER_NOT_HOST);
+        }
+
+        // 3. 상태 업데이트 (JPA Dirty Checking으로 자동 반영)
+        application.updateStatus(status);
+
+        // 4. 결과 DTO 반환
+        return ApplicationResponseDTO.UpdateResultDTO.builder()
+                .applicationId(application.getApplicationId())
+                .status(application.getApplicationStatus())
+                .updatedAt(LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy. MM. dd. HH:mm")))
+                .build();
+    }
+    private ApplicationResponseDTO.ApplicationDetailDTO toDetailDTO(Application application) {
+        User guest = application.getGuest();
+
+        // 태그 이름만 String 리스트로 추출
+        //List<String> tagNames = guest.getUserTags().stream()
+                //.map(ut -> ut.getTag().getName())
+                //.collect(Collectors.toList());
+
+        return ApplicationResponseDTO.ApplicationDetailDTO.builder()
+                .applicationId(application.getApplicationId())
+                .userId(guest.getId())
+                .name(guest.getName())
+                //.profileImageUrl(guest.getImageUrl()) //프로필 사진
+                .createdAt(application.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy. MM. dd.")))
+                //.tags(tagNames) //grouptag
+                .applyMsg(application.getApplyMsg())
+                .build();
+    }
+}

--- a/src/main/java/com/example/bookiibookii/domain/group/service/ApplicationService.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/service/ApplicationService.java
@@ -5,6 +5,7 @@ import com.example.bookiibookii.domain.group.dto.res.ApplicationResponseDTO;
 import com.example.bookiibookii.domain.group.entity.Application;
 import com.example.bookiibookii.domain.group.entity.Groups;
 import com.example.bookiibookii.domain.group.enums.ApplicationStatus;
+import com.example.bookiibookii.domain.group.enums.GroupStatus;
 import com.example.bookiibookii.domain.group.exception.code.GroupErrorCode;
 import com.example.bookiibookii.domain.group.repository.ApplicationRepository;
 import com.example.bookiibookii.domain.group.repository.GroupsRepository;
@@ -67,10 +68,21 @@ public class ApplicationService {
         // 3. 상태 업데이트 (JPA Dirty Checking으로 자동 반영)
         application.updateStatus(status);
 
+        // 3. 수락 시: 그룹 상태를 진행중으로 변경(MATCHED)
+        if (status == ApplicationStatus.ACCEPTED) {
+            application.getGroup().updateStatus(GroupStatus.MATCHED);
+        }
+
+        // 4. 거절 시: 알람 발송
+        //if (status == ApplicationStatus.REJECTED) {
+        //    notificationService.sendRejectNotification(application.getGuest(), application.getGroup());
+        //}
+
         // 4. 결과 DTO 반환
         return ApplicationResponseDTO.UpdateResultDTO.builder()
                 .applicationId(application.getApplicationId())
                 .status(application.getApplicationStatus())
+                .groupStatus(application.getGroup().getGroupStatus())
                 .updatedAt(LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy. MM. dd. HH:mm")))
                 .build();
     }

--- a/src/main/java/com/example/bookiibookii/domain/user/entity/User.java
+++ b/src/main/java/com/example/bookiibookii/domain/user/entity/User.java
@@ -6,6 +6,7 @@ import com.example.bookiibookii.global.auth.social.SocialUserInfo;
 import com.example.bookiibookii.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.cfg.Compatibility;
 
 import java.time.LocalDate;
 
@@ -28,6 +29,9 @@ public class User extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Column(name = "name",nullable = false)
+    private String name;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "social_type", nullable = false, length = 30)

--- a/src/main/java/com/example/bookiibookii/global/security/SecurityConfig.java
+++ b/src/main/java/com/example/bookiibookii/global/security/SecurityConfig.java
@@ -31,7 +31,8 @@ public class SecurityConfig {
                         .requestMatchers(
                                 "/api/auth/**",        // 로그인, 토큰 재발급, 로그아웃
                                 "/swagger-ui/**",
-                                "/v3/api-docs/**"
+                                "/v3/api-docs/**",
+                                "/api/groups/**"
                         ).permitAll()
                         .anyRequest().authenticated()
                 )


### PR DESCRIPTION
## 개요
신청자 명단 조회 API 구현: PENDING 상태의 신청자 리스트와 총 인원수를 반환합니다.
신청 상태 변경 API 구현: 방장 권한 확인 로직을 포함하여 신청서를 수락/거절할 수 있도록 구현했습니다.
보안 설정 업데이트: 테스트 및 원활한 프론트엔드 연동을 위해 /api/groups/** 경로의 보안 필터를 조정했습니다.
예외 처리: 존재하지 않는 신청서 접근이나 방장이 아닌 유저의 접근 시 커스텀 에러 코드를 반환하도록 처리했습니다.

<!---- Resolves: #(Isuue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

📣 **To Reviewers**
---
테스트 완료: Swagger UI를 통해 정상적인 신청/수락/거절 시나리오를 검증했으며, DB에 상태값이 올바르게 반영되는 것을 확인했습니다.

참고 사항: 개발 초기 단계의 원활한 테스트를 위해 SecurityConfig에서 그룹 관련 API를 임시로 허용(permitAll)해 두었습니다. 추후 실제 로그인 유저 토큰 기반으로 검증하도록 고도화할 예정입니다.

- Reviewers : 팀 선택
- Labels : 작업 유형, 자기 자신


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 그룹 신청자 목록 조회 및 신청 상태(ACCEPTED/PENDING/REJECTED) 업데이트 API 추가
  * 신청 수락 시 그룹 상태 자동 변경 및 남은 신청 자동 반려 흐름 도입
  * 매칭 멤버의 역할(HOST/GUEST) 및 멤버 관리 기능 추가

* **API & 보안**
  * 그룹 관련 엔드포인트에 대한 공개 접근 허용 확대

* **기타**
  * 사용자 이름 필드 추가, 신청 메시지 길이 제한 축소, 그룹 관련 오류 코드/메시지 정비

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->