### PR TITLE
[Feat] #132 타 유저 프로필 조회 API 구현 

### DIFF
--- a/src/main/java/com/example/bookiibookii/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/bookiibookii/domain/user/controller/UserController.java
@@ -62,10 +62,10 @@ public class UserController implements UserControllerDocs{
     // MyPage 조회
     @Override
     @GetMapping("/api/mypage")
-    public ApiResponse<UserResponseDTO.MypageDTO> getMypage(
+    public ApiResponse<UserResponseDTO.UserProfileResDTO> getMypage(
             @AuthenticationPrincipal(expression = "user") User user
     ) {
-        UserResponseDTO.MypageDTO result = userService.getMypageInfo(user.getId());
+        UserResponseDTO.UserProfileResDTO result = userService.getMypageInfo(user.getId());
         return ApiResponse.onSuccess(UserSuccessCode.MYPAGE_SUCCESS, result);
     }
 

--- a/src/main/java/com/example/bookiibookii/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/bookiibookii/domain/user/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.example.bookiibookii.domain.user.controller;
 
+import com.example.bookiibookii.domain.group.enums.GroupStatus;
 import com.example.bookiibookii.domain.user.dto.req.UserRequestDTO;
 import com.example.bookiibookii.domain.user.dto.res.UserResponseDTO;
 import com.example.bookiibookii.domain.user.dto.res.PresignedUrlResponseDTO;
@@ -17,6 +18,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.Map;
 
 @Validated
@@ -65,8 +67,21 @@ public class UserController implements UserControllerDocs{
     public ApiResponse<UserResponseDTO.UserProfileResDTO> getMypage(
             @AuthenticationPrincipal(expression = "user") User user
     ) {
-        UserResponseDTO.UserProfileResDTO result = userService.getMypageInfo(user.getId());
+        List<GroupStatus> statuses = List.of(GroupStatus.RECRUITING, GroupStatus.MATCHED);
+        UserResponseDTO.UserProfileResDTO result = userService.getProfileInfo(user.getId(), statuses);
         return ApiResponse.onSuccess(UserSuccessCode.MYPAGE_SUCCESS, result);
     }
 
+    // 타 유저 프로필 조회
+    @Override
+    @GetMapping("/api/profiles/{nickname}")
+    public ApiResponse<UserResponseDTO.UserProfileResDTO> getOtherProfile(
+            @PathVariable("nickname") String nickname
+    ) {
+        Long targetUserId = userService.findUserIdByNickname(nickname);
+        List<GroupStatus> statuses = List.of(GroupStatus.RECRUITING);
+        UserResponseDTO.UserProfileResDTO result = userService.getProfileInfo(targetUserId, statuses);
+
+        return ApiResponse.onSuccess(GeneralSuccessCode.REQUEST_OK, result);
+    }
 }

--- a/src/main/java/com/example/bookiibookii/domain/user/controller/UserControllerDocs.java
+++ b/src/main/java/com/example/bookiibookii/domain/user/controller/UserControllerDocs.java
@@ -76,5 +76,5 @@ public interface UserControllerDocs {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "마이페이지 조회 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "마이페이지 조회 실패")
     })
-    ApiResponse<UserResponseDTO.MypageDTO> getMypage(@AuthenticationPrincipal User user);
+    ApiResponse<UserResponseDTO.UserProfileResDTO> getMypage(@AuthenticationPrincipal User user);
 }

--- a/src/main/java/com/example/bookiibookii/domain/user/controller/UserControllerDocs.java
+++ b/src/main/java/com/example/bookiibookii/domain/user/controller/UserControllerDocs.java
@@ -7,15 +7,18 @@ import com.example.bookiibookii.domain.user.entity.User;
 import com.example.bookiibookii.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import java.util.Map;
 
+@Tag(name = "User", description = "유저 관련 API")
 public interface UserControllerDocs {
 
     @Operation(
@@ -77,4 +80,17 @@ public interface UserControllerDocs {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "마이페이지 조회 실패")
     })
     ApiResponse<UserResponseDTO.UserProfileResDTO> getMypage(@AuthenticationPrincipal User user);
+
+    // api/profiles/{nickname}
+    @Operation(
+            summary = "타 유저 프로필 조회 API",
+            description = """
+            타 유저의 프로필을 조회하는 API입니다.
+            """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "프로필 조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "프로필 조회 실패")
+    })
+    ApiResponse<UserResponseDTO.UserProfileResDTO> getOtherProfile(@PathVariable("nickname") String nickname);
 }

--- a/src/main/java/com/example/bookiibookii/domain/user/dto/res/UserResponseDTO.java
+++ b/src/main/java/com/example/bookiibookii/domain/user/dto/res/UserResponseDTO.java
@@ -9,7 +9,7 @@ import java.util.List;
 
 public class UserResponseDTO {
     @Builder
-    public record MypageDTO  (
+    public record UserProfileResDTO  (
             Long userId,
             UserImage userImage,
             String nickname,

--- a/src/main/java/com/example/bookiibookii/domain/user/dto/res/UserResponseDTO.java
+++ b/src/main/java/com/example/bookiibookii/domain/user/dto/res/UserResponseDTO.java
@@ -11,6 +11,7 @@ public class UserResponseDTO {
     @Builder
     public record UserProfileResDTO  (
             Long userId,
+            Boolean isMe,
             UserImage userImage,
             String nickname,
             Double manner,

--- a/src/main/java/com/example/bookiibookii/domain/user/dto/res/UserResponseDTO.java
+++ b/src/main/java/com/example/bookiibookii/domain/user/dto/res/UserResponseDTO.java
@@ -11,7 +11,6 @@ public class UserResponseDTO {
     @Builder
     public record UserProfileResDTO  (
             Long userId,
-            Boolean isMe,
             UserImage userImage,
             String nickname,
             Double manner,

--- a/src/main/java/com/example/bookiibookii/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/bookiibookii/domain/user/repository/UserRepository.java
@@ -17,6 +17,7 @@ import java.util.Optional;
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findById(Long id);
+    Optional<User> findByName(String name);
     boolean existsByName(String name);
 
     @Query("""

--- a/src/main/java/com/example/bookiibookii/domain/user/service/UserService.java
+++ b/src/main/java/com/example/bookiibookii/domain/user/service/UserService.java
@@ -153,7 +153,7 @@ public class UserService {
 
     // 마이페이지 조회
     @Transactional
-    public UserResponseDTO.MypageDTO getMypageInfo(Long userId) {
+    public UserResponseDTO.UserProfileResDTO getMypageInfo(Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserException(UserErrorCode.NOT_FOUND));
 
@@ -186,7 +186,7 @@ public class UserService {
                 PageRequest.of(0, 3)
         );
 
-        return UserResponseDTO.MypageDTO.builder()
+        return UserResponseDTO.UserProfileResDTO.builder()
                 // TODO : 프로필 이미지 조회
                 .userId(userId)
                 .nickname(user.getName())

--- a/src/main/java/com/example/bookiibookii/domain/user/service/UserService.java
+++ b/src/main/java/com/example/bookiibookii/domain/user/service/UserService.java
@@ -27,6 +27,7 @@ import com.example.bookiibookii.domain.user.repository.UserTagRepository;
 import com.example.bookiibookii.domain.userbook.dto.res.UserBookResponseDTO;
 import com.example.bookiibookii.domain.userbook.entity.UserBook;
 import com.example.bookiibookii.domain.userbook.repository.UserBookRepository;
+import com.example.bookiibookii.global.apiPayload.exception.GeneralException;
 import com.example.bookiibookii.global.auth.social.SocialUserInfo;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -151,9 +152,9 @@ public class UserService {
         }
     }
 
-    // 마이페이지 조회
+    // 유저 프로필 조회
     @Transactional
-    public UserResponseDTO.UserProfileResDTO getMypageInfo(Long userId) {
+    public UserResponseDTO.UserProfileResDTO getProfileInfo(Long userId, List<GroupStatus> targetGroupStatuses) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserException(UserErrorCode.NOT_FOUND));
 
@@ -161,8 +162,8 @@ public class UserService {
         List<TagType> targetTypes = List.of(TagType.METHOD, TagType.VIBE);
         List<UserTag> currentUserTags = userTagRepository.findByUserIdAndTagTypeIn(userId, targetTypes);
         // 누적도 -> 최신 등록 -> ID 순으로 태그 정렬 후 상위태그 추출
-        List<Tag> myTopTags = userTagService.extractTopTags(currentUserTags, 3);
-        List<String> topTagCodes = myTopTags.stream().map(ut -> ut.getCode()).toList();
+        List<Tag> TopTags = userTagService.extractTopTags(currentUserTags, 3);
+        List<String> topTagCodes = TopTags.stream().map(ut -> ut.getCode()).toList();
 
         // TODO : 배지 조회
 
@@ -173,10 +174,10 @@ public class UserService {
         Long togetherCount = matchedMemberRepository.countByUser_IdAndGroup_GroupType(userId, GroupType.TOGETHER);
 
         // 그룹 조회 (모집중, 진행중)
-        List<Groups> myGroups = matchedMemberRepository.findMyActiveGroups(
-                userId, List.of(GroupStatus.RECRUITING, GroupStatus.MATCHED)
+        List<Groups> targetGroups = matchedMemberRepository.findMyActiveGroups(
+                userId, targetGroupStatuses //List.of(GroupStatus.RECRUITING, GroupStatus.MATCHED)
         );
-        List<GroupResponseDTO.MypageGroupDto> MyGroupList = myGroups.stream()
+        List<GroupResponseDTO.MypageGroupDto> groupList = targetGroups.stream()
                 .map(this::toMypageGroupDto)
                 .collect(Collectors.toList());
 
@@ -195,7 +196,7 @@ public class UserService {
                 .completeBook(completeBookCount.intValue())
                 .relayGroup(relayCount.intValue())
                 .togetherGroup(togetherCount.intValue())
-                .groups(MyGroupList)
+                .groups(groupList)
                 .books(recentBooks)
                 .build();
     }
@@ -216,5 +217,12 @@ public class UserService {
                 .groupStatus(group.getGroupStatus())
                 .groupTags(displayTags)
                 .build();
+    }
+
+    // 닉네임으로 유저 ID 찾기 (타 유저 프로필 조회용)
+    public Long findUserIdByNickname(String nickname) {
+        return userRepository.findByName(nickname)
+                .orElseThrow(() -> new UserException(UserErrorCode.NOT_FOUND))
+                .getId();
     }
 }


### PR DESCRIPTION
## 개요
<!---- 자신이 완료한 이슈를 닫아주세요 -->
- closed #132 //이슈 번호는 추적을 위해 필요합니다!
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

<!---- Resolves: #132  -->

## PR 유형
어떤 변경 사항이 있나요?
타 유저 프로필 조회 API를 구현했습니다.
엔드포인트 형태, 그룹 상태 조건 외에는 '마이페이지 조회 API'와 ResDTO나 서비스 로직이 동일합니다. 때문에 기존 DTO명과 서비스명의 이름을 보다 포괄적으로 수정하여 두 API에서 모두 사용하도록 했습니다. 
또한 Service 메서드에 조회할 그룹 상태 목록 파라미터를 추가하여 '마이페이지 조회'와 '타 유저 프로필 조회' 분기를 처리했습니다.
<img width="1186" height="922" alt="image" src="https://github.com/user-attachments/assets/1126ec13-5326-403e-b8d6-eb5f4e47e99d" />


- [X] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [X] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

📣 **To Reviewers**
---
<!-- 전달사항 -->

- Reviewers : 팀 선택
- Labels : 작업 유형, 자기 자신


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 닉네임으로 다른 사용자의 프로필을 조회하는 신규 엔드포인트 추가
  * 내 프로필 조회의 응답 형식이 통일된 사용자 프로필 형태로 변경

* **개선**
  * 프로필 조회 시 그룹 필터링에 상태 기반 필터 적용으로 더 정확한 그룹 정보 제공
  * 닉네임 기반 사용자 조회 지원으로 프로필 조회 흐름 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->