### PR TITLE
[Mod] #337 트래커 상세 조회 수령완료 시에도 배송 정보 표시하도록 수정

### DIFF
--- a/src/main/java/com/example/bookiibookii/domain/tracker/service/TrackerService.java
+++ b/src/main/java/com/example/bookiibookii/domain/tracker/service/TrackerService.java
@@ -232,7 +232,9 @@ public class TrackerService {
 
                 List<TrackerStatus> shippingStatuses = List.of(
                         TrackerStatus.SHIPPING_TO_GUEST,
-                        TrackerStatus.SHIPPING_TO_HOST
+                        TrackerStatus.SHIPPING_TO_HOST,
+                        TrackerStatus.RECEIVED,
+                        TrackerStatus.RETURNED
                 );
 
                 latestHistory = trackerHistoryRepository.findLatestShippingHistory(tracker, shippingStatuses)

--- a/src/main/java/com/example/bookiibookii/domain/tracker/service/TrackerService.java
+++ b/src/main/java/com/example/bookiibookii/domain/tracker/service/TrackerService.java
@@ -486,6 +486,18 @@ public class TrackerService {
             throw new TrackerException(TrackerErrorCode.NOT_TRACKER_OWNER);
         }
 
+        List<TrackerStatus> shippingStatuses = List.of(
+                TrackerStatus.SHIPPING_TO_GUEST,
+                TrackerStatus.SHIPPING_TO_HOST
+        );
+
+        TrackerHistory lastShippingHistory = trackerHistoryRepository.findLatestShippingHistory(tracker, shippingStatuses)
+                .orElse(null);
+
+        String deliveryCompany = (lastShippingHistory != null) ? lastShippingHistory.getDeliveryCompany() : null;
+        String trackingNumber = (lastShippingHistory != null) ? lastShippingHistory.getTrackingNumber() : null;
+
+
         // S3 수령 인증 이미지 검증
         String s3Key = request.s3Key();
         validateTrackerImageS3Key(s3Key);
@@ -497,7 +509,7 @@ public class TrackerService {
         TrackerHistory receiveHistory = tracker.createHistorySnapshot(
                 null,
                 bookOwner.getId(),
-                null, null
+                deliveryCompany, trackingNumber
         );
         trackerHistoryRepository.save(receiveHistory);
 


### PR DESCRIPTION
## 개요
<!---- 자신이 완료한 이슈를 닫아주세요 -->
- closed #이슈 //이슈 번호는 추적을 위해 필요합니다!
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

closed #337 

기존에는 트래커 상세 조회 시, SHIPPING_TO_GUEST 또는 SHPPING_TO_HOST 인 경우에만 택배사명, 운송장 번호를 DTO에 포함하여 전달하였습니다.

RECEIVED 또는 RETURNED 상태일 떄도, TrackerHistory에 택배사명, 운송장번호를 기록하도록 변경하였고, 트래커 상세 조회 시에도 DTO에 null이 아닌 값을 반환합니다.

<!---- Resolves: #(Isuue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [X] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [X] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

📣 **To Reviewers**
---
<!-- 전달사항 -->

- Reviewers : 팀 선택
- Labels : 작업 유형, 자기 자신
