### PR TITLE
[Mod]#278 라이브러리 응답값-userBookId 대신 groupId로 변경

### DIFF
--- a/src/main/java/com/example/bookiibookii/domain/userbook/dto/res/LibraryBookResponseDTO.java
+++ b/src/main/java/com/example/bookiibookii/domain/userbook/dto/res/LibraryBookResponseDTO.java
@@ -9,7 +9,7 @@ import java.time.LocalDate;
 @Getter
 @Builder
 public class LibraryBookResponseDTO {
-    private Long userBookId;
+    private Long groupId;
     private Long bookId;
     private String title;
     private String author;

--- a/src/main/java/com/example/bookiibookii/domain/userbook/service/LibraryService.java
+++ b/src/main/java/com/example/bookiibookii/domain/userbook/service/LibraryService.java
@@ -63,7 +63,7 @@ public class LibraryService {
         }
 
         return LibraryBookResponseDTO.builder()
-                .userBookId(ub.getId())
+                .groupId(group.getGroupId())
                 .bookId(book.getId())
                 .title(book.getTitle())
                 .author(book.getAuthor())


### PR DESCRIPTION
## 개요
<!---- 자신이 완료한 이슈를 닫아주세요 -->
- closed #278 
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
라이브러리 응답값을 다음 유저 플로우(라이브러리 -> 그룹의 독서카드 리스트 조회)를 위해
유저북아이디 대신 그룹아이디를 반환하도록 변경했습니다.

<!---- Resolves: #(Isuue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

📣 **To Reviewers**
---
<!-- 전달사항 -->
해태 확인 부탁드려요

- Reviewers : 팀 선택
- Labels : 작업 유형, 자기 자신


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **업데이트**
  * 도서관 도서 조회 응답에서 반환되는 정보가 업데이트되었습니다. 도서 라이브러리의 식별자 정보가 변경되어 그룹 정보를 더 정확하게 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->