### PR TITLE
[Feat] #186 독서카드 댓글 api 구현

### DIFF
--- a/src/main/java/com/example/bookiibookii/domain/comment/controller/CardCommentController.java
+++ b/src/main/java/com/example/bookiibookii/domain/comment/controller/CardCommentController.java
@@ -25,7 +25,7 @@ public class CardCommentController implements CardCommentControllerDocs{
             @Valid @RequestBody CardCommentReqDTO.Create req
     ){
         CardCommentResDTO.Create result = cardCommentService.create(cardId, user, req);
-        return ApiResponse.onSuccess(CommentSuccessCode.CARD_CREATE_SUCCESS, result);
+        return ApiResponse.onSuccess(CommentSuccessCode.CARD_COMMENT_CREATE_SUCCESS, result);
     }
 
     @GetMapping("/cards/{cardId}/comments")

--- a/src/main/java/com/example/bookiibookii/domain/comment/controller/CardCommentController.java
+++ b/src/main/java/com/example/bookiibookii/domain/comment/controller/CardCommentController.java
@@ -33,7 +33,7 @@ public class CardCommentController implements CardCommentControllerDocs{
             @PathVariable Long cardId
     ) {
         CardCommentResDTO.ListResponse result = cardCommentService.getList(cardId);
-        return ApiResponse.onSuccess(CommentSuccessCode.COMMENT_FOUND_OK, result);
+        return ApiResponse.onSuccess(CommentSuccessCode.CARD_COMMENT_FOUND_OK, result);
     }
 
     @DeleteMapping("/cards/{cardId}/comments/{commentId}")

--- a/src/main/java/com/example/bookiibookii/domain/comment/controller/CardCommentController.java
+++ b/src/main/java/com/example/bookiibookii/domain/comment/controller/CardCommentController.java
@@ -1,0 +1,48 @@
+package com.example.bookiibookii.domain.comment.controller;
+
+import com.example.bookiibookii.domain.comment.dto.req.CardCommentReqDTO;
+import com.example.bookiibookii.domain.comment.dto.res.CardCommentResDTO;
+import com.example.bookiibookii.domain.comment.exception.code.CommentSuccessCode;
+import com.example.bookiibookii.domain.comment.service.CardCommentService;
+import com.example.bookiibookii.domain.user.entity.User;
+import com.example.bookiibookii.global.apiPayload.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class CardCommentController implements CardCommentControllerDocs{
+
+    private final CardCommentService cardCommentService;
+
+    @PostMapping("/cards/{cardId}/comments")
+    public ApiResponse<CardCommentResDTO.Create> create(
+            @PathVariable Long cardId,
+            @AuthenticationPrincipal(expression = "user") User user,
+            @Valid @RequestBody CardCommentReqDTO.Create req
+    ){
+        CardCommentResDTO.Create result = cardCommentService.create(cardId, user, req);
+        return ApiResponse.onSuccess(CommentSuccessCode.CARD_CREATE_SUCCESS, result);
+    }
+
+    @GetMapping("/cards/{cardId}/comments")
+    public ApiResponse<CardCommentResDTO.ListResponse> getCardComments(
+            @PathVariable Long cardId
+    ) {
+        CardCommentResDTO.ListResponse result = cardCommentService.getList(cardId);
+        return ApiResponse.onSuccess(CommentSuccessCode.COMMENT_FOUND_OK, result);
+    }
+
+    @DeleteMapping("/cards/{cardId}/comments/{commentId}")
+    public ApiResponse<Void> delete(
+            @PathVariable Long cardId,
+            @PathVariable Long commentId,
+            @AuthenticationPrincipal(expression = "user") User user
+    ) {
+        cardCommentService.delete(cardId, commentId, user);
+        return ApiResponse.onSuccess(CommentSuccessCode.DELETE_SUCCESS, null);
+    }
+}

--- a/src/main/java/com/example/bookiibookii/domain/comment/controller/CardCommentControllerDocs.java
+++ b/src/main/java/com/example/bookiibookii/domain/comment/controller/CardCommentControllerDocs.java
@@ -1,0 +1,63 @@
+package com.example.bookiibookii.domain.comment.controller;
+
+import com.example.bookiibookii.domain.comment.dto.req.CardCommentReqDTO;
+import com.example.bookiibookii.domain.comment.dto.res.CardCommentResDTO;
+import com.example.bookiibookii.domain.user.entity.User;
+import com.example.bookiibookii.global.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+public interface CardCommentControllerDocs {
+
+    @Operation(
+            summary = "카드 댓글 작성 api",
+            description = "카드(cardId)에 댓글을 작성합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "카드 댓글 작성 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "요청값이 올바르지 않음(빈 내용/길이 초과 등)"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "카드를 찾을 수 없음")
+    })
+    @PostMapping("/cards/{cardId}/comments")
+    ApiResponse<CardCommentResDTO.Create> create(
+            @PathVariable Long cardId,
+            @AuthenticationPrincipal(expression = "user") User user,
+            @Valid @RequestBody CardCommentReqDTO.Create req
+    );
+
+    @Operation(
+            summary = "카드 댓글 목록 조회 api",
+            description = "카드(cardId)의 댓글 목록을 시간순(오래된 댓글 -> 최신 댓글)으로 조회합니다. totalCount를 함께 반환합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "카드 댓글 조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "카드를 찾을 수 없음")
+    })
+    @GetMapping("/cards/{cardId}/comments")
+    ApiResponse<CardCommentResDTO.ListResponse> getCardComments(
+            @PathVariable Long cardId
+    );
+
+    @Operation(
+            summary = "카드 댓글 삭제 api",
+            description = "카드(cardId)에 속한 특정 댓글(commentId)을 삭제합니다. 작성자만 삭제 가능합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "카드 댓글 삭제 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "삭제 권한 없음(작성자 아님)"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "카드 댓글을 찾을 수 없음")
+    })
+    @DeleteMapping("/cards/{cardId}/comments/{commentId}")
+    ApiResponse<Void> delete(
+            @PathVariable Long cardId,
+            @PathVariable Long commentId,
+            @AuthenticationPrincipal(expression = "user") User user
+    );
+}

--- a/src/main/java/com/example/bookiibookii/domain/comment/dto/CardWriterDto.java
+++ b/src/main/java/com/example/bookiibookii/domain/comment/dto/CardWriterDto.java
@@ -1,0 +1,10 @@
+package com.example.bookiibookii.domain.comment.dto;
+
+import lombok.Builder;
+
+@Builder
+public record CardWriterDto(
+        Long userId,
+        String name,
+        String profileImage
+) {}

--- a/src/main/java/com/example/bookiibookii/domain/comment/dto/req/CardCommentReqDTO.java
+++ b/src/main/java/com/example/bookiibookii/domain/comment/dto/req/CardCommentReqDTO.java
@@ -1,0 +1,13 @@
+package com.example.bookiibookii.domain.comment.dto.req;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public class CardCommentReqDTO {
+
+    public record Create(
+            @NotBlank(message = "댓글 내용을 입력해주세요.")
+            @Size(max = 500, message = "댓글은 500자 이내로 입력해주세요.")
+            String content
+    ) {}
+}

--- a/src/main/java/com/example/bookiibookii/domain/comment/dto/res/CardCommentResDTO.java
+++ b/src/main/java/com/example/bookiibookii/domain/comment/dto/res/CardCommentResDTO.java
@@ -1,0 +1,24 @@
+package com.example.bookiibookii.domain.comment.dto.res;
+
+import com.example.bookiibookii.domain.comment.dto.CardWriterDto;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class CardCommentResDTO {
+
+    public record Create(
+            Long id
+    ) {}
+
+    public record Comment(
+            Long id,
+            String content,
+            CardWriterDto writer,
+            LocalDateTime createdAt
+    ) {}
+
+    public record ListResponse(
+            long totalCount,
+            List<Comment> comments
+    ) {}
+}

--- a/src/main/java/com/example/bookiibookii/domain/comment/entity/CardComment.java
+++ b/src/main/java/com/example/bookiibookii/domain/comment/entity/CardComment.java
@@ -1,0 +1,31 @@
+package com.example.bookiibookii.domain.comment.entity;
+
+import com.example.bookiibookii.domain.user.entity.User;
+import com.example.bookiibookii.domain.userbook.entity.Card;
+import com.example.bookiibookii.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import static jakarta.persistence.FetchType.LAZY;
+
+@Entity
+@Builder
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class CardComment extends BaseEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String content;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "reading_card_id", nullable = false)
+    private Card card;
+}

--- a/src/main/java/com/example/bookiibookii/domain/comment/exception/code/CommentErrorCode.java
+++ b/src/main/java/com/example/bookiibookii/domain/comment/exception/code/CommentErrorCode.java
@@ -9,18 +9,26 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum CommentErrorCode implements BaseCode {
 
-    PARENT_COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND,
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND,
             "COMMENT404_1",
+            "해당 댓글을 찾을 수 없습니다."),
+    PARENT_COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND,
+            "COMMENT404_2",
             "부모 댓글을 찾을 수 없습니다."),
+
     PARENT_COMMENT_GROUP_MISMATCH(HttpStatus.BAD_REQUEST,
             "COMMENT400_1",
             "부모 댓글이 해당 그룹에 속하지 않습니다."),
     REPLY_DEPTH_EXCEEDED(HttpStatus.BAD_REQUEST,
             "COMMENT400_2",
             "대댓글의 대댓글은 허용되지 않습니다."),
+
     COMMENT_WRITE_FORBIDDEN(HttpStatus.FORBIDDEN,
             "COMMENT403_1",
             "진행 중인 그룹에는 그룹 멤버만 댓글 작성이 가능합니다."),
+    NO_PERMISSION(HttpStatus.FORBIDDEN,
+            "COMMENT403_2",
+            "해당 댓글에 대한 권한이 없습니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/example/bookiibookii/domain/comment/exception/code/CommentSuccessCode.java
+++ b/src/main/java/com/example/bookiibookii/domain/comment/exception/code/CommentSuccessCode.java
@@ -12,7 +12,7 @@ public enum CommentSuccessCode implements BaseCode {
     CREATE_SUCCESS(HttpStatus.CREATED,
             "COMMENT201_1",
             "댓글을 성공적으로 생성했습니다."),
-    CARD_CREATE_SUCCESS(HttpStatus.CREATED,
+    CARD_COMMENT_CREATE_SUCCESS(HttpStatus.CREATED,
             "COMMENT201_2",
             "독서카드 댓글을 성공적으로 생성했습니다."),
 

--- a/src/main/java/com/example/bookiibookii/domain/comment/exception/code/CommentSuccessCode.java
+++ b/src/main/java/com/example/bookiibookii/domain/comment/exception/code/CommentSuccessCode.java
@@ -12,9 +12,20 @@ public enum CommentSuccessCode implements BaseCode {
     CREATE_SUCCESS(HttpStatus.CREATED,
             "COMMENT201_1",
             "댓글을 성공적으로 생성했습니다."),
+    CARD_CREATE_SUCCESS(HttpStatus.CREATED,
+            "COMMENT201_2",
+            "독서카드 댓글을 성공적으로 생성했습니다."),
+
     COMMENT_FOUND_OK(HttpStatus.OK,
             "COMMENT200_1",
-            "그룹의 댓글을 성공적으로 찾았습니다."),
+            "댓글 조회에 성공했습니다."),
+    CARD_COMMENT_FOUND_OK(HttpStatus.OK,
+            "COMMENT200_2",
+            "독서카드 댓글 조회에 성공했습니다."),
+
+    DELETE_SUCCESS(HttpStatus.OK,
+            "COMMENT200_2",
+            "댓글 삭제에 성공했습니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/example/bookiibookii/domain/comment/exception/code/CommentSuccessCode.java
+++ b/src/main/java/com/example/bookiibookii/domain/comment/exception/code/CommentSuccessCode.java
@@ -24,7 +24,7 @@ public enum CommentSuccessCode implements BaseCode {
             "독서카드 댓글 조회에 성공했습니다."),
 
     DELETE_SUCCESS(HttpStatus.OK,
-            "COMMENT200_2",
+            "COMMENT200_3",
             "댓글 삭제에 성공했습니다."),
     ;
 

--- a/src/main/java/com/example/bookiibookii/domain/comment/repository/CardCommentRepository.java
+++ b/src/main/java/com/example/bookiibookii/domain/comment/repository/CardCommentRepository.java
@@ -22,6 +22,4 @@ public interface CardCommentRepository extends JpaRepository<CardComment, Long> 
 
     Optional<CardComment> findByIdAndCardId(Long commentId, Long cardId);
 
-    long countByCardId(Long cardId);
-
 }

--- a/src/main/java/com/example/bookiibookii/domain/comment/repository/CardCommentRepository.java
+++ b/src/main/java/com/example/bookiibookii/domain/comment/repository/CardCommentRepository.java
@@ -1,0 +1,27 @@
+package com.example.bookiibookii.domain.comment.repository;
+
+import com.example.bookiibookii.domain.comment.entity.CardComment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface CardCommentRepository extends JpaRepository<CardComment, Long> {
+
+    @Query("""
+        select cc
+        from CardComment cc
+        join fetch cc.user u
+        left join fetch u.userImage
+        where cc.card.id = :cardId
+        order by cc.createdAt asc
+    """)
+    List<CardComment> findAllByCardIdWithUserOrderByCreatedAtAsc(@Param("cardId") Long cardId);
+
+    Optional<CardComment> findByIdAndCardId(Long commentId, Long cardId);
+
+    long countByCardId(Long cardId);
+
+}

--- a/src/main/java/com/example/bookiibookii/domain/comment/service/CardCommentService.java
+++ b/src/main/java/com/example/bookiibookii/domain/comment/service/CardCommentService.java
@@ -1,0 +1,97 @@
+package com.example.bookiibookii.domain.comment.service;
+
+import com.example.bookiibookii.domain.comment.dto.CardWriterDto;
+import com.example.bookiibookii.domain.comment.dto.req.CardCommentReqDTO;
+import com.example.bookiibookii.domain.comment.dto.res.CardCommentResDTO;
+import com.example.bookiibookii.domain.comment.entity.CardComment;
+import com.example.bookiibookii.domain.comment.exception.CommentException;
+import com.example.bookiibookii.domain.comment.exception.code.CommentErrorCode;
+import com.example.bookiibookii.domain.comment.repository.CardCommentRepository;
+import com.example.bookiibookii.domain.user.service.UserImageS3Service;
+import com.example.bookiibookii.domain.userbook.entity.Card;
+import com.example.bookiibookii.domain.userbook.exception.CardImageException;
+import com.example.bookiibookii.domain.userbook.exception.code.CardImageErrorCode;
+import com.example.bookiibookii.domain.userbook.repository.CardRepository;
+import org.springframework.stereotype.Service;
+import com.example.bookiibookii.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CardCommentService {
+
+    private final CardRepository cardRepository;
+    private final CardCommentRepository cardCommentRepository;
+    private final UserImageS3Service userImageS3Service;
+
+    private static final int PRESIGNED_GET_URL_EXPIRATION_MINUTES = 60;
+
+    @Transactional
+    public CardCommentResDTO.Create create(Long cardId, User user, CardCommentReqDTO.Create req) {
+        Card card = cardRepository.findById(cardId)
+                .orElseThrow(() -> new CardImageException(CardImageErrorCode.CARD_NOT_FOUND));
+
+        CardComment saved = cardCommentRepository.save(
+                CardComment.builder()
+                        .card(card)
+                        .user(user)
+                        .content(req.content().trim())
+                        .build()
+        );
+
+        return new CardCommentResDTO.Create(saved.getId());
+    }
+
+    public CardCommentResDTO.ListResponse getList(Long cardId) {
+        if (!cardRepository.existsById(cardId)) {
+            throw new CardImageException(CardImageErrorCode.CARD_NOT_FOUND);
+        }
+
+        long totalCount = cardCommentRepository.countByCardId(cardId);
+
+        var comments = cardCommentRepository.findAllByCardIdWithUserOrderByCreatedAtAsc(cardId).stream()
+                .map(this::toCommentDto)
+                .toList();
+
+        return new CardCommentResDTO.ListResponse(totalCount, comments);
+    }
+
+    @Transactional
+    public void delete(Long cardId, Long commentId, User user) {
+        CardComment comment = cardCommentRepository.findByIdAndCardId(commentId, cardId)
+                .orElseThrow(() -> new CommentException(CommentErrorCode.COMMENT_NOT_FOUND));
+
+        if (!comment.getUser().getId().equals(user.getId())) {
+            throw new CommentException(CommentErrorCode.NO_PERMISSION);
+        }
+
+        cardCommentRepository.delete(comment);
+    }
+
+    // converter
+    private CardCommentResDTO.Comment toCommentDto(CardComment c) {
+        return new CardCommentResDTO.Comment(
+                c.getId(),
+                c.getContent(),
+                toWriterDto(c.getUser()),
+                c.getCreatedAt()
+        );
+    }
+
+    private CardWriterDto toWriterDto(User u) {
+        String profileImageUrl = u.getUserImage() != null
+                ? userImageS3Service.generatePresignedGetUrl(
+                u.getUserImage().getS3Key(),
+                PRESIGNED_GET_URL_EXPIRATION_MINUTES
+        )
+                : null;
+
+        return CardWriterDto.builder()
+                .userId(u.getId())
+                .name(u.getName())
+                .profileImage(profileImageUrl)
+                .build();
+    }
+}

--- a/src/main/java/com/example/bookiibookii/domain/comment/service/CardCommentService.java
+++ b/src/main/java/com/example/bookiibookii/domain/comment/service/CardCommentService.java
@@ -49,11 +49,10 @@ public class CardCommentService {
             throw new CardImageException(CardImageErrorCode.CARD_NOT_FOUND);
         }
 
-        long totalCount = cardCommentRepository.countByCardId(cardId);
-
         var comments = cardCommentRepository.findAllByCardIdWithUserOrderByCreatedAtAsc(cardId).stream()
                 .map(this::toCommentDto)
                 .toList();
+        long totalCount = comments.size();
 
         return new CardCommentResDTO.ListResponse(totalCount, comments);
     }


### PR DESCRIPTION
## 개요
<!---- 자신이 완료한 이슈를 닫아주세요 -->
- closed #186 
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
기존 그룹 댓글 엔티티와 분리하여, 독서카드에 달리는 댓글 전용 엔티티를 생성했습니다.
독서카드 생성, 조회, 삭제 api를 구현했습니다

<!---- Resolves: #(Isuue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

📣 **To Reviewers**
---
<!-- 전달사항 -->
해태 프로필 이미지 관련 세팅 기존 댓글 참고해서 세팅했는데 
틀린 부분 있으면 리뷰 남겨주세요 수정하겠습니다

- Reviewers : 팀 선택
- Labels : 작업 유형, 자기 자신


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 새로운 기능
* **카드 댓글 기능**
  * 독서카드에 댓글 작성(최대 500자) 가능 (로그인 필요)
  * 독서카드의 댓글 목록을 생성일 기준 오름차순으로 조회 가능
  * 작성한 댓글 삭제 가능(작성자 권한 필요)
  * 댓글 작성자 정보(이름, 프로필 이미지)가 함께 제공되어 표시됩니다
<!-- end of auto-generated comment: release notes by coderabbit.ai -->