### PR TITLE
[Feat]#36 그룹 신청 api 구현

### DIFF
--- a/src/main/java/com/example/bookiibookii/domain/group/controller/ApplicationController.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/controller/ApplicationController.java
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -57,6 +58,21 @@ public class ApplicationController {
     ) {
         ApplicationResponseDTO.UpdateResultDTO result =
                 applicationService.updateApplicationStatus(applyId, userId, request.getStatus());
+        return ApiResponse.onSuccess(GeneralSuccessCode.REQUEST_OK, result);
+    }
+
+    @PostMapping("/{groupId}/apply")
+    @Operation(summary = "그룹 참여 신청 API", description = "게스트가 특정 그룹에 참여 신청을 보냅니다.")
+    @Parameters({
+            @Parameter(name = "groupId", description = "참여하려는 그룹의 ID", example = "1"),
+            @Parameter(name = "userId", description = "현재 로그인한 유저의 ID (테스트용)", example = "2")
+    })
+    public ApiResponse<ApplicationResponseDTO.JoinResultDTO> joinGroup(
+            @PathVariable(name = "groupId") Long groupId,
+            @RequestParam(name = "userId") Long userId, // 실제 배포 시에는 Authentication 객체 등으로 교체 예정
+            @RequestBody @Valid ApplicationRequestDTO.JoinApplicationDTO request // @Valid로 글자 수 등 검증
+    ) {
+        ApplicationResponseDTO.JoinResultDTO result = applicationService.joinGroup(groupId, userId, request);
         return ApiResponse.onSuccess(GeneralSuccessCode.REQUEST_OK, result);
     }
 }

--- a/src/main/java/com/example/bookiibookii/domain/group/dto/req/ApplicationRequestDTO.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/dto/req/ApplicationRequestDTO.java
@@ -2,12 +2,24 @@ package com.example.bookiibookii.domain.group.dto.req;
 
 import com.example.bookiibookii.domain.group.enums.ApplicationStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 
 public class ApplicationRequestDTO {
+    // host의 수락/거절 상태 변화용
     @Getter
     public static class UpdateStatusDTO {
         @Schema(description = "변경할 상태 (ACCEPTED/REJECTED)", example = "ACCEPTED")
         private ApplicationStatus status;
+    }
+
+    //게스트 그룹참여 신청서
+    @Getter
+    public static class JoinApplicationDTO {
+        @Schema(description = "신청 한 마디", example = "안녕하세요! 끝까지 완독할 자신 있습니다.")
+        @NotBlank(message = "신청 메시지를 입력해주세요.") //
+        @Size(max = 50, message = "신청 메시지는 50자 이내로 입력해주세요.") // 기획서의 0/50 반영
+        private String applyMsg;
     }
 }

--- a/src/main/java/com/example/bookiibookii/domain/group/dto/res/ApplicationResponseDTO.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/dto/res/ApplicationResponseDTO.java
@@ -19,7 +19,7 @@ public class ApplicationResponseDTO {
     @Getter
     @Builder
     @AllArgsConstructor
-    public static class ApplicationListDTO{
+    public static class ApplicationListDTO {
         @Builder.Default
         private List<ApplicationDetailDTO> applicationList = new ArrayList<>();
         private Integer totalCount;
@@ -50,4 +50,13 @@ public class ApplicationResponseDTO {
         private String updatedAt;         // 변경된 시간 (포맷팅된 문자열)
     }
 
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class JoinResultDTO {
+        private Long applicationId;  // 신청서 ID
+        private String status;       // 신청 상태 (PENDING 등)
+        private String createdAt;    // 신청 일자
+    }
 }

--- a/src/main/java/com/example/bookiibookii/domain/group/exception/GroupException.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/exception/GroupException.java
@@ -1,0 +1,10 @@
+package com.example.bookiibookii.domain.group.exception;
+
+import com.example.bookiibookii.global.apiPayload.code.BaseCode;
+import com.example.bookiibookii.global.apiPayload.exception.GeneralException;
+
+public class GroupException extends GeneralException {
+    public GroupException(BaseCode code) {
+        super(code);
+    }
+}

--- a/src/main/java/com/example/bookiibookii/domain/group/exception/code/GroupErrorCode.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/exception/code/GroupErrorCode.java
@@ -13,9 +13,11 @@ public enum GroupErrorCode implements BaseCode {
     APPLICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "GROUP4002", "신청 내역을 찾을 수 없습니다."),
     ALREADY_PROCESSED_APPLICATION(HttpStatus.BAD_REQUEST, "GROUP4005", "이미 처리된 신청 내역입니다."),
     GROUP_FULL(HttpStatus.BAD_REQUEST, "GROUP4006", "이미 정원이 가득 찬 그룹입니다."),
+    GROUP_NOT_RECRUTING(HttpStatus.BAD_REQUEST, "GROUP4007", "그룹이 RECRUTING 상태가 아닙니다."),
 
     // 403 Forbidden
-    MEMBER_NOT_HOST(HttpStatus.FORBIDDEN, "GROUP4003", "Host만 접근 가능한 메뉴입니다.");
+    MEMBER_NOT_HOST(HttpStatus.FORBIDDEN, "GROUP4003", "Host만 접근 가능한 메뉴입니다."),
+    HOST_CANNOT_APPLY(HttpStatus.FORBIDDEN, "GROUP4008", "Host는 신청 할 수 없습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/example/bookiibookii/domain/group/exception/code/GroupErrorCode.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/exception/code/GroupErrorCode.java
@@ -9,15 +9,17 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum GroupErrorCode implements BaseCode {
     // 404 Not Found
-    GROUP_NOT_FOUND(HttpStatus.NOT_FOUND,"GROUP4001", "해당 그룹을 찾을 수 없습니다."),
-    APPLICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "GROUP4002", "신청 내역을 찾을 수 없습니다."),
-    ALREADY_PROCESSED_APPLICATION(HttpStatus.BAD_REQUEST, "GROUP4005", "이미 처리된 신청 내역입니다."),
-    GROUP_FULL(HttpStatus.BAD_REQUEST, "GROUP4006", "이미 정원이 가득 찬 그룹입니다."),
-    GROUP_NOT_RECRUTING(HttpStatus.BAD_REQUEST, "GROUP4007", "그룹이 RECRUTING 상태가 아닙니다."),
+    GROUP_NOT_FOUND(HttpStatus.NOT_FOUND, "GROUP404_1", "그룹을 찾을 수 없습니다."),
+    APPLICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "GROUP404_2", "신청 내역을 찾을 수 없습니다."),
+
+    // 400 Bad Request
+    ALREADY_PROCESSED_APPLICATION(HttpStatus.BAD_REQUEST, "GROUP400_1", "이미 처리된 신청 내역입니다."),
+    GROUP_FULL(HttpStatus.BAD_REQUEST, "GROUP400_2", "이미 정원이 가득 찬 그룹입니다."),
+    GROUP_NOT_RECRUITING(HttpStatus.BAD_REQUEST, "GROUP400_3", "그룹이 RECRUITING 상태가 아닙니다."),
 
     // 403 Forbidden
-    MEMBER_NOT_HOST(HttpStatus.FORBIDDEN, "GROUP4003", "Host만 접근 가능한 메뉴입니다."),
-    HOST_CANNOT_APPLY(HttpStatus.FORBIDDEN, "GROUP4008", "Host는 신청 할 수 없습니다.");
+    MEMBER_NOT_HOST(HttpStatus.FORBIDDEN, "GROUP403_1", "Host만 접근 가능한 메뉴입니다."),
+    HOST_CANNOT_APPLY(HttpStatus.FORBIDDEN, "GROUP403_2", "Host는 신청할 수 없습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/example/bookiibookii/domain/group/repository/ApplicationRepository.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/repository/ApplicationRepository.java
@@ -25,4 +25,7 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
     //특정 그룹의 '대기 중'인 신청서들만 조회 (Fetch Join으로 Guest 정보까지 한 번에)
     @Query("SELECT a FROM Application a JOIN FETCH a.guest WHERE a.group.id = :groupId AND a.applicationStatus = 'PENDING'")
     List<Application> findAllPendingByGroupId(@Param("groupId") Long groupId);
+
+    // 중복 신청 확인: 특정 그룹에 특정 유저가 이미 신청했는지 여부
+    boolean existsByGroupGroupIdAndGuestId(Long groupId, Long guestId);
 }

--- a/src/main/java/com/example/bookiibookii/domain/group/service/ApplicationService.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/service/ApplicationService.java
@@ -1,16 +1,21 @@
 package com.example.bookiibookii.domain.group.service;
 
 
+import com.example.bookiibookii.domain.group.dto.req.ApplicationRequestDTO;
 import com.example.bookiibookii.domain.group.dto.res.ApplicationResponseDTO;
 import com.example.bookiibookii.domain.group.entity.Application;
 import com.example.bookiibookii.domain.group.entity.Groups;
 import com.example.bookiibookii.domain.group.enums.ApplicationStatus;
 import com.example.bookiibookii.domain.group.enums.GroupStatus;
 import com.example.bookiibookii.domain.group.exception.code.GroupErrorCode;
+import com.example.bookiibookii.domain.group.exception.GroupException;
 import com.example.bookiibookii.domain.group.repository.ApplicationRepository;
 import com.example.bookiibookii.domain.group.repository.GroupsRepository;
 import com.example.bookiibookii.domain.user.entity.User;
-import com.example.bookiibookii.global.apiPayload.exception.GeneralException;
+import com.example.bookiibookii.domain.user.exception.UserException;
+import com.example.bookiibookii.domain.user.exception.code.UserErrorCode;
+import com.example.bookiibookii.domain.user.repository.UserRepository;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,16 +32,17 @@ import java.util.stream.Collectors;
 public class ApplicationService {
     private final ApplicationRepository applicationRepository;
     private final GroupsRepository groupsRepository;
+    private final UserRepository userRepository;
 
     // 신청 조회 로직
     public ApplicationResponseDTO.ApplicationListDTO getApplicantList(Long groupId, Long currentUserId) {
         // 1. 그룹 존재 여부 확인
         Groups group = groupsRepository.findById(groupId)
-                .orElseThrow(() -> new GeneralException(GroupErrorCode.GROUP_NOT_FOUND));
+                .orElseThrow(() -> new GroupException(GroupErrorCode.GROUP_NOT_FOUND));
 
         // 2. 권한 체크: 현재 로그인한 유저가 이 그룹의 방장(Host)인지 확인
         if (!group.getHost().getId().equals(currentUserId)) {
-            throw new GeneralException(GroupErrorCode.MEMBER_NOT_HOST);
+            throw new GroupException(GroupErrorCode.MEMBER_NOT_HOST);
         }
 
         // 3. 신청자 명단 조회 (Fetch Join으로 User와 Tag까지 한 번에!)
@@ -59,17 +65,17 @@ public class ApplicationService {
 
         // 1. 신청 내역 존재 여부 확인
         Application application = applicationRepository.findById(applyId)
-                .orElseThrow(() -> new GeneralException(GroupErrorCode.APPLICATION_NOT_FOUND));
+                .orElseThrow(() -> new GroupException(GroupErrorCode.APPLICATION_NOT_FOUND));
 
         // 2. 권한 체크: 이 신청이 들어온 그룹의 방장이 요청자(userId)와 일치하는지 확인
         if (!application.getGroup().getHost().getId().equals(userId)) {
-            throw new GeneralException(GroupErrorCode.MEMBER_NOT_HOST);
+            throw new GroupException(GroupErrorCode.MEMBER_NOT_HOST);
         }
 
         //3. 이미 처리된 신청인지 확인
         // 상태가 PENDING(대기 중)이 아닐 때 수락/거절을 시도하면 예외 발생
         if (application.getApplicationStatus() != ApplicationStatus.PENDING) {
-            throw new GeneralException(GroupErrorCode.ALREADY_PROCESSED_APPLICATION);
+            throw new GroupException(GroupErrorCode.ALREADY_PROCESSED_APPLICATION);
         }
 
         // 4. 수락(ACCEPTED) 시도 시 정원 초과 여부 사전 체크
@@ -81,7 +87,7 @@ public class ApplicationService {
 
             // 이미 정원이 찼는데 또 수락하려는 경우 예외 발생
             if (currentAcceptedCount >= groups.getMaxCapacity()) {
-                throw new GeneralException(GroupErrorCode.GROUP_FULL);
+                throw new GroupException(GroupErrorCode.GROUP_FULL);
             }
         }
 
@@ -123,7 +129,53 @@ public class ApplicationService {
                 .groupStatus(application.getGroup().getGroupStatus())
                 .updatedAt(LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy. MM. dd. HH:mm")))
                 .build();
+
+
     }
+
+    //참가신청 service
+    @Transactional(readOnly = false)
+    public ApplicationResponseDTO.JoinResultDTO joinGroup(Long groupId, Long userId, ApplicationRequestDTO.JoinApplicationDTO request){
+        //그룹 존재여부 확인
+        Groups group = groupsRepository.findById(groupId)
+                .orElseThrow(() -> new GroupException(GroupErrorCode.GROUP_NOT_FOUND));
+
+        //그룹 상태 확인(RECRUTING)
+        if(group.getGroupStatus() != GroupStatus.RECRUITING){
+            throw new GroupException(GroupErrorCode.GROUP_NOT_RECRUTING);
+        }
+
+        //권한체크(HOST는 참가신청불가)
+        if(group.getHost().getId().equals(userId)){
+            throw new GroupException(GroupErrorCode.HOST_CANNOT_APPLY);
+        }
+
+        //중복신청확인
+        if(applicationRepository.existsByGroupGroupIdAndGuestId(groupId,userId)){
+            throw new GroupException(GroupErrorCode.ALREADY_PROCESSED_APPLICATION);
+        }
+
+        //유저 정보 조회
+        User guest = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(UserErrorCode.NOT_FOUND));
+
+        // 신청 엔티티 생성 및 저장
+        Application application = Application.builder()
+                .group(group)
+                .guest(guest)
+                .applyMsg(request.getApplyMsg())
+                .applicationStatus(ApplicationStatus.PENDING)
+                .build();
+
+        applicationRepository.save(application);
+
+        return ApplicationResponseDTO.JoinResultDTO.builder()
+                .applicationId(application.getApplicationId())
+                .status(application.getApplicationStatus().name())
+                .createdAt(LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy. MM. dd.")))
+                .build();
+    }
+
     private ApplicationResponseDTO.ApplicationDetailDTO toDetailDTO(Application application) {
         User guest = application.getGuest();
 

--- a/src/main/java/com/example/bookiibookii/domain/group/service/ApplicationService.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/service/ApplicationService.java
@@ -142,7 +142,7 @@ public class ApplicationService {
 
         //그룹 상태 확인(RECRUTING)
         if(group.getGroupStatus() != GroupStatus.RECRUITING){
-            throw new GroupException(GroupErrorCode.GROUP_NOT_RECRUTING);
+            throw new GroupException(GroupErrorCode.GROUP_NOT_RECRUITING);
         }
 
         //권한체크(HOST는 참가신청불가)

--- a/src/main/java/com/example/bookiibookii/domain/group/service/ApplicationService.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/service/ApplicationService.java
@@ -17,6 +17,7 @@ import com.example.bookiibookii.domain.user.exception.code.UserErrorCode;
 import com.example.bookiibookii.domain.user.repository.UserRepository;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -167,7 +168,12 @@ public class ApplicationService {
                 .applicationStatus(ApplicationStatus.PENDING)
                 .build();
 
-        applicationRepository.save(application);
+        try {
+            applicationRepository.save(application);
+        } catch (DataIntegrityViolationException ex) {
+            // DB에서 유니크 제약조건 위반이 발생하면(중복 신청 시) 처리
+            throw new GroupException(GroupErrorCode.ALREADY_PROCESSED_APPLICATION);
+        }
 
         return ApplicationResponseDTO.JoinResultDTO.builder()
                 .applicationId(application.getApplicationId())


### PR DESCRIPTION
## 개요
게스트가 특정 그룹에 참여 신청을 할 수 있는 API를 구현하고  swagger 테스트 진행했습니다. 

그룹 상태 체크: RECRUITING 상태인 그룹만 신청 가능 (마감 시 GROUP4007 에러)

권한 체크: 방장은 본인 그룹에 신청 불가 (HOST_CANNOT_APPLY)

중복 방지: 동일 그룹에 대한 중복 신청 차단

데이터 검증: 신청 메시지 50자 제한 및 필수값 검증 (@Valid, @Size)

<!---- Resolves: #(Isuue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

📣 **To Reviewers**

철저한 예외 처리: joinGroup 서비스 로직에서 총 4가지 방어 로직을 구축했습니다.

그룹 존재 여부 및 모집 상태(RECRUITING) 확인

방장은 본인 그룹에 신청 불가 (HOST_CANNOT_APPLY)

동일 그룹에 대한 중복 신청 방지 (ALREADY_PROCESSED_APPLICATION)

유저 존재 여부 확인

자동화된 상태 전환: 정원이 꽉 차는 마지막 인원을 수락(ACCEPTED)하는 순간, 해당 그룹의 상태가 자동으로 MATCHED로 변경되며, 아직 대기 중인(PENDING) 다른 신청자들은 일괄 거절(REJECTED)되도록 처리했습니다.

데이터 검증: DTO에서 @Size(max = 50)를 사용하여 글자 수 제한을 엄격히 적용했습니다.
- Reviewers : 팀 선택
- Labels : 작업 유형, 자기 자신


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 그룹 참여 신청 API 추가: 모집 중인 그룹에 신청 메시지와 함께 참여 요청을 보낼 수 있으며, 신청 ID·상태·생성 시각을 반환합니다.

* **개선**
  * 신청 메시지 검증 추가(빈값 불가, 최대 길이 제한).
  * 중복 신청, 호스트 신청 제한, 모집 여부·정원 초과 등 상황에 대한 명확한 오류 응답 강화.

* **문서/오류**
  * 그룹 관련 오류 코드 및 메시지 정비 및 확장.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->