### PR TITLE
[Mod] #304 meeting 레코드 생성 분기

### DIFF
--- a/src/main/java/com/example/bookiibookii/domain/group/entity/Groups.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/entity/Groups.java
@@ -87,6 +87,7 @@ public class Groups extends BaseEntity {
     @OneToMany(mappedBy = "group", cascade = CascadeType.ALL)
     private List<UserBook> userBooks = new ArrayList<>();
 
+    @Builder.Default
     @OneToMany(mappedBy = "group", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Meeting> meetings = new ArrayList<>();
 

--- a/src/main/java/com/example/bookiibookii/domain/group/entity/Groups.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/entity/Groups.java
@@ -87,6 +87,9 @@ public class Groups extends BaseEntity {
     @OneToMany(mappedBy = "group", cascade = CascadeType.ALL)
     private List<UserBook> userBooks = new ArrayList<>();
 
+    @OneToMany(mappedBy = "group", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Meeting> meetings = new ArrayList<>();
+
     public void updateStatus(GroupStatus status) {
         this.groupStatus = status;
     }

--- a/src/main/java/com/example/bookiibookii/domain/group/service/GroupService.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/service/GroupService.java
@@ -149,15 +149,24 @@ public class GroupService {
         // 1:1 직접 교환일 때 Meeting 초기 데이터 생성
         if (request.getGroupType() == GroupType.RELAY && request.getTradeType() == TradeType.DIRECT) {
 
-            // request.getMeetPlace()를 통해 유저가 최종 수정한 주소를 저장
-            Meeting initialMeeting = Meeting.builder()
-                    .group(savedGroup)
-                    .meetingPlace(request.getMeetPlace()) //host 프로필이 아닌 DTO 값 사용
-                    .trackerStatus(TrackerStatus.READY)
+            // 1. 전달용 약속 (호스트 -> 게스트)
+            Meeting shippingMeeting = Meeting.builder()
+                    .group(group)
+                    .trackerStatus(TrackerStatus.SHIPPING_TO_GUEST)
+                    .meetingPlace(group.getHost().getMeetPlace())
                     .meetingTime(null)
                     .build();
 
-            meetingRepository.save(initialMeeting);
+            // 2. 반납용 약속 (마지막 게스트 -> 호스트)
+            Meeting returnMeeting = Meeting.builder()
+                    .group(group)
+                    .trackerStatus(TrackerStatus.SHIPPING_TO_HOST)
+                    .meetingPlace(group.getHost().getMeetPlace())
+                    .meetingTime(null)
+                    .build();
+
+            meetingRepository.saveAll(List.of(shippingMeeting, returnMeeting));
+
         }
 
         // 방장을 MatchedMember의 첫 번째 멤버로 등록


### PR DESCRIPTION
## 개요
<!---- 자신이 완료한 이슈를 닫아주세요 -->
- closed #이슈 //이슈 번호는 추적을 위해 필요합니다!
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

closed #308 

meeting 레코드 생성 분기 ( 직접교환 시 약속이 두번 발생하기 때문에 두개의 미팅을 생성해야됨)

<!---- Resolves: #(Isuue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [X] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [X] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

📣 **To Reviewers**
---
<!-- 전달사항 -->

- Reviewers : 팀 선택
- Labels : 작업 유형, 자기 자신


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 1:1 직접 릴레이 그룹의 모임 생성 흐름을 개선했습니다. 초기 단일 모임 대신 게스트로의 배송과 호스트로의 반환을 위한 두 개의 모임이 자동으로 생성되어 추적 상태가 정확히 반영됩니다.

* **새 기능**
  * 그룹에 연결된 모임들을 관리하도록 엔티티 관계가 확장되어 관련 모임의 생성·삭제가 더 일관되게 처리됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->