### PR TITLE
[Feat] #101 댓글 생성시 알림 저장

### DIFF
--- a/src/main/java/com/example/bookiibookii/domain/comment/event/CommentEvent.java
+++ b/src/main/java/com/example/bookiibookii/domain/comment/event/CommentEvent.java
@@ -1,0 +1,13 @@
+package com.example.bookiibookii.domain.comment.event;
+
+public record CommentEvent(
+        // 알림 내용
+        String commenterNickname,
+        String bookTitle,
+
+        // 수신자
+        Long hostId,
+
+        // redirect
+        Long groupId
+) {}

--- a/src/main/java/com/example/bookiibookii/domain/comment/service/CommentNotificationService.java
+++ b/src/main/java/com/example/bookiibookii/domain/comment/service/CommentNotificationService.java
@@ -1,0 +1,33 @@
+package com.example.bookiibookii.domain.comment.service;
+
+import com.example.bookiibookii.domain.comment.event.CommentEvent;
+import com.example.bookiibookii.domain.notification.enums.NotificationType;
+import com.example.bookiibookii.domain.notification.repository.NotificationRepository;
+import com.example.bookiibookii.domain.notification.service.NotificationFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class CommentNotificationService {
+
+    private final NotificationRepository notificationRepository;
+    private final NotificationFactory notificationFactory;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void send(CommentEvent event) {
+        Long receiverId = event.hostId();
+        String title = "새로운 댓글이 달렸어요";
+        String message = String.format("%s님이 %s 그룹에 댓글을 남겼어요. 확인해볼까요?",
+                event.commenterNickname(), event.bookTitle());
+        String payload = notificationFactory.toJson(Map.of("groupId", event.groupId()));
+
+        notificationRepository.save(
+                notificationFactory.create(receiverId, NotificationType.SYSTEM, title, message, payload)
+        );
+    }
+}

--- a/src/main/java/com/example/bookiibookii/domain/comment/service/CommentService.java
+++ b/src/main/java/com/example/bookiibookii/domain/comment/service/CommentService.java
@@ -6,6 +6,7 @@ import com.example.bookiibookii.domain.comment.dto.res.CommentTreeResDTO;
 import com.example.bookiibookii.domain.comment.dto.req.CommentCreateReqDTO;
 import com.example.bookiibookii.domain.comment.entity.Comment;
 import com.example.bookiibookii.domain.comment.enums.WriterRole;
+import com.example.bookiibookii.domain.comment.event.CommentEvent;
 import com.example.bookiibookii.domain.comment.exception.code.CommentErrorCode;
 import com.example.bookiibookii.domain.comment.exception.CommentException;
 import com.example.bookiibookii.domain.comment.repository.CommentRepository;
@@ -16,6 +17,7 @@ import com.example.bookiibookii.domain.group.exception.GroupException;
 import com.example.bookiibookii.domain.group.exception.code.GroupErrorCode;
 import com.example.bookiibookii.domain.group.repository.GroupsRepository;
 import com.example.bookiibookii.domain.group.repository.MatchedMemberRepository;
+import com.example.bookiibookii.domain.notification.publisher.DomainEventPublisher;
 import com.example.bookiibookii.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -34,10 +36,11 @@ public class CommentService {
     private final CommentRepository commentRepository;
     private final GroupsRepository groupRepository;
     private final MatchedMemberRepository matchedMemberRepository;
+    private final DomainEventPublisher eventPublisher;
 
     @Transactional
     public CommentCreateResDTO create(Long groupId, User user, CommentCreateReqDTO req) {
-        Groups group = groupRepository.findById(groupId)
+        Groups group = groupRepository.findByIdWithBookAndHost(groupId)
                 .orElseThrow(() -> new GroupException(GroupErrorCode.GROUP_NOT_FOUND));
 
         // 댓글 작성자의 그룹 내 역할
@@ -71,6 +74,8 @@ public class CommentService {
                 .parent(parent)
                 .build();
         Comment saved = commentRepository.save(comment);
+
+        eventPublisher.publish(new CommentEvent(user.getName(), group.getBook().getTitle(), group.getHost().getId(), group.getGroupId()));
 
         return toCreateResDTO(saved, writerRole);
     }
@@ -111,7 +116,6 @@ public class CommentService {
 
         return roots;
     }
-
 
     private static WriterRole toWriterRole(RoleStatus roleStatus) {
         if (roleStatus == null) return WriterRole.NONE;

--- a/src/main/java/com/example/bookiibookii/domain/group/repository/GroupsRepository.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/repository/GroupsRepository.java
@@ -43,4 +43,13 @@ public interface GroupsRepository extends JpaRepository<Groups, Long> {
             //"LEFT JOIN FETCH gt.tag " +
             "WHERE g.groupId = :groupId AND g.groupStatus != 'DELETED'")
     Optional<Groups> findDetailById(@Param("groupId") Long groupId);
+
+    // fetch join 적용된 기본 그룹 조회
+    @Query("""
+    select g from Groups g
+    join fetch g.book
+    join fetch g.host
+    where g.groupId = :id
+    """)
+    Optional<Groups> findByIdWithBookAndHost(Long id);
 }

--- a/src/main/java/com/example/bookiibookii/domain/notification/listener/NotificationEventListener.java
+++ b/src/main/java/com/example/bookiibookii/domain/notification/listener/NotificationEventListener.java
@@ -1,5 +1,7 @@
 package com.example.bookiibookii.domain.notification.listener;
 
+import com.example.bookiibookii.domain.comment.event.CommentEvent;
+import com.example.bookiibookii.domain.comment.service.CommentNotificationService;
 import com.example.bookiibookii.domain.notification.event.KeywordGroupMatchedEvent;
 import com.example.bookiibookii.domain.notification.service.KeywordNotificationService;
 import lombok.RequiredArgsConstructor;
@@ -12,9 +14,15 @@ import org.springframework.transaction.event.TransactionalEventListener;
 public class NotificationEventListener {
 
     private final KeywordNotificationService keywordNotificationService;
+    private final CommentNotificationService commentNotificationService;
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    public void handle(KeywordGroupMatchedEvent event) {
+    public void handleKeyword(KeywordGroupMatchedEvent event) {
         keywordNotificationService.send(event);
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleComment(CommentEvent event) {
+        commentNotificationService.send(event);
     }
 }

--- a/src/main/java/com/example/bookiibookii/domain/notification/publisher/DomainEventPublisher.java
+++ b/src/main/java/com/example/bookiibookii/domain/notification/publisher/DomainEventPublisher.java
@@ -1,0 +1,15 @@
+package com.example.bookiibookii.domain.notification.publisher;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class DomainEventPublisher {
+    private final ApplicationEventPublisher publisher;
+
+    public void publish(Object event) {
+        publisher.publishEvent(event);
+    }
+}


### PR DESCRIPTION
## 개요
<!---- 자신이 완료한 이슈를 닫아주세요 -->
- closed #101 
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
도메인 이벤트 발행을 위한 DomainEventPublisher를 추가했습니다.
댓글 생성 성공 후 이벤트를 발행하고, 리스너에서 알림 엔티티를 생성해 DB에 저장하도록 구현했습니다.

<img width="1524" height="635" alt="스크린샷 2026-01-28 173311" src="https://github.com/user-attachments/assets/eee40cfb-80b5-4838-9d5c-75e109541de7" />

<!---- Resolves: #(Isuue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

📣 **To Reviewers**
---
<!-- 전달사항 -->
동일 계정 기준으로 댓글 생성 → 호스트 알림 저장 동작 확인 완료
타 유저로 로그인이 어려워 
게스트 댓글 생성 -> 호스트에게 알림 저장되는 부분은 추후 테스트 예정입니다

- Reviewers : 팀 선택
- Labels : 작업 유형, 자기 자신


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 새로운 댓글 알림 기능 추가: 그룹에 댓글이 달리면 그룹 호스트에게 시스템 알림이 자동으로 발송됩니다. 알림에는 댓글 작성자 닉네임, 책 제목, 해당 그룹 정보가 포함되어 빠르게 확인할 수 있습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->