### PR TITLE
[Feat] #79 그룹신청취소 api 구현

### DIFF
--- a/src/main/java/com/example/bookiibookii/domain/group/controller/ApplicationController.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/controller/ApplicationController.java
@@ -18,6 +18,7 @@ public class ApplicationController implements ApplicationControllerDocs {
 
     private final ApplicationService applicationService;
 
+    //신청자 명단 조회
     @GetMapping("/{groupId}/applylist")
     public ApiResponse<ApplicationResponseDTO.ApplicationListDTO> getApplicantList(
             @PathVariable(name = "groupId") Long groupId,
@@ -27,6 +28,7 @@ public class ApplicationController implements ApplicationControllerDocs {
         return ApiResponse.onSuccess(GeneralSuccessCode.REQUEST_OK, response);
     }
 
+    //수락 거절
     @PatchMapping("/apply/{applyId}")
     public ApiResponse<ApplicationResponseDTO.UpdateResultDTO> updateApplicationStatus(
             @PathVariable(name = "applyId") Long applyId,
@@ -38,6 +40,7 @@ public class ApplicationController implements ApplicationControllerDocs {
         return ApiResponse.onSuccess(GeneralSuccessCode.REQUEST_OK, result);
     }
 
+    //게스트 참여 신청
     @PostMapping("/{groupId}/apply")
     public ApiResponse<ApplicationResponseDTO.JoinResultDTO> joinGroup(
             @PathVariable(name = "groupId") Long groupId,
@@ -45,6 +48,16 @@ public class ApplicationController implements ApplicationControllerDocs {
             @RequestBody @Valid ApplicationRequestDTO.JoinApplicationDTO request
     ) {
         ApplicationResponseDTO.JoinResultDTO result = applicationService.joinGroup(groupId, user.getId(), request);
+        return ApiResponse.onSuccess(GeneralSuccessCode.REQUEST_OK, result);
+    }
+
+    //그룹 신청 취소
+    @DeleteMapping("/{groupId}/apply")
+    public ApiResponse<ApplicationResponseDTO.CancelResultDTO> cancelApplication(
+            @PathVariable(name = "groupId") Long groupId,
+            @AuthenticationPrincipal(expression = "user") User user
+    ) {
+        ApplicationResponseDTO.CancelResultDTO result = applicationService.cancelApplication(groupId, user.getId());
         return ApiResponse.onSuccess(GeneralSuccessCode.REQUEST_OK, result);
     }
 }

--- a/src/main/java/com/example/bookiibookii/domain/group/controller/ApplicationControllerDocs.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/controller/ApplicationControllerDocs.java
@@ -69,6 +69,7 @@ public interface ApplicationControllerDocs {
     @Operation(summary = "참여 신청 취소 API", description = "게스트가 본인의 참여 신청을 취소하거나 그룹에서 나갑니다. (모집 중인 그룹만 가능)")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "성공입니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "GROUP404_1", description = "그룹을 찾을 수 없습니다."),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "GROUP404_3", description = "해당 그룹의 참여자가 아닙니다."),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "GROUP403_3", description = "방장은 취소할 수 없습니다."),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "GROUP400_12", description = "그룹 신청을 취소할 수 없습니다.")

--- a/src/main/java/com/example/bookiibookii/domain/group/controller/ApplicationControllerDocs.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/controller/ApplicationControllerDocs.java
@@ -71,7 +71,7 @@ public interface ApplicationControllerDocs {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "성공입니다."),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "GROUP404_3", description = "해당 그룹의 참여자가 아닙니다."),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "GROUP403_3", description = "방장은 취소할 수 없습니다."),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "GROUP400_4", description = "정원이 가득 찼거나 이미 진행 중인 그룹은 취소할 수 없습니다.")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "GROUP400_12", description = "그룹 신청을 취소할 수 없습니다.")
     })
     @Parameters({
             @Parameter(name = "groupId", description = "참여 취소하려는 그룹의 ID", example = "1")

--- a/src/main/java/com/example/bookiibookii/domain/group/controller/ApplicationControllerDocs.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/controller/ApplicationControllerDocs.java
@@ -65,4 +65,19 @@ public interface ApplicationControllerDocs {
             @AuthenticationPrincipal(expression = "user") User user,
             @RequestBody @Valid ApplicationRequestDTO.JoinApplicationDTO request
     );
+
+    @Operation(summary = "참여 신청 취소 API", description = "게스트가 본인의 참여 신청을 취소하거나 그룹에서 나갑니다. (모집 중인 그룹만 가능)")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "성공입니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "GROUP404_3", description = "해당 그룹의 참여자가 아닙니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "GROUP403_3", description = "방장은 취소할 수 없습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "GROUP400_4", description = "정원이 가득 찼거나 이미 진행 중인 그룹은 취소할 수 없습니다.")
+    })
+    @Parameters({
+            @Parameter(name = "groupId", description = "참여 취소하려는 그룹의 ID", example = "1")
+    })
+    ApiResponse<ApplicationResponseDTO.CancelResultDTO> cancelApplication(
+            @PathVariable(name = "groupId") Long groupId,
+            @AuthenticationPrincipal(expression = "user") User user
+    );
 }

--- a/src/main/java/com/example/bookiibookii/domain/group/dto/res/ApplicationResponseDTO.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/dto/res/ApplicationResponseDTO.java
@@ -59,4 +59,14 @@ public class ApplicationResponseDTO {
         private String status;       // 신청 상태 (PENDING 등)
         private String createdAt;    // 신청 일자
     }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class CancelResultDTO{
+        private Long groupId;
+        private String canceledAt; //취소한 시간
+    }
+
 }

--- a/src/main/java/com/example/bookiibookii/domain/group/exception/code/GroupErrorCode.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/exception/code/GroupErrorCode.java
@@ -11,6 +11,7 @@ public enum GroupErrorCode implements BaseCode {
     // 404 Not Found
     GROUP_NOT_FOUND(HttpStatus.NOT_FOUND, "GROUP404_1", "그룹을 찾을 수 없습니다."),
     APPLICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "GROUP404_2", "신청 내역을 찾을 수 없습니다."),
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "GROUP404_3", "해당 그룹에 신청한 내역이 없습니다."),
 
     // 400 Bad Request
     ALREADY_PROCESSED_APPLICATION(HttpStatus.BAD_REQUEST, "GROUP400_1", "이미 처리된 신청 내역입니다."),
@@ -24,10 +25,12 @@ public enum GroupErrorCode implements BaseCode {
     GROUP_CANT_UPDATE(HttpStatus.BAD_REQUEST, "GROUP400_9", "그룹을 수정할 수 없습니다."),
     GROUP_CANT_DELETE(HttpStatus.BAD_REQUEST, "GROUP400_10", "그룹을 삭제할 수 없습니다."),
     COMMENT_REQUIRED(HttpStatus.BAD_REQUEST, "GROUP400_11", "그룹 소개글을 입력해야 합니다."),
+    APPLY_CANT_CANCEL(HttpStatus.BAD_REQUEST, "GROUP400_12", "그룹신청을 취소할 수 없습니다."),
 
     // 403 Forbidden
     MEMBER_NOT_HOST(HttpStatus.FORBIDDEN, "GROUP403_1", "Host만 접근 가능한 메뉴입니다."),
-    HOST_CANNOT_APPLY(HttpStatus.FORBIDDEN, "GROUP403_2", "Host는 신청할 수 없습니다.");
+    HOST_CANNOT_APPLY(HttpStatus.FORBIDDEN, "GROUP403_2", "Host는 신청할 수 없습니다."),
+    HOST_CANNOT_LEAVE(HttpStatus.FORBIDDEN, "GROUP403_3","Host는 그룹을 떠날 수 없습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/example/bookiibookii/domain/group/repository/ApplicationRepository.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/repository/ApplicationRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface ApplicationRepository extends JpaRepository<Application, Long> {
@@ -28,4 +29,8 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
 
     // 중복 신청 확인: 특정 그룹에 특정 유저가 이미 신청했는지 여부
     boolean existsByGroupGroupIdAndGuestId(Long groupId, Long guestId);
+
+    //특정 그룹 ID와 게스트(유저) ID로 신청서 엔티티 조회 (참가 목록에서 취소한 사람 제외용도)
+    Optional<Application> findByGroupGroupIdAndGuestId(Long groupId, Long guestId);
+
 }

--- a/src/main/java/com/example/bookiibookii/domain/group/repository/MatchedMemberRepository.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/repository/MatchedMemberRepository.java
@@ -24,5 +24,9 @@ public interface MatchedMemberRepository extends JpaRepository<MatchedMember, Lo
         "WHERE g.groupId = :groupId AND mm.readingOrder = :readingOrder")
 Optional<MatchedMember> findByGroupAndOrder(@Param("groupId") Long groupId, @Param("readingOrder") int readingOrder);
 
+    //그룹 현재인원
     long countByGroup(Groups groups);
+
+    //참여 취소를 위한 조회 메서드
+    Optional<MatchedMember> findByGroup_GroupIdAndUserId_Id(Long groupId, Long userId);
 }

--- a/src/main/java/com/example/bookiibookii/domain/group/service/ApplicationService.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/service/ApplicationService.java
@@ -187,7 +187,11 @@ public class ApplicationService {
     @Transactional(readOnly = false)
     public ApplicationResponseDTO.CancelResultDTO cancelApplication (Long groupId, Long userId){
 
-        //참여정보 확인하기
+        // 그룹에 비관적 락을 먼저 걸고 조회
+        Groups group = groupsRepository.findByIdForUpdate(groupId)
+                .orElseThrow(() -> new GroupException(GroupErrorCode.GROUP_NOT_FOUND));
+
+        // 참여 정보 확인
         MatchedMember member = matchedMemberRepository.findByGroup_GroupIdAndUserId_Id(groupId, userId)
                 .orElseThrow(() -> new GroupException(GroupErrorCode.MEMBER_NOT_FOUND));
 

--- a/src/main/java/com/example/bookiibookii/domain/group/service/ApplicationService.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/service/ApplicationService.java
@@ -183,6 +183,43 @@ public class ApplicationService {
                 .build();
     }
 
+    //참여 취소하기
+    @Transactional(readOnly = false)
+    public ApplicationResponseDTO.CancelResultDTO cancelApplication (Long groupId, Long userId){
+
+        //참여정보 확인하기
+        MatchedMember member = matchedMemberRepository.findByGroup_GroupIdAndUserId_Id(groupId, userId)
+                .orElseThrow(() -> new GroupException(GroupErrorCode.MEMBER_NOT_FOUND));
+
+        //권한 체크 (Host)는 취소 불가
+        if(member.getRole() == RoleStatus.HOST){
+            throw new GroupException(GroupErrorCode.HOST_CANNOT_LEAVE);
+        }
+
+        Groups group = member.getGroup();
+
+        //그룹이 모집중(RECRUITING) 일때만 취소가능
+        if(group.getGroupStatus() != GroupStatus.RECRUITING){
+            throw new GroupException(GroupErrorCode.APPLY_CANT_CANCEL);
+        }
+
+        //참여신청 목록에서 제외, 참여 내역 삭제
+        applicationRepository.findByGroupGroupIdAndGuestId(groupId, userId)
+                        .ifPresent(applicationRepository::delete);
+        matchedMemberRepository.delete(member);
+
+        //취소 후 그룹 정원 다시 계산
+        long currentCount = matchedMemberRepository.countByGroup(group);
+        if (currentCount < group.getMaxCapacity()) {
+            group.updateStatus(GroupStatus.RECRUITING);
+        }
+
+        return ApplicationResponseDTO.CancelResultDTO.builder()
+                .groupId(groupId)
+                .canceledAt(LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy. MM. dd. HH:mm")))
+                .build();
+    }
+
     private ApplicationResponseDTO.ApplicationDetailDTO toDetailDTO(Application application) {
         User guest = application.getGuest();
 
@@ -201,4 +238,6 @@ public class ApplicationService {
                 .applyMsg(application.getApplyMsg())
                 .build();
     }
+
+
 }

--- a/src/main/java/com/example/bookiibookii/domain/group/service/ApplicationService.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/service/ApplicationService.java
@@ -200,7 +200,6 @@ public class ApplicationService {
             throw new GroupException(GroupErrorCode.HOST_CANNOT_LEAVE);
         }
 
-        Groups group = member.getGroup();
 
         //그룹이 모집중(RECRUITING) 일때만 취소가능
         if(group.getGroupStatus() != GroupStatus.RECRUITING){

--- a/src/main/java/com/example/bookiibookii/domain/group/service/GroupService.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/service/GroupService.java
@@ -132,7 +132,8 @@ public class GroupService {
                 // "마이페이지에서 배송지를 먼저 등록해주세요." 에러 발생
                 throw new GroupException(GroupErrorCode.ADDRESS_NOT_FOUND);
             }*/
-        }
+
+    }
 
 
 


### PR DESCRIPTION
## 개요
closed #79 
게스트가 신청한 그룹 참여를 취소할 수 있는 API를 추가했습니다.
사용자가 잘못 신청했거나 변심했을 경우 취소 권한을 부여합니다.
취소 시 신청서(Application)와 멤버 정보(MatchedMember)를 동시에 삭제하여 방장의 신청자 목록 조회(getApplicantList) 화면과 데이터 정합성을 맞추었습니다.
기획 정책에 따라 '모집 중(RECRUITING)' 상태인 그룹에서만 취소가 가능하도록 제한했습니다.

<!---- Resolves: #(Isuue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

📣 **To Reviewers**
---


- Reviewers : 팀 선택
- Labels : 작업 유형, 자기 자신


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 그룹 가입 신청 목록 조회, 신청, 신청 상태 변경, 신청 취소 기능 추가
  * 신청 취소 시 결과(취소 시각 포함) 반환 및 관련 상태 자동 반영

* **Documentation**
  * 신청 취소 API 문서화 및 응답 코드 명시

* **Bug Fixes / Improvements**
  * 오류 코드 및 검증 메시지 추가로 더 명확한 피드백 제공

* **Chores**
  * 코드 안정성 및 조회/조회규칙 보완

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->