### PR TITLE
[Add] #264 토큰 만료 시 예외처리 추가

### DIFF
--- a/src/main/java/com/example/bookiibookii/global/auth/exception/code/AuthErrorCode.java
+++ b/src/main/java/com/example/bookiibookii/global/auth/exception/code/AuthErrorCode.java
@@ -24,6 +24,9 @@ public enum AuthErrorCode implements BaseCode {
     INVALID_SOCIAL_TOKEN(HttpStatus.UNAUTHORIZED,
             "AUTH401_1",
             "소셜 인증에 실패했습니다."),
+    EXPIRED_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED,
+            "AUTH401_2",
+            "AccessToken이 만료되었습니다."),
 
     NOT_FOUND_REFRESH_TOKEN(HttpStatus.NOT_FOUND,
             "AUTH404_1",

--- a/src/main/java/com/example/bookiibookii/global/auth/jwt/JwtAuthFilter.java
+++ b/src/main/java/com/example/bookiibookii/global/auth/jwt/JwtAuthFilter.java
@@ -10,6 +10,7 @@ import com.example.bookiibookii.global.auth.exception.AuthException;
 import com.example.bookiibookii.global.auth.exception.code.AuthErrorCode;
 import com.example.bookiibookii.global.util.RedisUtil;
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -40,15 +41,15 @@ public class JwtAuthFilter extends OncePerRequestFilter {
     ) throws ServletException, IOException {
 
         String token = tokenResolver.resolve(request);
+        String path = request.getRequestURI();
 
-        if (token != null) {
+        if (token != null && !path.equals("/api/auth/refresh")) {
             try {
                 // 블랙리스트 확인
                 if (redisUtil.hasKey("BL:" + token)) {
                     // 로그아웃된 토큰이므로 예외 발생 -> catch 블록으로 이동
                     throw new AuthException(AuthErrorCode.INVALID_ACCESS_TOKEN);
                 }
-
                 Claims claims = jwtProvider.parseClaims(token);
 
                 Long userId = Long.valueOf(claims.getSubject());
@@ -78,11 +79,28 @@ public class JwtAuthFilter extends OncePerRequestFilter {
                 );
 
                 SecurityContextHolder.getContext().setAuthentication(auth);
-            } catch (JwtException | UserException | AuthException e) {
-                request.setAttribute("jwt_exception", e);
+            } catch (ExpiredJwtException e) { // 만료된 경우
+                sendErrorResponse(response, AuthErrorCode.EXPIRED_ACCESS_TOKEN);
+                return;
+            } catch (JwtException | AuthException e) { // 그 외 잘못된 토큰
+                sendErrorResponse(response, AuthErrorCode.INVALID_ACCESS_TOKEN);
+                return;
             }
         }
 
         filterChain.doFilter(request, response);
+    }
+
+    private void sendErrorResponse(HttpServletResponse response, AuthErrorCode errorCode) throws IOException {
+        response.setStatus(errorCode.getStatus().value());
+        response.setContentType("application/json;charset=UTF-8");
+
+        String json = String.format(
+                "{\"code\": \"%s\", \"message\": \"%s\"}",
+                errorCode.getCode(),
+                errorCode.getMessage()
+        );
+
+        response.getWriter().write(json);
     }
 }

--- a/src/main/java/com/example/bookiibookii/global/auth/jwt/JwtAuthFilter.java
+++ b/src/main/java/com/example/bookiibookii/global/auth/jwt/JwtAuthFilter.java
@@ -5,6 +5,7 @@ import com.example.bookiibookii.domain.user.enums.Status;
 import com.example.bookiibookii.domain.user.exception.UserException;
 import com.example.bookiibookii.domain.user.exception.code.UserErrorCode;
 import com.example.bookiibookii.domain.user.repository.UserRepository;
+import com.example.bookiibookii.global.apiPayload.code.BaseCode;
 import com.example.bookiibookii.global.auth.CustomUserDetails;
 import com.example.bookiibookii.global.auth.exception.AuthException;
 import com.example.bookiibookii.global.auth.exception.code.AuthErrorCode;
@@ -85,13 +86,16 @@ public class JwtAuthFilter extends OncePerRequestFilter {
             } catch (JwtException | AuthException e) { // 그 외 잘못된 토큰
                 sendErrorResponse(response, AuthErrorCode.INVALID_ACCESS_TOKEN);
                 return;
+            } catch (UserException e) {
+                sendErrorResponse(response, e.getCode());
+                return;
             }
         }
 
         filterChain.doFilter(request, response);
     }
 
-    private void sendErrorResponse(HttpServletResponse response, AuthErrorCode errorCode) throws IOException {
+    private void sendErrorResponse(HttpServletResponse response, BaseCode errorCode) throws IOException {
         response.setStatus(errorCode.getStatus().value());
         response.setContentType("application/json;charset=UTF-8");
 

--- a/src/main/java/com/example/bookiibookii/global/auth/service/AuthService.java
+++ b/src/main/java/com/example/bookiibookii/global/auth/service/AuthService.java
@@ -81,48 +81,45 @@ public class AuthService {
                 .build();
     }
 
-    
+
     // Access Token 재발급
-    public AuthResponseDTO.TokenResponse refresh(AuthRequestDTO.RefreshRequest requestRefreshToken,
+    public AuthResponseDTO.TokenResponse refresh(AuthRequestDTO.RefreshRequest requestDTO,
                                                  HttpServletRequest request) {
         String accessToken = jwtTokenResolver.resolve(request);
-        if (accessToken == null) {
-            throw new AuthException(AuthErrorCode.NOT_FOUND_ACCESS_TOKEN);
+        String requestRT = requestDTO.refreshToken();
+
+        if (accessToken == null || requestRT == null) {
+            throw new AuthException(AuthErrorCode.NOT_FOUND);
         }
 
-        Long userId;
-        try {
-            userId = jwtProvider.getUserIdIgnoreExpiration(accessToken);
-        } catch (Exception e) {
-            throw new AuthException(AuthErrorCode.INVALID_ACCESS_TOKEN);
-        }
-
-        // Redis에서 Refresh Token 조회
-        String savedRefreshToken = redisUtil.get("RT:" + userId, String.class);
-
-        // Redis에 토큰이 있는지 + 클라이언트가 보낸 것과 일치하는지 + 유효한지
-        if (savedRefreshToken == null ||
-                !savedRefreshToken.equals(requestRefreshToken.refreshToken()) ||
-                !jwtProvider.validateToken(requestRefreshToken.refreshToken())) {
-
+        // RT 자체 유효성 선검증 (서명, 만료여부)
+        if (!jwtProvider.validateToken(requestRT)) {
             throw new AuthException(AuthErrorCode.INVALID_REFRESH_TOKEN);
         }
 
+        // AT에서 유저 정보 추출 (만료 무시)
+        Long userId = jwtProvider.getUserIdIgnoreExpiration(accessToken);
+
+        // Redis 대조
+        String savedRT = redisUtil.get("RT:" + userId, String.class);
+        if (savedRT == null || !savedRT.equals(requestRT)) {
+            throw new AuthException(AuthErrorCode.INVALID_REFRESH_TOKEN);
+        }
+
+        // 사용자 존재 확인 및 권한 획득
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new AuthException(AuthErrorCode.NOT_FOUND));
-        String role = user.getRole().name();
 
-        // 새 토큰 발급
-        String newAccessToken = jwtProvider.createAccessToken(userId, role);
-        String newRefreshToken = jwtProvider.createRefreshToken(userId);
+        // 신규 토큰 생성 및 Redis 갱신
+        String newAT = jwtProvider.createAccessToken(userId, user.getRole().name());
+        String newRT = jwtProvider.createRefreshToken(userId);
 
-        // Redis 업데이트 (덮어쓰기)
-        int rtExpirationMinutes = (int) Math.ceil(jwtProvider.getRefreshTokenExpireTime() / 1000.0 / 60);
-        redisUtil.set("RT:" + userId, newRefreshToken, rtExpirationMinutes);
+        long expireMs = jwtProvider.getRefreshTokenExpireTime();
+        redisUtil.set("RT:" + userId, newRT, (int) (expireMs / (1000 * 60)));
 
         return AuthResponseDTO.TokenResponse.builder()
-                .accessToken(newAccessToken)
-                .refreshToken(newRefreshToken)
+                .accessToken(newAT)
+                .refreshToken(newRT)
                 .userId(userId)
                 .build();
     }

--- a/src/main/java/com/example/bookiibookii/global/auth/service/AuthService.java
+++ b/src/main/java/com/example/bookiibookii/global/auth/service/AuthService.java
@@ -89,7 +89,7 @@ public class AuthService {
         String requestRT = requestDTO.refreshToken();
 
         if (accessToken == null || requestRT == null) {
-            throw new AuthException(AuthErrorCode.NOT_FOUND);
+            throw new AuthException(AuthErrorCode.NOT_FOUND_ACCESS_TOKEN);
         }
 
         // RT 자체 유효성 선검증 (서명, 만료여부)


### PR DESCRIPTION
## 개요
<!---- 자신이 완료한 이슈를 닫아주세요 -->
- closed #264 //이슈 번호는 추적을 위해 필요합니다!
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
사용자 로그인 후 30분이 경과하여 토큰이 만료되면 앱 내 API 호출 시 500 에러가 발생하는 문제 상황을 발견했습니다. 
토큰 자동 재발급 프로세스를 구축하기 위해 500에러 대신 특정 에러 코드의 401에러 메시지를 반환하도록 AccessToken 만료 예외처리를 추가했습니다.

토큰 재발급 API(/api/auth/refresh)는 토큰 필터링 검사에서 제외하여, 만료된 AccessToken으로 새 토큰을 발급 받을 수 있도록 했습니다.

<img width="1430" height="194" alt="image" src="https://github.com/user-attachments/assets/f4f64852-0c7d-4236-9430-d2344b91dab1" />

<!---- Resolves: #264  -->

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [X] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

📣 **To Reviewers**
---
<!-- 전달사항 -->

- Reviewers : 팀 선택
- Labels : 작업 유형, 자기 자신


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 만료된 액세스 토큰에 대해 명확한 오류 응답(EXPIRED) 추가 및 즉시 응답 처리
  * 인증 오류 응답 분류 및 일관성 개선
  * 리프레시 토큰 검증 강화(사전 유효성 검사 및 저장된 토큰 비교) 및 토큰 재발급/저장 로직 보완
  * 리프레시 엔드포인트에 대한 불필요한 검증 건너뛰기 처리 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->