### PR TITLE
[Feat] #156 서재검색 api 구현

### DIFF
--- a/src/main/java/com/example/bookiibookii/domain/group/service/ApplicationService.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/service/ApplicationService.java
@@ -131,8 +131,8 @@ public class ApplicationService {
                     newMember.getUser().getId(), null, group.getGroupId()
             ));
 
-            if (currentTotalCount + 1 >= group.getMaxCapacity()) {
-                group.updateStatus(GroupStatus.MATCHED);
+                if (currentTotalCount + 1 >= group.getMaxCapacity()) {
+                    group.updateStatus(GroupStatus.MATCHED);
 
                 List<Application> pendingApplications =
                         applicationRepository.findAllPendingByGroupId(group.getGroupId());

--- a/src/main/java/com/example/bookiibookii/domain/userbook/controller/LibraryController.java
+++ b/src/main/java/com/example/bookiibookii/domain/userbook/controller/LibraryController.java
@@ -1,13 +1,16 @@
 package com.example.bookiibookii.domain.userbook.controller;
 
 import com.example.bookiibookii.domain.user.entity.User;
+import com.example.bookiibookii.domain.userbook.dto.req.LibraryBookRequestDTO;
 import com.example.bookiibookii.domain.userbook.dto.res.LibraryBookResponseDTO;
 import com.example.bookiibookii.domain.userbook.service.LibraryService;
 import com.example.bookiibookii.global.apiPayload.ApiResponse;
 import com.example.bookiibookii.global.apiPayload.code.GeneralSuccessCode;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -26,6 +29,15 @@ public class LibraryController implements LibraryControllerDocs {
             @AuthenticationPrincipal(expression = "user") User user
     ) {
         List<LibraryBookResponseDTO> result = libraryService.getLibraryBooks(user.getId());
+        return ApiResponse.onSuccess(GeneralSuccessCode.FOUND, result);
+    }
+
+    @GetMapping("/search")
+    public ApiResponse<List<LibraryBookResponseDTO>> searchLibraryBooks(
+            @AuthenticationPrincipal(expression = "user") User user,
+            @Valid @ModelAttribute LibraryBookRequestDTO.SearchDTO request
+    ) {
+        List<LibraryBookResponseDTO> result = libraryService.searchLibraryBooks(user.getId(), request.getKeyword());
         return ApiResponse.onSuccess(GeneralSuccessCode.FOUND, result);
     }
 }

--- a/src/main/java/com/example/bookiibookii/domain/userbook/controller/LibraryControllerDocs.java
+++ b/src/main/java/com/example/bookiibookii/domain/userbook/controller/LibraryControllerDocs.java
@@ -1,6 +1,7 @@
 package com.example.bookiibookii.domain.userbook.controller;
 
 import com.example.bookiibookii.domain.user.entity.User;
+import com.example.bookiibookii.domain.userbook.dto.req.LibraryBookRequestDTO;
 import com.example.bookiibookii.domain.userbook.dto.res.LibraryBookResponseDTO;
 import com.example.bookiibookii.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -8,6 +9,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 
 import java.util.List;
 
@@ -32,4 +34,19 @@ public interface LibraryControllerDocs {
     ApiResponse<List<LibraryBookResponseDTO>> getLibraryBooks(
             @AuthenticationPrincipal(expression = "user") User user
     );
+
+    @Operation(
+            summary = "내 서재 검색 API",
+            description = "내 서재에 저장된 책을 제목, 저자, 한줄평 키워드로 검색합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "검색 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 필요")
+    })
+    @GetMapping("/search")
+    ApiResponse<List<LibraryBookResponseDTO>> searchLibraryBooks(
+            @AuthenticationPrincipal(expression = "user") User user,
+            @ModelAttribute LibraryBookRequestDTO.SearchDTO request
+    );
+
 }

--- a/src/main/java/com/example/bookiibookii/domain/userbook/dto/req/LibraryBookRequestDTO.java
+++ b/src/main/java/com/example/bookiibookii/domain/userbook/dto/req/LibraryBookRequestDTO.java
@@ -2,12 +2,14 @@ package com.example.bookiibookii.domain.userbook.dto.req;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 
 public class LibraryBookRequestDTO {
 
     @Getter
     @NoArgsConstructor
+    @Setter
     public static class SearchDTO {
         private String keyword; // 검색어 (제목, 저자, 한줄평)
     }

--- a/src/main/java/com/example/bookiibookii/domain/userbook/dto/req/LibraryBookRequestDTO.java
+++ b/src/main/java/com/example/bookiibookii/domain/userbook/dto/req/LibraryBookRequestDTO.java
@@ -1,5 +1,6 @@
 package com.example.bookiibookii.domain.userbook.dto.req;
 
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -7,9 +8,7 @@ import lombok.Setter;
 
 public class LibraryBookRequestDTO {
 
-    @Getter
-    @NoArgsConstructor
-    @Setter
+    @Builder
     public static class SearchDTO {
         private String keyword; // 검색어 (제목, 저자, 한줄평)
     }

--- a/src/main/java/com/example/bookiibookii/domain/userbook/dto/req/LibraryBookRequestDTO.java
+++ b/src/main/java/com/example/bookiibookii/domain/userbook/dto/req/LibraryBookRequestDTO.java
@@ -1,0 +1,14 @@
+package com.example.bookiibookii.domain.userbook.dto.req;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+public class LibraryBookRequestDTO {
+
+    @Getter
+    @NoArgsConstructor
+    public static class SearchDTO {
+        private String keyword; // 검색어 (제목, 저자, 한줄평)
+    }
+}

--- a/src/main/java/com/example/bookiibookii/domain/userbook/repository/UserBookRepository.java
+++ b/src/main/java/com/example/bookiibookii/domain/userbook/repository/UserBookRepository.java
@@ -54,4 +54,19 @@ public interface UserBookRepository extends JpaRepository<UserBook, Long> {
             @Param("userId") Long userId,
             Pageable pageable
     );
+
+    //검색로직
+    @Query("""
+    SELECT DISTINCT ub FROM UserBook ub
+    JOIN FETCH ub.group g
+    JOIN FETCH g.book b
+    JOIN FETCH g.host h
+    LEFT JOIN FETCH h.userImage
+    WHERE ub.user.id = :userId
+    AND (b.title LIKE %:keyword% 
+         OR b.author LIKE %:keyword% 
+         OR ub.comment LIKE %:keyword%)
+    ORDER BY ub.updatedAt DESC
+    """)
+    List<UserBook> searchMyLibrary(@Param("userId") Long userId, @Param("keyword") String keyword);
 }

--- a/src/main/java/com/example/bookiibookii/domain/userbook/service/LibraryService.java
+++ b/src/main/java/com/example/bookiibookii/domain/userbook/service/LibraryService.java
@@ -63,4 +63,18 @@ public class LibraryService {
                 .comment(ub.getComment())
                 .build();
     }
+
+    //서재검색
+    @Transactional(readOnly = true)
+    public List<LibraryBookResponseDTO> searchLibraryBooks(Long userId, String keyword) {
+        // 키워드가 없으면 전체 목록 조회로 대체하거나 빈 리스트 반환
+        if (keyword == null || keyword.isBlank()) {
+            return getLibraryBooks(userId);
+        }
+
+        List<UserBook> userBooks = userBookRepository.searchMyLibrary(userId, keyword);
+        return userBooks.stream()
+                .map(this::toLibraryBookResponseDTO) // 기존에 잘 만들어두신 메서드 재사용!
+                .toList();
+    }
 }


### PR DESCRIPTION
## 개요
closed #156 
서재에서 작가, 책제목, 자신이 남긴 책의 한줄평으로 검색해서 자신이 참여한 서재를 검색할 수 있습니다.

<!---- Resolves: #(Isuue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

📣 **To Reviewers**
---


- Reviewers : 팀 선택
- Labels : 작업 유형, 자기 자신


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 도서관 검색 기능이 추가되었습니다. 사용자는 도서 제목, 저자 또는 개인 코멘트(리뷰)를 키워드로 입력해 자신의 도서 라이브러리를 검색하고 관련 도서 목록을 확인할 수 있습니다. 기존의 전체 목록 조회 기능은 변경 없이 유지됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->