### PR TITLE
[Fix] #102 직접교환 주소 내부 저장로직 변경

### DIFF
--- a/src/main/java/com/example/bookiibookii/domain/group/entity/Meeting.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/entity/Meeting.java
@@ -18,17 +18,21 @@ public class Meeting extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "meeting_id")
-    private Long id;
+    private Long meetingId;
 
     @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "group_id")
+    @JoinColumn(name = "group_id", nullable = false)
     private Groups group;
 
+    @Column(name = "meeting_time") // 초기에는 null, 트래커 단계에서 업데이트
+    private LocalDateTime meetingTime;
 
-    @Column(name = "meeting_time")
-    private LocalDateTime meetingTime;// 교환희망일시
-    @Column(name = "meeting_place")
-    private String meetingPlace;            //교환희망장소
+    @Column(name = "meeting_place", nullable = false)
+    private String meetingPlace;
 
+    // 트래커 도메인에서 약속을 확정할 때 사용할 업데이트 메서드
+    public void setMeetingDetails(String place, LocalDateTime time) {
+        this.meetingPlace = place;
+        this.meetingTime = time;
+    }
 }

--- a/src/main/java/com/example/bookiibookii/domain/group/repository/MeetingRepository.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/repository/MeetingRepository.java
@@ -1,0 +1,12 @@
+package com.example.bookiibookii.domain.group.repository;
+
+import com.example.bookiibookii.domain.group.entity.Meeting;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MeetingRepository extends JpaRepository<Meeting, Long> {
+    // 그룹 ID로 약속 정보를 찾는 메서드
+    Optional<Meeting> findByGroupGroupId(Long groupId);
+
+}

--- a/src/main/java/com/example/bookiibookii/domain/group/service/GroupService.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/service/GroupService.java
@@ -7,12 +7,14 @@ import com.example.bookiibookii.domain.group.dto.req.GroupRequestDTO;
 import com.example.bookiibookii.domain.group.dto.res.GroupResponseDTO;
 import com.example.bookiibookii.domain.group.entity.Groups;
 import com.example.bookiibookii.domain.group.entity.MatchedMember;
+import com.example.bookiibookii.domain.group.entity.Meeting;
 import com.example.bookiibookii.domain.group.enums.*;
 import com.example.bookiibookii.domain.group.exception.GroupException;
 import com.example.bookiibookii.domain.group.exception.code.GroupErrorCode;
 import com.example.bookiibookii.domain.group.repository.ApplicationRepository;
 import com.example.bookiibookii.domain.group.repository.GroupsRepository;
 import com.example.bookiibookii.domain.group.repository.MatchedMemberRepository;
+import com.example.bookiibookii.domain.group.repository.MeetingRepository;
 import com.example.bookiibookii.domain.user.entity.User;
 import com.example.bookiibookii.domain.user.exception.UserException;
 import com.example.bookiibookii.domain.user.exception.code.UserErrorCode;
@@ -34,7 +36,9 @@ public class GroupService {
     private final GroupsRepository groupsRepository;
     private final MatchedMemberRepository matchedMemberRepository;
     private final ApplicationRepository applicationRepository;
+    private final MeetingRepository meetingRepository;
     private final BookService bookService;
+
 
     //그룹생성 service
     public GroupResponseDTO.CreateResultDTO createGroup(User host, GroupRequestDTO.CreateDTO request){
@@ -85,6 +89,19 @@ public class GroupService {
 
         Groups savedGroup = groupsRepository.save(group);
 
+        // 1:1 직접 교환일 때 Meeting 초기 데이터 생성
+        if (request.getGroupType() == GroupType.RELAY && request.getTradeType() == TradeType.DIRECT) {
+
+            // host.getMeetPlace()를 통해 유저가 미리 입력한 주소를 초기 장소로 저장
+            Meeting initialMeeting = Meeting.builder()
+                    .group(savedGroup)
+                    .meetingPlace(host.getMeetPlace()) //host가 마이페이지에서 입력한 meetPlace
+                    .meetingTime(null) // 시간은 초기 생성 시에는 결정되지 않음
+                    .build();
+
+            meetingRepository.save(initialMeeting);
+        }
+
         // 방장을 MatchedMember의 첫 번째 멤버로 등록
         MatchedMember hostMember = MatchedMember.builder()
                 .group(savedGroup)           // 엔티티의 private Groups group;
@@ -94,6 +111,7 @@ public class GroupService {
                 .build();
 
         matchedMemberRepository.save(hostMember);
+
         return GroupResponseDTO.CreateResultDTO.builder()
                 .groupId(savedGroup.getGroupId()) //
                 .groupStatus(savedGroup.getGroupStatus()) //


### PR DESCRIPTION
## 개요
closed #102 
기존 autofilled로 받던 직접교환 주소를 Meeting 테이블을 추가해 meetingPlace에 저장하도록 로직을 변경하였습니다.
이후 트래커에서 직접교환 장소, 시간 정하기 모달에서 host가 주소를 변경, 시간을 지정 할 때 Meeting 테이블에 적용되는 로직을 사용할 예정입니다. 이 장소는 user의 meetPlace에 영향을 주지 않는 이번 그룹에서만 사용될 수 있는 장소 , 시간이 됩니다

<!---- Resolves: #(Isuue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

📣 **To Reviewers**
---

- Reviewers : 팀 선택
- Labels : 작업 유형, 자기 자신


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
- Relay 직거래 그룹을 생성하면 초기 모임이 자동으로 생성됩니다.
- 모임 장소와 시간 정보의 데이터 무결성이 개선되었습니다.
- 모임 정보를 더욱 효율적으로 관리할 수 있는 기능이 추가되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->