### PR TITLE
[Feat] #302 그룹 종료 조건 로직 구현

### DIFF
--- a/src/main/java/com/example/bookiibookii/domain/group/controller/GroupController.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/controller/GroupController.java
@@ -34,7 +34,7 @@ public class GroupController implements GroupControllerDocs {
     @PatchMapping("/{groupId}")
     public ApiResponse<GroupResponseDTO.UpdateResultDTO> updateGroup(
             @PathVariable(name = "groupId") Long groupId,
-            @AuthenticationPrincipal User host,
+            @AuthenticationPrincipal (expression = "user") User host,
             @RequestBody @Valid GroupRequestDTO.UpdateDTO request) { // @RequestBody와 @Valid 추가
 
         // 서비스에서 비관적 락(Pessimistic Lock)과 RECRUITING 상태 체크를 수행합니다.

--- a/src/main/java/com/example/bookiibookii/domain/group/entity/MatchedMember.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/entity/MatchedMember.java
@@ -42,6 +42,13 @@ public class MatchedMember extends BaseEntity {
     @Column(name = "completed_at")
     private LocalDateTime completedAt; // 독서 종료일 기록
 
+    @Column(name = "is_review_written", nullable = false)
+    private boolean isReviewWritten = false; // 리뷰 작성 여부 추가
+
+    public void markReviewAsWritten() {
+        this.isReviewWritten = true;
+    }
+
     public void updateReadingRate(int newRate) {
         int normalized = Math.min(100, Math.max(0,newRate));
         this.currentReadingRate = normalized;

--- a/src/main/java/com/example/bookiibookii/domain/group/exception/code/GroupErrorCode.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/exception/code/GroupErrorCode.java
@@ -35,6 +35,7 @@ public enum GroupErrorCode implements BaseCode {
     FORBIDDEN_WORD_INCLUDED(HttpStatus.BAD_REQUEST, "GROUP400_16", "금칙어가 포함되어 있습니다."),
     GUEST_MAX_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "GROUP400_17", "그룹은 3개까지 신청할 수 있습니다."),
     HOST_MAX_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "GROUP400_18", "그룹은 3개까지 생성 할 수 있습니다."),
+    INVALID_GROUP_STATUS(HttpStatus.BAD_REQUEST, "GROUP400_19", "그룹상태가 진행중이 아닙니다."),
 
     // 403 Forbidden
     MEMBER_NOT_HOST(HttpStatus.FORBIDDEN, "GROUP403_1", "Host만 접근 가능한 메뉴입니다."),

--- a/src/main/java/com/example/bookiibookii/domain/group/repository/GroupsRepository.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/repository/GroupsRepository.java
@@ -99,7 +99,8 @@ public interface GroupsRepository extends JpaRepository<Groups, Long> {
     long countByHostIdAndGroupStatusIn(Long hostId, List<GroupStatus> statuses);
 
     // 독서 종료일로부터 3일이 지났는데 아직 종료되지 않은(MATCHED) 그룹 조회
-    @Query("SELECT g FROM Groups g WHERE g.groupStatus = 'MATCHED' " +
-            "AND FUNCTION('DATE_ADD', g.startDate, g.readingPeriod) <= :deadline")
+    @Query(value = "SELECT * FROM `groups` g WHERE g.group_status = 'MATCHED' " +
+            "AND DATE_ADD(g.start_date, INTERVAL g.reading_period DAY) <= :deadline",
+            nativeQuery = true)
     List<Groups> findGroupsPastReviewDeadline(@Param("deadline") LocalDate deadline);
 }

--- a/src/main/java/com/example/bookiibookii/domain/group/repository/GroupsRepository.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/repository/GroupsRepository.java
@@ -97,4 +97,9 @@ public interface GroupsRepository extends JpaRepository<Groups, Long> {
 
     // 내가 방장인 그룹 중 '모집 중' 또는 '진행 중'인 개수
     long countByHostIdAndGroupStatusIn(Long hostId, List<GroupStatus> statuses);
+
+    // 독서 종료일로부터 3일이 지났는데 아직 종료되지 않은(MATCHED) 그룹 조회
+    @Query("SELECT g FROM Groups g WHERE g.groupStatus = 'MATCHED' " +
+            "AND FUNCTION('DATE_ADD', g.startDate, g.readingPeriod) <= :deadline")
+    List<Groups> findGroupsPastReviewDeadline(@Param("deadline") LocalDate deadline);
 }

--- a/src/main/java/com/example/bookiibookii/domain/group/repository/MatchedMemberRepository.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/repository/MatchedMemberRepository.java
@@ -105,4 +105,9 @@ public interface MatchedMemberRepository extends JpaRepository<MatchedMember, Lo
     // 내가 게스트로 '참여 확정'되어 진행 중인 그룹 개수
     long countByUserIdAndRoleAndGroup_GroupStatusIn(Long userId, RoleStatus role, List<GroupStatus> statuses);
 
+    // 특정 그룹에서 아직 리뷰를 안 쓴 멤버 수 카운트
+    long countByGroup_GroupIdAndIsReviewWrittenFalse(Long groupId);
+
+    // 특정 그룹에서 리뷰 안 쓴 멤버 리스트 조회
+    List<MatchedMember> findAllByGroup_GroupIdAndIsReviewWrittenFalse(Long groupId);
 }

--- a/src/main/java/com/example/bookiibookii/domain/group/scheduler/GroupScheduler.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/scheduler/GroupScheduler.java
@@ -1,8 +1,10 @@
 package com.example.bookiibookii.domain.group.scheduler;
 
 import com.example.bookiibookii.domain.group.entity.Groups;
+import com.example.bookiibookii.domain.group.entity.MatchedMember;
 import com.example.bookiibookii.domain.group.enums.ApplicationStatus;
 import com.example.bookiibookii.domain.group.enums.GroupStatus;
+import com.example.bookiibookii.domain.group.enums.GroupType;
 import com.example.bookiibookii.domain.group.event.GroupMatchedEvent;
 import com.example.bookiibookii.domain.group.event.GroupNotificationEvent;
 import com.example.bookiibookii.domain.group.repository.ApplicationRepository;
@@ -11,6 +13,8 @@ import com.example.bookiibookii.domain.group.repository.MatchedMemberRepository;
 import com.example.bookiibookii.domain.notification.publisher.DomainEventPublisher;
 
 
+import com.example.bookiibookii.domain.user.entity.User;
+import com.example.bookiibookii.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -31,6 +35,7 @@ public class GroupScheduler {
     private final ApplicationRepository applicationRepository;
     private final MatchedMemberRepository matchedMemberRepository;
     private final DomainEventPublisher eventPublisher;
+    private final UserRepository userRepository;
 
     @Scheduled(cron = "0 0 0 * * *")
     @Transactional
@@ -68,5 +73,36 @@ public class GroupScheduler {
             // 어떤 경우든 남은 대기자(Pending)는 일괄 거절 처리
             applicationRepository.updatePendingToRejectedByGroupId(group.getGroupId(), ApplicationStatus.REJECTED);
         }
+    }
+
+    @Scheduled(cron = "0 0 3 * * *")
+    @Transactional
+    public void forceCompleteGroups() {
+        log.info("[Scheduler] 리뷰 기간 만료 그룹 강제 종료 프로세스 시작");
+
+        LocalDate deadline = LocalDate.now().minusDays(3);
+        List<Groups> timeoutGroups = groupsRepository.findGroupsPastReviewDeadline(deadline);
+
+        for (Groups group : timeoutGroups) {
+            List<MatchedMember> lazyMembers = matchedMemberRepository
+                    .findAllByGroup_GroupIdAndIsReviewWrittenFalse(group.getGroupId());
+
+            for (MatchedMember mm : lazyMembers) {
+                if (group.getGroupType() == GroupType.RELAY) {
+                    matchedMemberRepository.findPartnerUserId(group.getGroupId(), mm.getUser().getId())
+                            .ifPresent(partnerId -> {
+                                User partner = userRepository.findById(partnerId).orElse(null);
+                                if (partner != null) {
+                                    partner.updateManner(3.0, 0);
+                                }
+                            });
+                }
+                mm.markReviewAsWritten();
+            }
+
+            group.updateStatus(GroupStatus.COMPLETED);
+        }
+
+        log.info("[Scheduler] 리뷰 기간 만료 그룹 강제 종료 프로세스 완료 (처리 대상: {}건)", timeoutGroups.size());
     }
 }

--- a/src/main/java/com/example/bookiibookii/domain/group/scheduler/GroupScheduler.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/scheduler/GroupScheduler.java
@@ -39,7 +39,7 @@ public class GroupScheduler {
     private final UserRepository userRepository;
     private final GroupCompletionService groupCompletionService;
 
-    @Scheduled(cron = "0 0 0 * * *")
+    @Scheduled(cron = "0 0 0 * * *", zone="Asia/Seoul")
     @Transactional
     public void autoProcessGroups() {
         LocalDate today = LocalDate.now();
@@ -77,7 +77,7 @@ public class GroupScheduler {
         }
     }
 
-    @Scheduled(cron = "0 0 3 * * *")
+    @Scheduled(cron = "0 0 3 * * *", zone="Asia/Seoul")
     public void forceCompleteGroups() {
         log.info("[Scheduler] 리뷰 기간 만료 그룹 강제 종료 프로세스 시작");
 

--- a/src/main/java/com/example/bookiibookii/domain/group/scheduler/GroupScheduler.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/scheduler/GroupScheduler.java
@@ -10,6 +10,7 @@ import com.example.bookiibookii.domain.group.event.GroupNotificationEvent;
 import com.example.bookiibookii.domain.group.repository.ApplicationRepository;
 import com.example.bookiibookii.domain.group.repository.GroupsRepository;
 import com.example.bookiibookii.domain.group.repository.MatchedMemberRepository;
+import com.example.bookiibookii.domain.group.service.GroupCompletionService;
 import com.example.bookiibookii.domain.notification.publisher.DomainEventPublisher;
 
 
@@ -36,6 +37,7 @@ public class GroupScheduler {
     private final MatchedMemberRepository matchedMemberRepository;
     private final DomainEventPublisher eventPublisher;
     private final UserRepository userRepository;
+    private final GroupCompletionService groupCompletionService;
 
     @Scheduled(cron = "0 0 0 * * *")
     @Transactional
@@ -76,7 +78,6 @@ public class GroupScheduler {
     }
 
     @Scheduled(cron = "0 0 3 * * *")
-    @Transactional
     public void forceCompleteGroups() {
         log.info("[Scheduler] 리뷰 기간 만료 그룹 강제 종료 프로세스 시작");
 
@@ -84,23 +85,14 @@ public class GroupScheduler {
         List<Groups> timeoutGroups = groupsRepository.findGroupsPastReviewDeadline(deadline);
 
         for (Groups group : timeoutGroups) {
-            List<MatchedMember> lazyMembers = matchedMemberRepository
-                    .findAllByGroup_GroupIdAndIsReviewWrittenFalse(group.getGroupId());
-
-            for (MatchedMember mm : lazyMembers) {
-                if (group.getGroupType() == GroupType.RELAY) {
-                    matchedMemberRepository.findPartnerUserId(group.getGroupId(), mm.getUser().getId())
-                            .ifPresent(partnerId -> {
-                                User partner = userRepository.findById(partnerId).orElse(null);
-                                if (partner != null) {
-                                    partner.updateManner(3.0, 0);
-                                }
-                            });
-                }
-                mm.markReviewAsWritten();
+            try {
+                // 3. 방금 만든 서비스 호출 (각 호출마다 독립적인 트랜잭션 생성)
+                groupCompletionService.forceCompleteSingleGroup(group.getGroupId());
+                log.info("[Scheduler] 그룹 강제 종료 성공");
+            } catch (Exception e) {
+                // 4. 하나가 실패해도 catch문에서 잡히므로 다음 그룹 루프는 계속 돌아감!
+                log.error("[Scheduler] 그룹 처리 중 오류 발생");
             }
-
-            group.updateStatus(GroupStatus.COMPLETED);
         }
 
         log.info("[Scheduler] 리뷰 기간 만료 그룹 강제 종료 프로세스 완료 (처리 대상: {}건)", timeoutGroups.size());

--- a/src/main/java/com/example/bookiibookii/domain/group/service/GroupCompletionService.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/service/GroupCompletionService.java
@@ -33,8 +33,13 @@ public class GroupCompletionService {
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void forceCompleteSingleGroup(Long groupId) {
-        Groups group = groupsRepository.findById(groupId)
+        Groups group = groupsRepository.findByIdForUpdate(groupId)
                 .orElseThrow(() -> new GroupException(GroupErrorCode.GROUP_NOT_FOUND));
+
+        if(group.getGroupStatus()!=GroupStatus.MATCHED){
+            log.info("MATCHED 상태가 아닌 그룹");
+            return;
+        }
 
         List<MatchedMember> lazyMembers = matchedMemberRepository
                 .findAllByGroup_GroupIdAndIsReviewWrittenFalse(groupId);

--- a/src/main/java/com/example/bookiibookii/domain/group/service/GroupCompletionService.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/service/GroupCompletionService.java
@@ -1,0 +1,74 @@
+package com.example.bookiibookii.domain.group.service;
+
+import com.example.bookiibookii.domain.group.entity.Groups;
+import com.example.bookiibookii.domain.group.entity.MatchedMember;
+import com.example.bookiibookii.domain.group.enums.GroupStatus;
+import com.example.bookiibookii.domain.group.enums.GroupType;
+import com.example.bookiibookii.domain.group.exception.GroupException;
+import com.example.bookiibookii.domain.group.exception.code.GroupErrorCode;
+import com.example.bookiibookii.domain.group.repository.GroupsRepository;
+import com.example.bookiibookii.domain.group.repository.MatchedMemberRepository;
+import com.example.bookiibookii.domain.review.entity.GroupReview;
+import com.example.bookiibookii.domain.review.repository.GroupReviewRepository;
+import com.example.bookiibookii.domain.user.entity.User;
+import com.example.bookiibookii.domain.user.repository.UserRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class GroupCompletionService {
+
+    private final GroupsRepository groupsRepository;
+    private final MatchedMemberRepository matchedMemberRepository;
+    private final GroupReviewRepository groupReviewRepository; // 리뷰 레포지토리 추가
+    private final UserRepository userRepository;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void forceCompleteSingleGroup(Long groupId) {
+        Groups group = groupsRepository.findById(groupId)
+                .orElseThrow(() -> new GroupException(GroupErrorCode.GROUP_NOT_FOUND));
+
+        List<MatchedMember> lazyMembers = matchedMemberRepository
+                .findAllByGroup_GroupIdAndIsReviewWrittenFalse(groupId);
+
+        for (MatchedMember mm : lazyMembers) {
+            if (group.getGroupType() == GroupType.RELAY) {
+                // 1. 파트너의 User ID가 아니라 MatchedMember 자체를 찾아야 합니다.
+                matchedMemberRepository.findPartnerUserId(groupId, mm.getUser().getId())
+                        .ifPresent(partnerId -> {
+                            // 파트너의 MatchedMember 엔티티 조회
+                            MatchedMember partnerMM = matchedMemberRepository.findByGroup_GroupIdAndUser_Id(groupId, partnerId)
+                                    .orElseThrow(() -> new GroupException(GroupErrorCode.MATCHED_MEMBER_NOT_FOUND));
+
+                            if (partnerMM != null) {
+                                // 2. 파트너 매너 점수 업데이트 (User 엔티티)
+                                partnerMM.getUser().updateManner(3.0, 0);
+
+                                // 3. 기본 리뷰 생성 (수정된 메서드 호출)
+                                createDefaultReview(mm, partnerMM);
+                            }
+                        });
+            }
+            mm.markReviewAsWritten();
+        }
+        group.updateStatus(GroupStatus.COMPLETED);
+    }
+
+    private void createDefaultReview(MatchedMember reviewer, MatchedMember reviewed) {
+        GroupReview defaultReview = GroupReview.builder()
+                .reviewer(reviewer)   // MatchedMember 타입
+                .reviewed(reviewed)   // MatchedMember 타입
+                .rating(3.0)          // score -> rating
+                .comment(null) // content -> comment
+                .build();
+        groupReviewRepository.save(defaultReview);
+    }
+}

--- a/src/main/java/com/example/bookiibookii/domain/review/service/ReviewService.java
+++ b/src/main/java/com/example/bookiibookii/domain/review/service/ReviewService.java
@@ -2,6 +2,7 @@ package com.example.bookiibookii.domain.review.service;
 
 import com.example.bookiibookii.domain.group.entity.Groups;
 import com.example.bookiibookii.domain.group.entity.MatchedMember;
+import com.example.bookiibookii.domain.group.enums.GroupStatus;
 import com.example.bookiibookii.domain.group.enums.GroupType;
 import com.example.bookiibookii.domain.group.exception.GroupException;
 import com.example.bookiibookii.domain.group.exception.code.GroupErrorCode;
@@ -65,6 +66,25 @@ public class ReviewService {
         }
 
         userBook.updateReview(request.rating(), request.comment());
+
+        // [추가] 1:N 그룹 자동 종료 트리거 로직
+        Groups group = userBook.getGroup();
+
+        if (group != null) {
+            // 4. 현재 유저의 MatchedMember '리뷰 작성 완료' 마킹
+            MatchedMember matchedMember = matchedMemberRepository.findByGroup_GroupIdAndUser_Id(group.getGroupId(), user.getId())
+                    .orElseThrow(() -> new ReviewException(ReviewErrorCode.MATCHED_MEMBER_NOT_FOUND));
+
+            matchedMember.markReviewAsWritten(); // isReviewWritten = true 처리
+
+            // 5. 이 그룹에 아직 리뷰를 안 쓴 사람이 남았는지 카운트
+            long remainingCount = matchedMemberRepository.countByGroup_GroupIdAndIsReviewWrittenFalse(group.getGroupId());
+
+            // 6. 만약 남은 사람이 0명(내가 마지막 작성자)이라면 그룹 전체 상태를 COMPLETED로 변경
+            if (remainingCount == 0) {
+                group.updateStatus(GroupStatus.COMPLETED);
+            }
+        }
     }
 
     /**
@@ -73,13 +93,11 @@ public class ReviewService {
      */
     @Transactional
     public void createRelayReview(Long userBookId, ReviewRequestDTO.RelayReviewDTO request, User user) {
-        // 2-1. 모든 평점 및 코멘트 검증
         validateRating(request.bookRating());
         validateRating(request.partnerRating());
         validateCommentLength(request.bookComment(), BOOK_COMMENT_MAX_LENGTH);
         validateCommentLength(request.partnerComment(), GROUP_COMMENT_MAX_LENGTH);
 
-        // 2-2. UserBook 조회 및 권한 확인
         UserBook userBook = userBookRepository.findById(userBookId)
                 .orElseThrow(() -> new ReviewException(ReviewErrorCode.USER_BOOK_NOT_FOUND));
         if (!userBook.getUser().getId().equals(user.getId())) {
@@ -92,19 +110,19 @@ public class ReviewService {
         }
         Long groupId = group.getGroupId();
 
-        // 2-3. 트래커 상태 확인 (RETURNED여야 최종 완료 가능)
         ensureTrackerReturned(groupId);
 
-        // 2-4. [책 리뷰] 업데이트
         userBook.updateReview(request.bookRating(), request.bookComment());
 
-        // 2-5. [상대방 리뷰] 생성 및 뱃지/매너점수 처리
         MatchedMember reviewer = matchedMemberRepository.findByGroup_GroupIdAndUser_Id(groupId, user.getId())
                 .orElseThrow(() -> new ReviewException(ReviewErrorCode.MATCHED_MEMBER_NOT_FOUND));
 
         if (groupReviewRepository.existsByGroupIdAndReviewerUserId(groupId, user.getId())) {
             throw new ReviewException(ReviewErrorCode.REVIEW_ALREADY_EXISTS);
         }
+
+        // [추가] 1:1 유저 상태 완료 처리
+        reviewer.markReviewAsWritten(); // isReviewWritten = true
 
         Long partnerUserId = matchedMemberRepository.findPartnerUserId(groupId, user.getId())
                 .orElseThrow(() -> new ReviewException(ReviewErrorCode.PARTNER_NOT_FOUND));
@@ -122,7 +140,12 @@ public class ReviewService {
         processGroupReview(reviewed.getUser(), groupReview, request.badgeCodes(), request.partnerRating());
         groupReviewRepository.save(groupReview);
 
+        // [추가] 1:1 파트너 작성 여부 체크
+        long remainingCount = matchedMemberRepository.countByGroup_GroupIdAndIsReviewWrittenFalse(groupId);
 
+        if (remainingCount == 0) {
+            group.updateStatus(GroupStatus.COMPLETED);
+        }
     }
 
     /**

--- a/src/main/java/com/example/bookiibookii/domain/review/service/ReviewService.java
+++ b/src/main/java/com/example/bookiibookii/domain/review/service/ReviewService.java
@@ -6,6 +6,7 @@ import com.example.bookiibookii.domain.group.enums.GroupStatus;
 import com.example.bookiibookii.domain.group.enums.GroupType;
 import com.example.bookiibookii.domain.group.exception.GroupException;
 import com.example.bookiibookii.domain.group.exception.code.GroupErrorCode;
+import com.example.bookiibookii.domain.group.repository.GroupsRepository;
 import com.example.bookiibookii.domain.group.repository.MatchedMemberRepository;
 import com.example.bookiibookii.domain.review.dto.req.ReviewRequestDTO;
 import com.example.bookiibookii.domain.review.dto.res.GroupReviewResponseDTO;
@@ -48,6 +49,7 @@ public class ReviewService {
     private final MatchedMemberRepository matchedMemberRepository;
     private final GroupReviewRepository groupReviewRepository;
     private final UserBadgeRepository userBadgeRepository;
+    private final GroupsRepository groupsRepository;
 
     /**
      * 1. [함께 읽기] 리뷰 생성
@@ -67,20 +69,19 @@ public class ReviewService {
 
         userBook.updateReview(request.rating(), request.comment());
 
-        // [추가] 1:N 그룹 자동 종료 트리거 로직
-        Groups group = userBook.getGroup();
+        //그룹 조회 락 추가
+        Groups group = groupsRepository.findByIdForUpdate(userBook.getGroup().getGroupId())
+                .orElseThrow(() -> new GroupException(GroupErrorCode.GROUP_NOT_FOUND));
 
-        if (group != null) {
-            // 4. 현재 유저의 MatchedMember '리뷰 작성 완료' 마킹
+        // 그룹이 MATCHED 상태일 때만 종료 로직 수행
+        if (group.getGroupStatus() == GroupStatus.MATCHED) {
             MatchedMember matchedMember = matchedMemberRepository.findByGroup_GroupIdAndUser_Id(group.getGroupId(), user.getId())
                     .orElseThrow(() -> new ReviewException(ReviewErrorCode.MATCHED_MEMBER_NOT_FOUND));
 
-            matchedMember.markReviewAsWritten(); // isReviewWritten = true 처리
+            matchedMember.markReviewAsWritten();
 
-            // 5. 이 그룹에 아직 리뷰를 안 쓴 사람이 남았는지 카운트
             long remainingCount = matchedMemberRepository.countByGroup_GroupIdAndIsReviewWrittenFalse(group.getGroupId());
 
-            // 6. 만약 남은 사람이 0명(내가 마지막 작성자)이라면 그룹 전체 상태를 COMPLETED로 변경
             if (remainingCount == 0) {
                 group.updateStatus(GroupStatus.COMPLETED);
             }
@@ -93,27 +94,36 @@ public class ReviewService {
      */
     @Transactional
     public void createRelayReview(Long userBookId, ReviewRequestDTO.RelayReviewDTO request, User user) {
+        // 2-1. 모든 평점 및 코멘트 검증
         validateRating(request.bookRating());
         validateRating(request.partnerRating());
         validateCommentLength(request.bookComment(), BOOK_COMMENT_MAX_LENGTH);
         validateCommentLength(request.partnerComment(), GROUP_COMMENT_MAX_LENGTH);
 
+        // 2-2. UserBook 조회 및 권한 확인
         UserBook userBook = userBookRepository.findById(userBookId)
                 .orElseThrow(() -> new ReviewException(ReviewErrorCode.USER_BOOK_NOT_FOUND));
         if (!userBook.getUser().getId().equals(user.getId())) {
             throw new ReviewException(ReviewErrorCode.NOT_USER_BOOK_OWNER);
         }
 
-        Groups group = userBook.getGroup();
-        if (group == null) {
-            throw new GroupException(GroupErrorCode.GROUP_NOT_FOUND);
-        }
-        Long groupId = group.getGroupId();
+        // [보완] 비관적 락을 사용하여 그룹 조회 (동시성 제어)
+        Groups group = groupsRepository.findByIdForUpdate(userBook.getGroup().getGroupId())
+                .orElseThrow(() -> new GroupException(GroupErrorCode.GROUP_NOT_FOUND));
 
+        // [보완] 그룹 상태가 MATCHED일 때만 리뷰 프로세스 진행
+        if (group.getGroupStatus() != GroupStatus.MATCHED) {
+            // 이미 COMPLETED거나 DELETED인 경우 예외를 던지거나 리턴 처리
+            throw new GroupException(GroupErrorCode.INVALID_GROUP_STATUS);
+        }
+
+        Long groupId = group.getGroupId();
         ensureTrackerReturned(groupId);
 
+        // 2-3. [책 리뷰] 업데이트
         userBook.updateReview(request.bookRating(), request.bookComment());
 
+        // 2-4. 리뷰어 조회 및 중복 체크
         MatchedMember reviewer = matchedMemberRepository.findByGroup_GroupIdAndUser_Id(groupId, user.getId())
                 .orElseThrow(() -> new ReviewException(ReviewErrorCode.MATCHED_MEMBER_NOT_FOUND));
 
@@ -121,9 +131,10 @@ public class ReviewService {
             throw new ReviewException(ReviewErrorCode.REVIEW_ALREADY_EXISTS);
         }
 
-        // [추가] 1:1 유저 상태 완료 처리
+        // 2-5. 내 상태 업데이트
         reviewer.markReviewAsWritten(); // isReviewWritten = true
 
+        // 2-6. 상대방 조회 및 리뷰 저장
         Long partnerUserId = matchedMemberRepository.findPartnerUserId(groupId, user.getId())
                 .orElseThrow(() -> new ReviewException(ReviewErrorCode.PARTNER_NOT_FOUND));
 
@@ -140,7 +151,7 @@ public class ReviewService {
         processGroupReview(reviewed.getUser(), groupReview, request.badgeCodes(), request.partnerRating());
         groupReviewRepository.save(groupReview);
 
-        // [추가] 1:1 파트너 작성 여부 체크
+        // [핵심] 락이 걸린 상태에서 전원 완료 여부 체크
         long remainingCount = matchedMemberRepository.countByGroup_GroupIdAndIsReviewWrittenFalse(groupId);
 
         if (remainingCount == 0) {


### PR DESCRIPTION
## 개요
closed #302 
현재 서비스 정책상 그룹의 최종 종료(COMPLETED) 조건이 '참여 유저의 리뷰 작성'에 의존하고 있습니다. 이로 인해 일부 인원이 리뷰를 남기지 않을 경우 그룹이 무기한 '진행 중' 상태에 머무는 문제가 발생합니다. 이를 해결하기 위해 전원 작성 시 즉시 종료(수동)와 3일 경과 시 강제 종료(자동) 로직을 도입합니다.

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

📣 **To Reviewers**
---
<!-- 전달사항 -->

- Reviewers : 팀 선택
- Labels : 작업 유형, 자기 자신


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 리뷰 마감일 경과 그룹을 정해진 시각에 자동으로 강제 완료 처리하는 스케줄 추가
  * 모든 멤버의 리뷰 작성 여부를 집계해, 전원이 작성되면 그룹 상태를 자동으로 완료하도록 변경
  * 멤버별 리뷰 작성 상태를 저장·표시하는 필드 추가 및 미작성자 집계 기능 도입
  * 미작성 리뷰에 대해 기본 평점으로 대체 리뷰를 생성해 완료 처리하는 보완 로직 추가
* **버그 수정**
  * 인증된 사용자 바인딩 방식이 개선되어 권한 관련 동작 신뢰성 향상
<!-- end of auto-generated comment: release notes by coderabbit.ai -->