### PR TITLE
[Feat]#228 userbook, card delete API 개발

### DIFF
--- a/src/main/java/com/example/bookiibookii/domain/user/service/UserService.java
+++ b/src/main/java/com/example/bookiibookii/domain/user/service/UserService.java
@@ -172,7 +172,7 @@ public class UserService {
                         .build()).toList();
 
         // 완독 수 (로직에 따라 조건 추가 가능)
-        Long completeBookCount = userBookRepository.countByUser_Id(userId);
+        Long completeBookCount = userBookRepository.countByUser_IdAndRemovedAtIsNull(userId);
         // 참여한 그룹 수 (타입별)
         Long relayCount = matchedMemberRepository.countByUser_IdAndGroup_GroupType(userId, GroupType.RELAY);
         Long togetherCount = matchedMemberRepository.countByUser_IdAndGroup_GroupType(userId, GroupType.TOGETHER);

--- a/src/main/java/com/example/bookiibookii/domain/userbook/controller/CardController.java
+++ b/src/main/java/com/example/bookiibookii/domain/userbook/controller/CardController.java
@@ -14,6 +14,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.*;
 
 @Validated
@@ -81,5 +82,15 @@ public class CardController implements CardControllerDocs {
         CardCreateResponseDTO responseDTO = cardService.updateCardResponseDTO(
                 cardId, user.getId(), request, PRESIGNED_GET_URL_EXPIRATION_MINUTES);
         return ApiResponse.onSuccess(CardImageSuccessCode.CARD_UPDATED, responseDTO);
+    }
+
+    @Override
+    @DeleteMapping("/{cardId}")
+    public ApiResponse<Void> removeCardFromView(
+            @AuthenticationPrincipal(expression = "user") User user,
+            @PathVariable Long cardId
+    ) {
+        cardService.markCardAsDeleted(cardId, user.getId());
+        return ApiResponse.onSuccess(CardImageSuccessCode.CARD_REMOVED_FROM_VIEW, null);
     }
 }

--- a/src/main/java/com/example/bookiibookii/domain/userbook/controller/CardControllerDocs.java
+++ b/src/main/java/com/example/bookiibookii/domain/userbook/controller/CardControllerDocs.java
@@ -14,6 +14,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -173,5 +174,22 @@ public interface CardControllerDocs {
             @Parameter(description = "카드 식별자(ID)", example = "1")
             @PathVariable Long cardId,
             @Valid @RequestBody CardUpdateRequestDTO request
+    );
+
+    @Operation(
+            summary = "독서카드 내 화면에서 제거",
+            description = """
+            그룹 내 공유된 독서카드를 '내 화면에서만' 숨깁니다. 카드/그룹은 삭제되지 않으며, 다른 멤버는 계속 조회할 수 있습니다.
+            카드 소유자 또는 그룹 멤버만 호출 가능합니다. 이미 제거한 카드는 무시됩니다(멱등).
+            """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "제거 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "카드 없음 또는 접근 권한 없음")
+    })
+    @DeleteMapping("/{cardId}")
+    ApiResponse<Void> removeCardFromView(
+            @AuthenticationPrincipal(expression = "user") User user,
+            @Parameter(description = "카드 식별자(ID)", example = "1") @PathVariable Long cardId
     );
 }

--- a/src/main/java/com/example/bookiibookii/domain/userbook/controller/LibraryController.java
+++ b/src/main/java/com/example/bookiibookii/domain/userbook/controller/LibraryController.java
@@ -9,8 +9,10 @@ import com.example.bookiibookii.global.apiPayload.code.GeneralSuccessCode;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -22,6 +24,16 @@ import java.util.List;
 public class LibraryController implements LibraryControllerDocs {
 
     private final LibraryService libraryService;
+
+    @Override
+    @DeleteMapping("/{userBookId}")
+    public ApiResponse<Void> removeFromLibrary(
+            @AuthenticationPrincipal(expression = "user") User user,
+            @PathVariable Long userBookId
+    ) {
+        libraryService.removeFromLibrary(userBookId, user.getId());
+        return ApiResponse.onSuccess(GeneralSuccessCode.REQUEST_OK, null);
+    }
 
     @Override
     @GetMapping("/books")

--- a/src/main/java/com/example/bookiibookii/domain/userbook/controller/LibraryControllerDocs.java
+++ b/src/main/java/com/example/bookiibookii/domain/userbook/controller/LibraryControllerDocs.java
@@ -8,13 +8,33 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
 
 import java.util.List;
 
 @Tag(name = "Library", description = "라이브러리(내 책 목록) 관련 API")
 public interface LibraryControllerDocs {
+
+    @Operation(
+            summary = "서재에서 제거",
+            description = """
+            내 서재에서 해당 UserBook(책)을 제거합니다. 소프트 삭제이며, 그룹·카드는 삭제되지 않습니다.
+            그룹 내 다른 멤버는 그룹과 카드를 계속 조회할 수 있습니다. 본인 소유 UserBook만 제거 가능합니다.
+            """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "제거 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 필요"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "UserBook 없음 또는 소유자가 아님")
+    })
+    @DeleteMapping("/{userBookId}")
+    ApiResponse<Void> removeFromLibrary(
+            @AuthenticationPrincipal(expression = "user") User user,
+            @PathVariable Long userBookId
+    );
 
     @Operation(
             summary = "라이브러리 책 목록 조회",

--- a/src/main/java/com/example/bookiibookii/domain/userbook/entity/DeletedCard.java
+++ b/src/main/java/com/example/bookiibookii/domain/userbook/entity/DeletedCard.java
@@ -1,0 +1,35 @@
+package com.example.bookiibookii.domain.userbook.entity;
+
+import com.example.bookiibookii.domain.user.entity.User;
+import com.example.bookiibookii.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+/**
+ * 그룹 내 공유 카드를 "내 화면에서만 숨김" 처리한 기록.
+ * 카드/그룹은 삭제되지 않고, 해당 사용자만 목록·상세에서 제외된다.
+ */
+@Entity
+@Table(
+        name = "deleted_card",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "card_id"})
+)
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class DeletedCard extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "deleted_card_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "card_id", nullable = false)
+    private Card card;
+}

--- a/src/main/java/com/example/bookiibookii/domain/userbook/entity/UserBook.java
+++ b/src/main/java/com/example/bookiibookii/domain/userbook/entity/UserBook.java
@@ -7,6 +7,8 @@ import com.example.bookiibookii.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Table(name = "user_book")
 @Getter
@@ -38,8 +40,17 @@ public class UserBook extends BaseEntity {
     @Column(name = "comment", length = 500)
     private String comment;
 
+    /** 서재에서 제거한 시점. null이면 목록에 노출, 값이 있으면 라이브러리에서 제외 */
+    @Column(name = "removed_at")
+    private LocalDateTime removedAt;
+
     public void updateReview(Double rating, String comment) {
         this.rating = rating;
         this.comment = comment;
+    }
+
+    /** 서재에서만 제거(소프트 삭제??). 다른 멤버는 계속 조회 가능. */
+    public void markRemoved() {
+        this.removedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/example/bookiibookii/domain/userbook/exception/code/CardImageSuccessCode.java
+++ b/src/main/java/com/example/bookiibookii/domain/userbook/exception/code/CardImageSuccessCode.java
@@ -16,7 +16,7 @@ public enum CardImageSuccessCode implements BaseCode {
     CARD_CREATED(HttpStatus.CREATED, "CARDIMG201_2", "독서카드를 생성했습니다."),
     CARDS_FOUND(HttpStatus.OK, "CARDIMG200_4", "독서카드 목록을 조회했습니다."),
     CARD_UPDATED(HttpStatus.OK, "CARDIMG200_5", "독서카드를 수정했습니다."),
-    CARD_REMOVED_FROM_VIEW(HttpStatus.OK, "CARDIMG200_9", "독서카드를 내 화면에서 제거했습니다.");
+    CARD_REMOVED_FROM_VIEW(HttpStatus.OK, "CARDIMG200_9", "독서카드를 내 화면에서 제거했습니다."),
     BOOKMARK_TOGGLED(HttpStatus.OK, "CARDIMG200_7", "북마크를 변경했습니다."),
     BOOKMARKED_CARDS_FOUND(HttpStatus.OK, "CARDIMG200_8", "북마크한 독서카드 목록을 조회했습니다.");
 

--- a/src/main/java/com/example/bookiibookii/domain/userbook/exception/code/CardImageSuccessCode.java
+++ b/src/main/java/com/example/bookiibookii/domain/userbook/exception/code/CardImageSuccessCode.java
@@ -15,7 +15,8 @@ public enum CardImageSuccessCode implements BaseCode {
     CARD_FOUND(HttpStatus.OK, "CARDIMG200_6", "독서카드를 조회했습니다."),
     CARD_CREATED(HttpStatus.CREATED, "CARDIMG201_2", "독서카드를 생성했습니다."),
     CARDS_FOUND(HttpStatus.OK, "CARDIMG200_4", "독서카드 목록을 조회했습니다."),
-    CARD_UPDATED(HttpStatus.OK, "CARDIMG200_5", "독서카드를 수정했습니다.");
+    CARD_UPDATED(HttpStatus.OK, "CARDIMG200_5", "독서카드를 수정했습니다."),
+    CARD_REMOVED_FROM_VIEW(HttpStatus.OK, "CARDIMG200_9", "독서카드를 내 화면에서 제거했습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/example/bookiibookii/domain/userbook/repository/DeletedCardRepository.java
+++ b/src/main/java/com/example/bookiibookii/domain/userbook/repository/DeletedCardRepository.java
@@ -14,8 +14,6 @@ public interface DeletedCardRepository extends JpaRepository<DeletedCard, Long> 
 
     boolean existsByUser_IdAndCard_Id(Long userId, Long cardId);
 
-    Optional<DeletedCard> findByUser_IdAndCard_Id(Long userId, Long cardId);
-
     @Query("SELECT dc.card.id FROM DeletedCard dc WHERE dc.user.id = :userId")
     List<Long> findCardIdsByUser_Id(@Param("userId") Long userId);
 }

--- a/src/main/java/com/example/bookiibookii/domain/userbook/repository/DeletedCardRepository.java
+++ b/src/main/java/com/example/bookiibookii/domain/userbook/repository/DeletedCardRepository.java
@@ -1,0 +1,21 @@
+package com.example.bookiibookii.domain.userbook.repository;
+
+import com.example.bookiibookii.domain.userbook.entity.DeletedCard;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface DeletedCardRepository extends JpaRepository<DeletedCard, Long> {
+
+    boolean existsByUser_IdAndCard_Id(Long userId, Long cardId);
+
+    Optional<DeletedCard> findByUser_IdAndCard_Id(Long userId, Long cardId);
+
+    @Query("SELECT dc.card.id FROM DeletedCard dc WHERE dc.user.id = :userId")
+    List<Long> findCardIdsByUser_Id(@Param("userId") Long userId);
+}

--- a/src/main/java/com/example/bookiibookii/domain/userbook/repository/UserBookRepository.java
+++ b/src/main/java/com/example/bookiibookii/domain/userbook/repository/UserBookRepository.java
@@ -43,8 +43,6 @@ public interface UserBookRepository extends JpaRepository<UserBook, Long> {
     List<String> findRecentBookTitle(@Param("userId") Long userId, Pageable pageable);
 
     // 완독한 책 개수 (서재에서 제거한 항목 제외)
-    Long countByUser_Id(Long userId);
-
     Long countByUser_IdAndRemovedAtIsNull(Long userId);
 
 

--- a/src/main/java/com/example/bookiibookii/domain/userbook/repository/UserBookRepository.java
+++ b/src/main/java/com/example/bookiibookii/domain/userbook/repository/UserBookRepository.java
@@ -27,6 +27,7 @@ public interface UserBookRepository extends JpaRepository<UserBook, Long> {
         JOIN FETCH g.host h
         LEFT JOIN FETCH h.userImage
         WHERE ub.user.id = :userId
+        AND ub.removedAt IS NULL
         ORDER BY ub.updatedAt DESC
         """)
     List<UserBook> findAllByUser_IdWithGroupAndBookAndHost(@Param("userId") Long userId);
@@ -36,12 +37,15 @@ public interface UserBookRepository extends JpaRepository<UserBook, Long> {
         FROM UserBook ub
         JOIN ub.group g
         WHERE ub.user.id = :userId
+        AND ub.removedAt IS NULL
         ORDER BY ub.updatedAt DESC
     """)
     List<String> findRecentBookTitle(@Param("userId") Long userId, Pageable pageable);
 
-    // 완독한 책 개수
+    // 완독한 책 개수 (서재에서 제거한 항목 제외)
     Long countByUser_Id(Long userId);
+
+    Long countByUser_IdAndRemovedAtIsNull(Long userId);
 
 
 
@@ -53,6 +57,7 @@ public interface UserBookRepository extends JpaRepository<UserBook, Long> {
     JOIN FETCH g.host h
     LEFT JOIN FETCH h.userImage
     WHERE ub.user.id = :userId
+    AND ub.removedAt IS NULL
     AND (b.title LIKE %:keyword% 
          OR b.author LIKE %:keyword% 
          OR ub.comment LIKE %:keyword%)

--- a/src/main/java/com/example/bookiibookii/domain/userbook/service/CardService.java
+++ b/src/main/java/com/example/bookiibookii/domain/userbook/service/CardService.java
@@ -193,7 +193,11 @@ public class CardService {
                 .user(userRepository.getReferenceById(userId))
                 .card(card)
                 .build();
-        deletedCardRepository.save(deleted);
+        try {
+            deletedCardRepository.saveAndFlush(deleted);
+        } catch (org.springframework.dao.DataIntegrityViolationException e) {
+            // 동시 요청으로 이미 삽입된 경우 — 멱등 처리
+        }
     }
 
     /**

--- a/src/main/java/com/example/bookiibookii/domain/userbook/service/CardService.java
+++ b/src/main/java/com/example/bookiibookii/domain/userbook/service/CardService.java
@@ -12,14 +12,17 @@ import com.example.bookiibookii.domain.userbook.dto.res.GroupCardResponseDTO;
 import com.example.bookiibookii.domain.userbook.dto.res.PresignedUrlResponseDTO;
 import com.example.bookiibookii.domain.userbook.entity.Card;
 import com.example.bookiibookii.domain.userbook.entity.CardImage;
+import com.example.bookiibookii.domain.userbook.entity.DeletedCard;
 import com.example.bookiibookii.domain.userbook.entity.UserBook;
 import com.example.bookiibookii.domain.userbook.exception.CardException;
 import com.example.bookiibookii.domain.userbook.exception.CardImageException;
 import com.example.bookiibookii.domain.userbook.exception.code.CardErrorCode;
 import com.example.bookiibookii.domain.userbook.exception.code.CardImageErrorCode;
 import com.example.bookiibookii.domain.group.repository.MatchedMemberRepository;
+import com.example.bookiibookii.domain.user.repository.UserRepository;
 import com.example.bookiibookii.domain.userbook.repository.CardImageRepository;
 import com.example.bookiibookii.domain.userbook.repository.CardRepository;
+import com.example.bookiibookii.domain.userbook.repository.DeletedCardRepository;
 import com.example.bookiibookii.domain.userbook.repository.UserBookRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -27,6 +30,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
@@ -34,6 +38,8 @@ import java.util.Optional;
 public class CardService {
 
     private final CardRepository cardRepository;
+    private final DeletedCardRepository deletedCardRepository;
+    private final UserRepository userRepository;
     private final CardImageRepository cardImageRepository;
     private final CardImageValidationService cardImageValidationService;
     private final CardImageS3Service cardImageS3Service;
@@ -131,6 +137,10 @@ public class CardService {
         String creatorName = userBook.getUser().getNickName();
 
         List<Card> cards = cardRepository.findByUserBookIdWithCardImage(userBookId);
+        Set<Long> deletedCardIds = Set.copyOf(deletedCardRepository.findCardIdsByUser_Id(userId));
+        cards = cards.stream()
+                .filter(c -> !deletedCardIds.contains(c.getId()))
+                .toList();
 
         List<GroupCardResponseDTO> cardDTOs = cards.stream()
                 .map(card -> buildGroupCardResponseDTO(card, card.getCardImage(), presignedGetUrlExpirationMinutes, bookTitle))
@@ -148,6 +158,9 @@ public class CardService {
      */
     public GroupCardResponseDTO getCardDetailResponseDTO(Long cardId, Long userId, int presignedGetUrlExpirationMinutes) {
         Card card = getCardDetail(cardId, userId);
+        if (deletedCardRepository.existsByUser_IdAndCard_Id(userId, cardId)) {
+            throw new CardImageException(CardImageErrorCode.CARD_NOT_FOUND);
+        }
         CardImage cardImage = card.getCardImage();
         String bookTitle = card.getUserBook().getGroup().getBook().getTitle();
         return buildGroupCardResponseDTO(card, cardImage, presignedGetUrlExpirationMinutes, bookTitle);
@@ -164,6 +177,23 @@ public class CardService {
             cardImage = getCardImage(cardId);
         }
         return buildCardCreateResponseDTO(card, cardImage, presignedGetUrlExpirationMinutes);
+    }
+
+    /**
+     * 카드를 "내 화면에서만 숨김" 처리. 그룹/카드는 삭제되지 않고, 해당 사용자만 목록·상세에서 제외.
+     * 카드 소유자 또는 그룹 멤버만 호출 가능. 이미 삭제 처리된 경우 무시(멱등).
+     */
+    @Transactional
+    public void markCardAsDeleted(Long cardId, Long userId) {
+        Card card = getCardDetail(cardId, userId);
+        if (deletedCardRepository.existsByUser_IdAndCard_Id(userId, cardId)) {
+            return;
+        }
+        DeletedCard deleted = DeletedCard.builder()
+                .user(userRepository.getReferenceById(userId))
+                .card(card)
+                .build();
+        deletedCardRepository.save(deleted);
     }
 
     /**

--- a/src/main/java/com/example/bookiibookii/domain/userbook/service/LibraryService.java
+++ b/src/main/java/com/example/bookiibookii/domain/userbook/service/LibraryService.java
@@ -3,6 +3,8 @@ package com.example.bookiibookii.domain.userbook.service;
 import com.example.bookiibookii.domain.user.service.UserImageS3Service;
 import com.example.bookiibookii.domain.userbook.dto.res.LibraryBookResponseDTO;
 import com.example.bookiibookii.domain.userbook.entity.UserBook;
+import com.example.bookiibookii.domain.userbook.exception.CardImageException;
+import com.example.bookiibookii.domain.userbook.exception.code.CardImageErrorCode;
 import com.example.bookiibookii.domain.userbook.repository.UserBookRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -23,8 +25,19 @@ public class LibraryService {
     private static final int PRESIGNED_GET_URL_EXPIRATION_MINUTES = 60;
 
     /**
+     * 서재에서만 제거(소프트 삭제). 그룹·카드는 삭제되지 않고, 다른 멤버는 계속 조회 가능.
+     * 본인 소유 UserBook만 제거 가능.
+     */
+    @Transactional
+    public void removeFromLibrary(Long userBookId, Long userId) {
+        UserBook userBook = userBookRepository.findByIdAndUser_Id(userBookId, userId)
+                .orElseThrow(() -> new CardImageException(CardImageErrorCode.USER_BOOK_NOT_FOUND));
+        userBook.markRemoved();
+    }
+
+    /**
      * 현재 사용자의 라이브러리(UserBook 목록)를 조회합니다.
-     * user_id = userId 인 UserBook 목록을 그룹·책·호스트·호스트 프로필 이미지와 함께 반환합니다.
+     * user_id = userId 이고 removedAt IS NULL 인 UserBook만 반환합니다.
      */
     @Transactional(readOnly = true)
     public List<LibraryBookResponseDTO> getLibraryBooks(Long userId) {


### PR DESCRIPTION
## 개요
<!---- 자신이 완료한 이슈를 닫아주세요 -->
- closed #228 
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
card 삭제 로직 : DeletedCard로 내가 삭제한 카드를 기록, 이후 카드 조회 시에 내가 삭제한 카드 id 조회 후 반환 목록에서 제외

userbook 삭제 로직 : userbook에 삭제에 대한 정보를 담고있는 속성을 추가하여, 서재에서 그룹 삭제시 해당 속성을 담고 있는 그룹은 보이지 않게 처리

<!---- Resolves: #(Isuue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

📣 **To Reviewers**
---
<!-- 전달사항 -->

- Reviewers : 팀 선택
- Labels : 작업 유형, 자기 자신


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신기능**
  * 개인 라이브러리에서 책을 '제거(숨김)'하여 내 목록에서 보이지 않도록 할 수 있습니다.
  * 다른 사용자가 공유한 독서카드를 개인 화면에서 숨길 수 있는 기능이 추가되어, 다른 사용자에게 영향 없이 관리할 수 있습니다.

* **개선사항**
  * 사용자 프로필의 완료된 책 개수가 라이브러리에서 제거된 항목을 제외하여 보다 정확하게 집계됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->