### PR TITLE
[Mod] #334 그룹 상태 전이 로직 수정

### DIFF
--- a/src/main/java/com/example/bookiibookii/domain/group/entity/Groups.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/entity/Groups.java
@@ -112,13 +112,11 @@ public class Groups extends BaseEntity {
     }
 
     //그룹상태 계산
-    public void syncStatus(long totalMemberCount) {
+    public void syncStatus(long totalMemberCount, LocalDate today) {
         // 1. 이미 종료된 그룹은 건드리지 않음
         if (this.groupStatus == GroupStatus.COMPLETED || this.groupStatus == GroupStatus.DELETED) {
             return;
         }
-
-        LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
 
         // 2. 시작일 도달 여부 체크 (최우선순위)
         if (!today.isBefore(this.startDate)) {

--- a/src/main/java/com/example/bookiibookii/domain/group/entity/Groups.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/entity/Groups.java
@@ -15,6 +15,7 @@ import lombok.*;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -95,7 +96,9 @@ public class Groups extends BaseEntity {
         this.groupStatus = status;
     }
 
-    public void markAsDELETED(){ this.groupStatus = GroupStatus.DELETED; }
+    public void markAsDELETED() {
+        this.groupStatus = GroupStatus.DELETED;
+    }
 
     // 태그 추가
     public void addGroupTag(Tag tag) {
@@ -106,5 +109,26 @@ public class Groups extends BaseEntity {
     // 태그 전체 삭제
     public void clearGroupTags() {
         this.groupTags.clear();
+    }
+
+    //그룹상태 계산
+    public void syncStatus(long totalMemberCount) {
+        // 1. 이미 종료된 그룹은 건드리지 않음
+        if (this.groupStatus == GroupStatus.COMPLETED || this.groupStatus == GroupStatus.DELETED) {
+            return;
+        }
+
+        LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
+
+        // 2. 시작일 도달 여부 체크 (최우선순위)
+        if (!today.isBefore(this.startDate)) {
+            // 오늘이 시작일이거나 지났다면: 2명 이상(호스트 포함)이면 MATCHED, 아니면 DELETED
+            this.groupStatus = (totalMemberCount >= 2) ? GroupStatus.MATCHED : GroupStatus.DELETED;
+        }
+        // 3. 아직 시작일 전인 경우 (모집 기간)
+        else {
+            // 정원이 찼으면 MATCHED, 아니면 RECRUITING (취소 시 복구까지 고려)
+            this.groupStatus = (totalMemberCount >= this.maxCapacity) ? GroupStatus.MATCHED : GroupStatus.RECRUITING;
+        }
     }
 }

--- a/src/main/java/com/example/bookiibookii/domain/group/scheduler/GroupScheduler.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/scheduler/GroupScheduler.java
@@ -46,39 +46,54 @@ public class GroupScheduler {
     public void autoProcessGroups() {
         log.info("[Scheduler] firedAtKST={}", ZonedDateTime.now(ZoneId.of("Asia/Seoul")));
         LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
+
         List<Groups> targetGroups = groupsRepository.findGroupsToStart(today);
 
         for (Groups group : targetGroups) {
             long memberCount = matchedMemberRepository.countByGroup(group);
+            GroupStatus oldStatus = group.getGroupStatus();
 
-            if (memberCount >= 2) {
-                group.updateStatus(GroupStatus.MATCHED);
-                //매칭 이벤트 발행
+            // 통합 로직 호출: 오늘 날짜와 인원수로 상태 판단
+            group.syncStatus(memberCount);
+
+            // 1. 매칭 성공(MATCHED)으로 변한 경우
+            if (group.getGroupStatus() == GroupStatus.MATCHED && oldStatus != GroupStatus.MATCHED) {
+                // 매칭 이벤트 발행 (트래커 생성 등 후속 조치용)
                 eventPublisher.publish(new GroupMatchedEvent(
                         group.getGroupId(),
                         group.getHost().getId(),
                         group.getStartDate(),
                         group.getMaxCapacity()
                 ));
-                // 매칭 성공 알람
-//                eventPublisher.publish(new GroupNotificationEvent(
-//                        MATCH_SUCCEEDED, group.getHost().getId(), group.getBook().getTitle(),
-//                        newMember.getUser().getId(), null, group.getGroupId()
-//                ));
-                // 대기자들 거절 알람
-
-            } else {
-                group.markAsDELETED();
-                eventPublisher.publish(new GroupNotificationEvent(MATCH_EXPIRED, null, group.getBook().getTitle(), group.getHost().getId(), null, group.getGroupId()));
-                // 신청자 관리: 알림 발송을 위해 대기자 명단 먼저 추출
-                List<Long> rcvIds = applicationRepository.findPendingUserIdsByGroupId(group.getGroupId());
-                eventPublisher.publish(new GroupNotificationEvent(MATCH_AUTO_REJECTED, group.getHost().getId(), group.getBook().getTitle(), null, rcvIds, group.getGroupId()));
             }
 
-            // 어떤 경우든 남은 대기자(Pending)는 일괄 거절 처리
-            applicationRepository.updatePendingToRejectedByGroupId(group.getGroupId(), ApplicationStatus.REJECTED);
+            // 2. 그룹삭제(DELETED)로 변한 경우
+            else if (group.getGroupStatus() == GroupStatus.DELETED && oldStatus != GroupStatus.DELETED) {
+                // 호스트에게 매칭 실패(기간 만료) 알림 발송
+                eventPublisher.publish(new GroupNotificationEvent(
+                        MATCH_EXPIRED, null, group.getBook().getTitle(),
+                        group.getHost().getId(), null, group.getGroupId()
+                ));
+            }
+
+            // 3. 상태가 RECRUITING이 아니게 되었다면 (매칭됐든 폭파됐든), 대기자들 일괄 거절 처리
+            if (group.getGroupStatus() != GroupStatus.RECRUITING) {
+                List<Long> pendingUserIds = applicationRepository.findPendingUserIdsByGroupId(group.getGroupId());
+
+                if (!pendingUserIds.isEmpty()) {
+                    // 대기자들에게 자동 거절 알림 발송
+                    eventPublisher.publish(new GroupNotificationEvent(
+                            MATCH_AUTO_REJECTED, group.getHost().getId(), group.getBook().getTitle(),
+                            null, pendingUserIds, group.getGroupId()
+                    ));
+
+                    // DB 상태 일괄 업데이트
+                    applicationRepository.updatePendingToRejectedByGroupId(group.getGroupId(), ApplicationStatus.REJECTED);
+                }
+            }
         }
     }
+
 
     @Scheduled(cron = "0 0 3 * * *", zone="Asia/Seoul")
     public void forceCompleteGroups() {

--- a/src/main/java/com/example/bookiibookii/domain/group/scheduler/GroupScheduler.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/scheduler/GroupScheduler.java
@@ -54,7 +54,7 @@ public class GroupScheduler {
             GroupStatus oldStatus = group.getGroupStatus();
 
             // 통합 로직 호출: 오늘 날짜와 인원수로 상태 판단
-            group.syncStatus(memberCount);
+            group.syncStatus(memberCount, today);
 
             // 1. 매칭 성공(MATCHED)으로 변한 경우
             if (group.getGroupStatus() == GroupStatus.MATCHED && oldStatus != GroupStatus.MATCHED) {

--- a/src/main/java/com/example/bookiibookii/domain/group/service/ApplicationService.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/service/ApplicationService.java
@@ -84,38 +84,39 @@ public class ApplicationService {
     public ApplicationResponseDTO.UpdateResultDTO updateApplicationStatus(Long applyId, Long userId, ApplicationStatus status)
     {
 
-        // 1. 신청 내역 존재 여부 확인
+        // 1. 신청 내역 및 그룹 조회 (비관적 락 적용으로 Race Condition 방지)
         Application application = applicationRepository.findById(applyId)
                 .orElseThrow(() -> new GroupException(GroupErrorCode.APPLICATION_NOT_FOUND));
 
-        // 그룹 조회를 할 때 락을 걸어 Race Condition 해결 (이 시점에 다른 쓰레드는 대기 상태가 됨)
         Groups group = groupsRepository.findByIdForUpdate(application.getGroup().getGroupId())
                 .orElseThrow(() -> new GroupException(GroupErrorCode.GROUP_NOT_FOUND));
 
-        // 2. 권한 체크: 이 신청이 들어온 그룹의 방장이 요청자(userId)와 일치하는지 확인
-        if (!application.getGroup().getHost().getId().equals(userId)) {
+        // 2. 권한 및 상태 체크
+        if (!group.getHost().getId().equals(userId)) {
             throw new GroupException(GroupErrorCode.MEMBER_NOT_HOST);
         }
 
-        //3. 이미 처리된 신청인지 확인
-        // 상태가 PENDING(대기 중)이 아닐 때 수락/거절을 시도하면 예외 발생
         if (application.getApplicationStatus() != ApplicationStatus.PENDING) {
             throw new GroupException(GroupErrorCode.ALREADY_PROCESSED_APPLICATION);
         }
 
-        // 알림 이벤트를 위한 book fetch join group 조회 추가
+        // 알림용 그룹 정보 조회 (Fetch Join)
         Groups thisGroup = groupsRepository.findByIdWithBookAndHost(group.getGroupId())
                 .orElseThrow(() -> new GroupException(GroupErrorCode.GROUP_NOT_FOUND));
 
-        // 4. 수락(ACCEPTED) 시도 시 정원 초과 여부 사전 체크
+        // 3. 수락(ACCEPTED) 로직
         if (status == ApplicationStatus.ACCEPTED) {
-
+            // 현재 인원 체크 (호스트 포함 MatchedMember 수)
             long currentTotalCount = matchedMemberRepository.countByGroup(group);
 
             if (currentTotalCount >= group.getMaxCapacity()) {
                 throw new GroupException(GroupErrorCode.GROUP_FULL);
             }
 
+            // 신청서 수락 상태로 업데이트
+            application.updateStatus(ApplicationStatus.ACCEPTED);
+
+            // 확정 멤버(MatchedMember) 추가 (readingOrder는 현재 인원 + 1)
             MatchedMember newMember = MatchedMember.builder()
                     .group(group)
                     .user(application.getGuest())
@@ -125,33 +126,32 @@ public class ApplicationService {
                     .build();
             matchedMemberRepository.save(newMember);
 
-            // 서재(UserBook)에 추가
+            // 서재(UserBook) 추가
             userBookService.createForParticipation(application.getGuest(), group);
 
-            // 신청서 상태 업데이트
-            application.updateStatus(ApplicationStatus.ACCEPTED);
-
+            // 개별 수락 알림 발송
             publisher.publish(new GroupNotificationEvent(
                     MATCH_SUCCEEDED, userId, thisGroup.getBook().getTitle(),
                     newMember.getUser().getId(), null, group.getGroupId()
             ));
 
-                if (currentTotalCount + 1 >= group.getMaxCapacity()) {
-                    group.updateStatus(GroupStatus.MATCHED);
+            // 그룹 상태 동기화 및 전이 판단
+            GroupStatus oldStatus = group.getGroupStatus();
+            long newTotalCount = currentTotalCount + 1; // 방금 추가된 멤버 포함
 
+            group.syncStatus(newTotalCount); // 엔티티의 통합 로직 호출
+
+            // 상태가 MATCHED로 변경되었을 경우에만 후속 작업 실행
+            if (oldStatus != GroupStatus.MATCHED && group.getGroupStatus() == GroupStatus.MATCHED) {
+                // 매칭 성공 이벤트 발행
                 eventPublisher.publishEvent(new GroupMatchedEvent(
-                        group.getGroupId(),
-                        group.getHost().getId(),
-                        group.getStartDate(),
-                        group.getMaxCapacity()
+                        group.getGroupId(), group.getHost().getId(), group.getStartDate(), group.getMaxCapacity()
                 ));
 
-                List<Application> pendingApplications =
-                        applicationRepository.findAllPendingByGroupId(group.getGroupId());
-
+                // 나머지 대기자들 자동 거절 처리
+                List<Application> pendingApplications = applicationRepository.findAllPendingByGroupId(group.getGroupId());
                 List<Long> autoRejectedReceiverIds = pendingApplications.stream()
                         .map(app -> app.getGuest().getId())
-                        .filter(id -> !id.equals(userId))   // host 제외
                         .distinct()
                         .toList();
 
@@ -159,15 +159,19 @@ public class ApplicationService {
                     pendingApp.updateStatus(ApplicationStatus.REJECTED);
                 }
 
-                publisher.publish(new GroupNotificationEvent(
-                        MATCH_AUTO_REJECTED, userId, thisGroup.getBook().getTitle(),
-                        null, autoRejectedReceiverIds, group.getGroupId()
-                ));
+                // 자동 거절 알림 발송
+                if (!autoRejectedReceiverIds.isEmpty()) {
+                    publisher.publish(new GroupNotificationEvent(
+                            MATCH_AUTO_REJECTED, userId, thisGroup.getBook().getTitle(),
+                            null, autoRejectedReceiverIds, group.getGroupId()
+                    ));
+                }
             }
 
-        } else {
+        }
+        // 4. 거절(REJECTED) 로직
+        else {
             application.updateStatus(ApplicationStatus.REJECTED);
-
             publisher.publish(new GroupNotificationEvent(
                     MATCH_REJECTED, userId, thisGroup.getBook().getTitle(),
                     application.getGuest().getId(), null, group.getGroupId()
@@ -282,9 +286,9 @@ public class ApplicationService {
 
         // 6. 인원 재계산 및 필요 시 모집 중(RECRUITING)으로 상태 복구
         long currentCount = matchedMemberRepository.countByGroup(group);
-        if (currentCount < group.getMaxCapacity()) {
-            group.updateStatus(GroupStatus.RECRUITING);
-        }
+
+        //통합 로직 호출 후 재계산
+        group.syncStatus(currentCount);
 
         return ApplicationResponseDTO.CancelResultDTO.builder()
                 .groupId(groupId)
@@ -323,6 +327,4 @@ public class ApplicationService {
                 .applyMsg(application.getApplyMsg())
                 .build();
     }
-
-
 }

--- a/src/main/java/com/example/bookiibookii/domain/group/service/ApplicationService.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/service/ApplicationService.java
@@ -30,7 +30,9 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -47,7 +49,6 @@ public class ApplicationService {
     private final GroupsRepository groupsRepository;
     private final UserRepository userRepository;
     private final MatchedMemberRepository matchedMemberRepository;
-    private final ApplicationEventPublisher eventPublisher;
     private final DomainEventPublisher publisher;
     private final UserBookService userBookService;
     private final UserImageS3Service userImageS3Service;
@@ -139,12 +140,13 @@ public class ApplicationService {
             GroupStatus oldStatus = group.getGroupStatus();
             long newTotalCount = currentTotalCount + 1; // 방금 추가된 멤버 포함
 
-            group.syncStatus(newTotalCount); // 엔티티의 통합 로직 호출
+            LocalDate seoulToday = LocalDate.now(ZoneId.of("Asia/Seoul"));
+            group.syncStatus(newTotalCount, seoulToday); // 엔티티의 통합 로직 호출
 
             // 상태가 MATCHED로 변경되었을 경우에만 후속 작업 실행
             if (oldStatus != GroupStatus.MATCHED && group.getGroupStatus() == GroupStatus.MATCHED) {
                 // 매칭 성공 이벤트 발행
-                eventPublisher.publishEvent(new GroupMatchedEvent(
+                publisher.publish(new GroupMatchedEvent(
                         group.getGroupId(), group.getHost().getId(), group.getStartDate(), group.getMaxCapacity()
                 ));
 
@@ -288,7 +290,9 @@ public class ApplicationService {
         long currentCount = matchedMemberRepository.countByGroup(group);
 
         //통합 로직 호출 후 재계산
-        group.syncStatus(currentCount);
+
+        LocalDate seoulToday = LocalDate.now(ZoneId.of("Asia/Seoul"));
+        group.syncStatus(currentCount, seoulToday);
 
         return ApplicationResponseDTO.CancelResultDTO.builder()
                 .groupId(groupId)


### PR DESCRIPTION
## 개요
각각의 서비스에서 변경하던 그룹상태를 groupentity의 메서드 하나에서 통제하도록 변경했습니다. 
<!---- Resolves: #(Isuue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

📣 **To Reviewers**
---
<!-- 전달사항 -->

- Reviewers : 팀 선택
- Labels : 작업 유형, 자기 자신


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 그룹 상태가 모집정원·현재 인원·시작일 기준으로 자동 동기화되어 더 정확하게 표시됩니다.
  - 매칭 성사·만료 시 호스트 및 참여자에게 적절한 알림이 발송됩니다.
  - 매칭 완료 시 대기 중인 신청이 자동으로 거절되고 대상자에게 알림이 전송됩니다.
- 버그 수정
  - 동시 신청/수락 상황에서 상태 불일치 및 중복 알림 발생을 줄였습니다.
- 리팩터링
  - 스케줄러와 신청 처리 흐름을 단일 규칙으로 통합해 상태 변경 일관성을 강화했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->