### PR TITLE
[Feat]#348 비밀 댓글 작성, 필터링

### DIFF
--- a/src/main/java/com/example/bookiibookii/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/example/bookiibookii/domain/comment/controller/CommentController.java
@@ -33,9 +33,10 @@ public class CommentController implements CommentControllerDocs{
 
     @GetMapping("/groups/{groupId}/comments")
     public ApiResponse<List<CommentTreeResDTO>> getGroupComments(
-            @PathVariable Long groupId
+            @PathVariable Long groupId,
+            @AuthenticationPrincipal(expression = "user") User user
     ) {
-        List<CommentTreeResDTO> result = commentService.getTree(groupId);
+        List<CommentTreeResDTO> result = commentService.getTree(groupId, user.getId());
         return ApiResponse.onSuccess(CommentSuccessCode.COMMENT_FOUND_OK, result);
     }
 

--- a/src/main/java/com/example/bookiibookii/domain/comment/controller/CommentControllerDocs.java
+++ b/src/main/java/com/example/bookiibookii/domain/comment/controller/CommentControllerDocs.java
@@ -50,8 +50,8 @@ public interface CommentControllerDocs {
             summary = "그룹 댓글 삭제 api"
     )
     @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "댓글 조회 성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "댓글 조회 실패")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "댓글 삭제 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "댓글 삭제 실패")
     })
     @DeleteMapping("/groups/{groupId}/comments/{commentId}")
     public ApiResponse<Void> deleteComment(

--- a/src/main/java/com/example/bookiibookii/domain/comment/controller/CommentControllerDocs.java
+++ b/src/main/java/com/example/bookiibookii/domain/comment/controller/CommentControllerDocs.java
@@ -10,10 +10,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -45,6 +42,21 @@ public interface CommentControllerDocs {
     })
     @GetMapping("/groups/{groupId}/comments")
     public ApiResponse<List<CommentTreeResDTO>> getGroupComments(
-            @PathVariable Long groupId
+            @PathVariable Long groupId,
+            @AuthenticationPrincipal(expression = "user") User user
+    );
+
+    @Operation(
+            summary = "그룹 댓글 삭제 api"
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "댓글 조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "댓글 조회 실패")
+    })
+    @DeleteMapping("/groups/{groupId}/comments/{commentId}")
+    public ApiResponse<Void> deleteComment(
+            @PathVariable Long groupId,
+            @PathVariable Long commentId,
+            @AuthenticationPrincipal(expression = "user") User user
     );
 }

--- a/src/main/java/com/example/bookiibookii/domain/comment/dto/req/CommentCreateReqDTO.java
+++ b/src/main/java/com/example/bookiibookii/domain/comment/dto/req/CommentCreateReqDTO.java
@@ -1,5 +1,6 @@
 package com.example.bookiibookii.domain.comment.dto.req;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
@@ -14,5 +15,9 @@ public class CommentCreateReqDTO {
     private String content;
 
     @Positive(message = "parentId는 1 이상의 값이어야 합니다.")
+    @Schema(description = "부모 댓글 ID (대댓글일 때만)", example = "null", nullable = true, defaultValue = "null")
     private Long parentId;
+
+    @Schema(description = "비밀 대댓글 여부 (대댓글일 때만 true 가능)", defaultValue = "false", example = "false")
+    private boolean secret;
 }

--- a/src/main/java/com/example/bookiibookii/domain/comment/entity/Comment.java
+++ b/src/main/java/com/example/bookiibookii/domain/comment/entity/Comment.java
@@ -28,6 +28,12 @@ public class Comment extends BaseEntity {
     @Column(name = "deleted", nullable = false)
     private boolean deleted;
 
+    @Column(name = "secret", nullable = false)
+    private boolean secret;
+
+    @Column(name = "secret_target_user_id")
+    private Long secretTargetUserId;
+
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;

--- a/src/main/java/com/example/bookiibookii/domain/comment/exception/code/CommentErrorCode.java
+++ b/src/main/java/com/example/bookiibookii/domain/comment/exception/code/CommentErrorCode.java
@@ -22,6 +22,9 @@ public enum CommentErrorCode implements BaseCode {
     REPLY_DEPTH_EXCEEDED(HttpStatus.BAD_REQUEST,
             "COMMENT400_2",
             "대댓글의 대댓글은 허용되지 않습니다."),
+    SECRET_REPLY_ONLY(HttpStatus.BAD_REQUEST,
+            "COMMENT400_3",
+            "비밀 댓글은 답글(대댓글)로만 작성할 수 있습니다."),
 
     COMMENT_WRITE_FORBIDDEN(HttpStatus.FORBIDDEN,
             "COMMENT403_1",

--- a/src/main/java/com/example/bookiibookii/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/example/bookiibookii/domain/comment/repository/CommentRepository.java
@@ -11,15 +11,6 @@ import java.util.Optional;
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     @Query("""
-        select c
-        from Comment c
-        join fetch c.user u
-        where c.group.groupId = :groupId
-        order by c.createdAt asc
-    """)
-    List<Comment> findAllByGroupIdWithUserOrderByCreatedAtAsc(@Param("groupId") Long groupId);
-
-    @Query("""
     select c
     from Comment c
     join fetch c.user u
@@ -28,5 +19,16 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     Optional<Comment> findByIdAndGroupIdWithUser(@Param("commentId") Long commentId,
                                                  @Param("groupId") Long groupId);
 
-    boolean existsByParent_Id(Long parentId);
+    @Query("""
+    select c from Comment c
+    join fetch c.user u
+    where c.group.groupId = :groupId
+    and (
+        c.secret = false
+        or (c.secret = true and (c.user.id = :viewerId or c.secretTargetUserId = :viewerId))
+    )
+    order by c.createdAt asc
+    """)
+    List<Comment> findVisibleTree(@Param("groupId") Long groupId,
+                                  @Param("viewerId") Long viewerId);
 }

--- a/src/main/java/com/example/bookiibookii/domain/comment/service/CommentService.java
+++ b/src/main/java/com/example/bookiibookii/domain/comment/service/CommentService.java
@@ -92,8 +92,9 @@ public class CommentService {
         Comment saved = commentRepository.save(comment);
 
         Long notifyUserId = isSecret ? secretTargetUserId : group.getHost().getId();
-        eventPublisher.publish(new CommentEvent(user.getNickName(), group.getBook().getTitle(), notifyUserId, group.getGroupId()));
-
+        if (!user.getId().equals(notifyUserId)) {
+            eventPublisher.publish(new CommentEvent(user.getNickName(), group.getBook().getTitle(), notifyUserId, group.getGroupId()));
+        }
         return toCreateResDTO(saved, writerRole);
     }
 

--- a/src/main/java/com/example/bookiibookii/domain/comment/service/CommentService.java
+++ b/src/main/java/com/example/bookiibookii/domain/comment/service/CommentService.java
@@ -71,24 +71,36 @@ public class CommentService {
             }
         }
 
+        boolean isSecret = req.isSecret();
+        if (isSecret && parent == null) {
+            throw new CommentException(CommentErrorCode.SECRET_REPLY_ONLY);
+        }
+
+        Long secretTargetUserId = null;
+        if (isSecret) {
+            secretTargetUserId = parent.getUser().getId();
+        }
+
         Comment comment = Comment.builder()
                 .content(req.getContent())
                 .user(user)
                 .group(group)
                 .parent(parent)
+                .secret(isSecret)
+                .secretTargetUserId(secretTargetUserId)
                 .build();
         Comment saved = commentRepository.save(comment);
 
-        eventPublisher.publish(new CommentEvent(user.getNickName(), group.getBook().getTitle(), group.getHost().getId(), group.getGroupId()));
+        Long notifyUserId = isSecret ? secretTargetUserId : group.getHost().getId();
+        eventPublisher.publish(new CommentEvent(user.getNickName(), group.getBook().getTitle(), notifyUserId, group.getGroupId()));
 
         return toCreateResDTO(saved, writerRole);
     }
 
     // 그룹 페이지 내 모든 댓글 조회(대댓글 포함)
     @Transactional(readOnly = true)
-    public List<CommentTreeResDTO> getTree(Long groupId) {
-        List<Comment> comments =
-                commentRepository.findAllByGroupIdWithUserOrderByCreatedAtAsc(groupId);
+    public List<CommentTreeResDTO> getTree(Long groupId, Long viewerId) {
+        List<Comment> comments = commentRepository.findVisibleTree(groupId, viewerId);
 
         // 그룹 멤버 역할 전체 로드 (user_id, mm.RoleStatus 가져옴)
         Map<Long, WriterRole> writerRoleMap = matchedMemberRepository.findWriterRowsByGroupId(groupId)


### PR DESCRIPTION
## 개요
<!---- 자신이 완료한 이슈를 닫아주세요 -->
- closed #348 
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
답글(대댓글)에 대해 비밀댓글 작성 기능을 추가했습니다.
댓글 트리 조회 시 작성자 또는 부모댓글 작성자에게만 비밀 대댓글이 노출되도록 조회 필터를 적용했습니다. (그 외 사용자에겐 트리에서 해당 댓글 자체가 보이지 않도록 처리했습니다)

<!---- Resolves: #(Isuue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [x] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

📣 **To Reviewers**
---
<!-- 전달사항 -->

- Reviewers : 팀 선택
- Labels : 작업 유형, 자기 자신


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 비밀 댓글 추가 — 비밀 댓글은 답글(대댓글)로만 작성 가능
  * 댓글 삭제 API 추가

* **개선 사항**
  * 로그인 사용자 기준으로 댓글 가시성 적용 (비밀 댓글 노출 제어 포함)
  * API 문서(스웨거) 주석 보강

* **버그 수정**
  * 비밀 댓글 작성 시 유효성 검증/오류 코드 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->