### PR TITLE
[Mod] 그룹생성 시 장소저장 추가

### DIFF
--- a/src/main/java/com/example/bookiibookii/domain/group/dto/req/GroupRequestDTO.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/dto/req/GroupRequestDTO.java
@@ -28,6 +28,8 @@ public class GroupRequestDTO {
         private String customTag;
         private GroupType groupType;   // RELAY, TOGETHER
         private TradeType tradeType;   // DELIVERY, DIRECT
+        private String preferRegion;
+        private String meetPlace;
         private List<GroupRequestDTO.TagSettingDTO> tags;
     }
 

--- a/src/main/java/com/example/bookiibookii/domain/group/dto/res/GroupResponseDTO.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/dto/res/GroupResponseDTO.java
@@ -51,6 +51,8 @@ public class GroupResponseDTO {
         private String title;          // 도서 제목
         private String groupStatus;    // RECRUITING, MATCHED
         private Boolean isHost;        // 조회자가 방장인지 여부
+        private String preferRegion;
+        private String meetPlace;
 
         // 2. 도서 상세 정보 (Book 엔티티와 매핑)
         private String bookTitle;

--- a/src/main/java/com/example/bookiibookii/domain/group/entity/Groups.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/entity/Groups.java
@@ -68,6 +68,9 @@ public class Groups extends BaseEntity {
     @Column(name = "trade_type")
     private TradeType tradeType;//DIRECT, DELIVERY
 
+    @Column(name = "prefer_region")
+    private String preferRegion;
+
     @Builder.Default
     @OneToMany(mappedBy = "group", cascade = CascadeType.ALL)
     private List<Application> applications = new ArrayList<>();

--- a/src/main/java/com/example/bookiibookii/domain/group/exception/code/GroupErrorCode.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/exception/code/GroupErrorCode.java
@@ -23,7 +23,7 @@ public enum GroupErrorCode implements BaseCode {
     BOOK_NOT_SELECTED(HttpStatus.BAD_REQUEST, "GROUP400_4", "도서를 선택해야 합니다."),
     INVALID_START_DATE(HttpStatus.BAD_REQUEST, "GROUP400_5", "시작 날짜는 오늘 이후여야 합니다."),
     INVALID_READING_PERIOD(HttpStatus.BAD_REQUEST, "GROUP400_6", "독서 기간은 3일에서 30일 사이여야 합니다."),
-    USER_LOCATION_NOT_FOUND(HttpStatus.BAD_REQUEST, "GROUP400_7", "직접 교환을 위해 마이페이지에서 장소를 설정해주세요."),
+    USER_LOCATION_NOT_FOUND(HttpStatus.BAD_REQUEST, "GROUP400_7", "직접 교환을 위해 장소를 설정해주세요."),
     INVALID_GROUP_CAPACITY(HttpStatus.BAD_REQUEST, "GROUP400_8", "함께읽기 정원은 방장 포함 2~8명 사이여야 합니다."),
     GROUP_CANT_UPDATE(HttpStatus.BAD_REQUEST, "GROUP400_9", "그룹을 수정할 수 없습니다."),
     GROUP_CANT_DELETE(HttpStatus.BAD_REQUEST, "GROUP400_10", "그룹을 삭제할 수 없습니다."),

--- a/src/main/java/com/example/bookiibookii/domain/group/repository/GroupQueryRepository.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/repository/GroupQueryRepository.java
@@ -100,7 +100,7 @@ public class GroupQueryRepository {
                    return place;
                })
                .filter(keyword -> keyword != null && !keyword.isBlank())
-               .map(user.meetPlace::contains)
+               .map(groups.preferRegion::contains)
                .reduce(BooleanExpression::or)
                .orElse(null);
    }

--- a/src/main/java/com/example/bookiibookii/domain/group/repository/MeetingRepository.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/repository/MeetingRepository.java
@@ -1,5 +1,6 @@
 package com.example.bookiibookii.domain.group.repository;
 
+import com.example.bookiibookii.domain.group.entity.Groups;
 import com.example.bookiibookii.domain.group.entity.Meeting;
 import com.example.bookiibookii.domain.tracker.enums.TrackerStatus;
 import jakarta.persistence.LockModeType;
@@ -24,4 +25,7 @@ public interface MeetingRepository extends JpaRepository<Meeting, Long> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT m FROM Meeting m WHERE m.group.groupId = :groupId AND m.trackerStatus = :status")
     Optional<Meeting> findByGroupWithLock(@Param("groupId") Long groupId, @Param("status") TrackerStatus status);
+
+    // 그룹에 속한 미팅 중 가장 최근에 생성된 1건을 가져옵니다.
+    Optional<Meeting> findFirstByGroupOrderByCreatedAtDesc(Groups group);
 }

--- a/src/main/java/com/example/bookiibookii/domain/group/service/GroupService.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/service/GroupService.java
@@ -7,6 +7,7 @@ import com.example.bookiibookii.domain.group.dto.res.GroupResponseDTO;
 import com.example.bookiibookii.domain.group.entity.GroupTag;
 import com.example.bookiibookii.domain.group.entity.Groups;
 import com.example.bookiibookii.domain.group.entity.MatchedMember;
+import com.example.bookiibookii.domain.group.entity.Meeting;
 import com.example.bookiibookii.domain.group.enums.*;
 import com.example.bookiibookii.domain.group.event.GroupNotificationEvent;
 import com.example.bookiibookii.domain.group.exception.GroupException;
@@ -21,6 +22,7 @@ import com.example.bookiibookii.domain.notification.entity.Keyword;
 import com.example.bookiibookii.domain.notification.event.KeywordGroupCreatedEvent;
 import com.example.bookiibookii.domain.notification.publisher.DomainEventPublisher;
 import com.example.bookiibookii.domain.notification.service.KeywordMatchService;
+import com.example.bookiibookii.domain.tracker.enums.TrackerStatus;
 import com.example.bookiibookii.domain.user.entity.User;
 import com.example.bookiibookii.domain.user.exception.UserException;
 import com.example.bookiibookii.domain.user.exception.code.UserErrorCode;
@@ -65,6 +67,7 @@ public class GroupService {
     private final UserBookService userBookService;
     private final AddressRepository addressRepository;
     private final RedisUtil redisUtil;
+    private final MeetingRepository meetingRepository;
 
     private static final int PRESIGNED_GET_URL_EXPIRATION_MINUTES = 60;
 
@@ -111,6 +114,7 @@ public class GroupService {
                 .groupType(request.getGroupType())
                 .tradeType(finalTradeType)
                 .groupStatus(GroupStatus.RECRUITING) // 초기 상태는 모집 중
+                .preferRegion(request.getPreferRegion()) //선호장소 저장
                 .build();
 
         // 5. 독서 태그 저장 로직
@@ -130,17 +134,18 @@ public class GroupService {
         Groups savedGroup = groupsRepository.save(group);
 
         // 1:1 직접 교환일 때 Meeting 초기 데이터 생성
-//        if (request.getGroupType() == GroupType.RELAY && request.getTradeType() == TradeType.DIRECT) {
-//
-//            // host.getMeetPlace()를 통해 유저가 미리 입력한 주소를 초기 장소로 저장
-//            Meeting initialMeeting = Meeting.builder()
-//                    .group(savedGroup)
-//                    .meetingPlace(host.getMeetPlace()) //host가 마이페이지에서 입력한 meetPlace
-//                    .meetingTime(null) // 시간은 초기 생성 시에는 결정되지 않음
-//                    .build();
-//
-//            meetingRepository.save(initialMeeting);
-//        }
+        if (request.getGroupType() == GroupType.RELAY && request.getTradeType() == TradeType.DIRECT) {
+
+            // request.getMeetPlace()를 통해 유저가 최종 수정한 주소를 저장
+            Meeting initialMeeting = Meeting.builder()
+                    .group(savedGroup)
+                    .meetingPlace(request.getMeetPlace()) //host 프로필이 아닌 DTO 값 사용
+                    .trackerStatus(TrackerStatus.READY)
+                    .meetingTime(null)
+                    .build();
+
+            meetingRepository.save(initialMeeting);
+        }
 
         // 방장을 MatchedMember의 첫 번째 멤버로 등록
         MatchedMember hostMember = MatchedMember.builder()
@@ -196,7 +201,8 @@ public class GroupService {
     private void validateRelayPolicy(User host, GroupRequestDTO.CreateDTO request) {
         // 직접 교환 시 유저 엔티티의 지역/상세장소 정보 필수
         if (request.getTradeType() == TradeType.DIRECT) {
-            if (host.getMeetPlace() == null) {
+            // host 프로필이 비어있어도 request에 값이 있다면 통과
+            if (request.getPreferRegion() == null || request.getMeetPlace() == null) {
                 throw new GroupException(GroupErrorCode.USER_LOCATION_NOT_FOUND);
             }
         }

--- a/src/main/java/com/example/bookiibookii/domain/group/service/GroupService.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/service/GroupService.java
@@ -339,6 +339,14 @@ public class GroupService {
         Groups group = groupsRepository.findDetailById(groupId)
                 .orElseThrow(() -> new GroupException(GroupErrorCode.GROUP_NOT_FOUND));
 
+        String persistedMeetPlace = null;
+        if (group.getTradeType() == TradeType.DIRECT) {
+            // findByGroup 대신 더 명확한 이름을 사용
+            persistedMeetPlace = meetingRepository.findFirstByGroupOrderByCreatedAtDesc(group)
+                    .map(Meeting::getMeetingPlace) // 엔티티 필드명이 meetingPlace이므로 정확함!
+                    .orElse(null);
+        }
+
         // 2. 해당 그룹에 참여가 확정된 멤버 리스트를 조회 (동그란 멤버 아이콘 리스트용)
         List<MatchedMember> matchedMembers = matchedMemberRepository.findAllByGroupOrderByReadingOrderAsc(group);
 
@@ -364,6 +372,8 @@ public class GroupService {
                 .groupComment(group.getGroupComment())
                 .groupStatus(group.getGroupStatus().name())
                 .isHost(group.getHost().getId().equals(userId))
+                .preferRegion(group.getPreferRegion())
+                .meetPlace(persistedMeetPlace)
                 .bookTitle(group.getBook().getTitle())
                 .bookImage(group.getBook().getImage())
                 .author(group.getBook().getAuthor())
@@ -508,11 +518,11 @@ public class GroupService {
         if (group.getTradeType() == TradeType.DELIVERY) return "택배";
 
         // '이어읽기' 중 '직접교환'이면 지역 정보 노출 (예: 서울 마포구 -> 마포구)
-        String meetPlace = group.getHost().getMeetPlace();
-        if (meetPlace == null || meetPlace.isBlank()) return "지역미정";
+        String region = group.getPreferRegion();
+        if (region == null || region.isBlank()) return "지역미정";
 
-        String[] parts = meetPlace.split(" ");
-        return parts[parts.length - 1]; // 마지막 단어(구 단위)만 추출
+        String[] parts = region.split(" ");
+        return parts[parts.length - 1];
     }
 
     //그룹검색

--- a/src/main/java/com/example/bookiibookii/domain/tracker/service/TrackerService.java
+++ b/src/main/java/com/example/bookiibookii/domain/tracker/service/TrackerService.java
@@ -596,7 +596,7 @@ public class TrackerService {
                 ))
                 .orElseGet(() -> {
                     // 약속 테이블 자체가 비어있을 때만 호스트의 선호 장소 반환
-                    String defaultPlace = tracker.getGroup().getHost().getMeetPlace();
+                    String defaultPlace = tracker.getGroup().getPreferRegion();
                     return new TrackerMeetingResponse(null, defaultPlace);
                 });
     }

--- a/src/main/java/com/example/bookiibookii/domain/tracker/service/TrackerService.java
+++ b/src/main/java/com/example/bookiibookii/domain/tracker/service/TrackerService.java
@@ -639,10 +639,13 @@ public class TrackerService {
             meeting = Meeting.builder()
                     .group(tracker.getGroup())
                     .trackerStatus(meetingStep)
+                    .meetingPlace(request.meetingPlace()) // Autofilled 된 값 그대로 저장
+                    .meetingTime(request.meetingTime())
                     .build();
         } else {
             log.info("==> [UPDATE] 기존 약속 수정 (그룹: {}, ID: {})", groupId, meeting.getMeetingId());
             meeting.resetConfirmation();
+
         }
 
         tracker.updateStatus(meetingStep);


### PR DESCRIPTION
## 개요

closed #251 
기존에는 마이페이지(User 엔티티)의 정보를 실시간으로 참조했으나, 이 경우 유저가 이사를 가서 프로필의 region을 수정하면 과거에 생성했던 그룹의 장소 정보까지 변경되는 문제가 있었습니다.
이를 해결하기 위해 그룹 생성 시점에 입력된 지역(preferRegion)과 상세 장소(meetPlace)를 각각 Groups와 Meeting 엔티티에 직접 저장하여 데이터의 독립성을 확보했습니다.

<!---- Resolves: #(Isuue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

📣 **To Reviewers**
---
<!-- 전달사항 -->

- Reviewers : 팀 선택
- Labels : 작업 유형, 자기 자신


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 그룹 생성에 선호 지역(preferRegion)과 만남 장소(meetPlace) 입력 추가
  * 직거래 그룹에서 초기 미팅 기록 자동 생성 및 그룹 상세에 선호 지역·만남 장소 노출
  * 지역 배지 및 모임 필터가 그룹의 선호 지역을 기준으로 동작
  * 미팅 생성·수정 시 만남 장소와 시간 저장 및 노출 강화

* **Bug Fixes**
  * 직거래 장소 안내 문구 간결화 및 사용자 메시지 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->