### PR TITLE
[Feat] #364 Admin용 Notice API 구현

### DIFF
--- a/src/main/java/com/example/bookiibookii/domain/support/notice/controller/AdminNoticeController.java
+++ b/src/main/java/com/example/bookiibookii/domain/support/notice/controller/AdminNoticeController.java
@@ -35,6 +35,14 @@ public class AdminNoticeController implements AdminNoticeControllerDocs {
             NoticeRequestDTO.UpdateNoticeDTO request
     ) {
         adminNoticeService.updateNotice(noticeId, request);
-        return ApiResponse.onSuccess(GeneralSuccessCode.CREATED, null);
+        return ApiResponse.onSuccess(GeneralSuccessCode.REQUEST_OK, null);
     }
+
+    // 공지사항 삭제
+    @DeleteMapping("/{noticeId}")
+    public ApiResponse<Void> deleteNotice(@PathVariable Long noticeId) {
+        adminNoticeService.deleteNotice(noticeId);
+        return ApiResponse.onSuccess(GeneralSuccessCode.REQUEST_OK, null);
+    }
+
 }

--- a/src/main/java/com/example/bookiibookii/domain/support/notice/controller/AdminNoticeController.java
+++ b/src/main/java/com/example/bookiibookii/domain/support/notice/controller/AdminNoticeController.java
@@ -27,4 +27,14 @@ public class AdminNoticeController implements AdminNoticeControllerDocs {
         adminNoticeService.createNotice(user.getId(), request);
         return ApiResponse.onSuccess(GeneralSuccessCode.CREATED, null);
     }
+
+    // 공지사항 수정
+    @PatchMapping("/{noticeId}")
+    public ApiResponse<Void> updateNotice(
+            @PathVariable Long noticeId,
+            NoticeRequestDTO.UpdateNoticeDTO request
+    ) {
+        adminNoticeService.updateNotice(noticeId, request);
+        return ApiResponse.onSuccess(GeneralSuccessCode.CREATED, null);
+    }
 }

--- a/src/main/java/com/example/bookiibookii/domain/support/notice/controller/AdminNoticeController.java
+++ b/src/main/java/com/example/bookiibookii/domain/support/notice/controller/AdminNoticeController.java
@@ -5,6 +5,7 @@ import com.example.bookiibookii.domain.support.notice.service.AdminNoticeService
 import com.example.bookiibookii.domain.user.entity.User;
 import com.example.bookiibookii.global.apiPayload.ApiResponse;
 import com.example.bookiibookii.global.apiPayload.code.GeneralSuccessCode;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -23,7 +24,7 @@ public class AdminNoticeController implements AdminNoticeControllerDocs {
     @PostMapping
     public ApiResponse<Void> createNotice(
             @AuthenticationPrincipal(expression = "user") User user,
-            NoticeRequestDTO.CreateNoticeDTO request) {
+            @Valid @RequestBody NoticeRequestDTO.CreateNoticeDTO request) {
         adminNoticeService.createNotice(user.getId(), request);
         return ApiResponse.onSuccess(GeneralSuccessCode.CREATED, null);
     }
@@ -32,7 +33,7 @@ public class AdminNoticeController implements AdminNoticeControllerDocs {
     @PatchMapping("/{noticeId}")
     public ApiResponse<Void> updateNotice(
             @PathVariable Long noticeId,
-            NoticeRequestDTO.UpdateNoticeDTO request
+            @RequestBody NoticeRequestDTO.UpdateNoticeDTO request
     ) {
         adminNoticeService.updateNotice(noticeId, request);
         return ApiResponse.onSuccess(GeneralSuccessCode.REQUEST_OK, null);

--- a/src/main/java/com/example/bookiibookii/domain/support/notice/controller/AdminNoticeController.java
+++ b/src/main/java/com/example/bookiibookii/domain/support/notice/controller/AdminNoticeController.java
@@ -1,0 +1,30 @@
+package com.example.bookiibookii.domain.support.notice.controller;
+
+import com.example.bookiibookii.domain.support.notice.dto.req.NoticeRequestDTO;
+import com.example.bookiibookii.domain.support.notice.service.AdminNoticeService;
+import com.example.bookiibookii.domain.user.entity.User;
+import com.example.bookiibookii.global.apiPayload.ApiResponse;
+import com.example.bookiibookii.global.apiPayload.code.GeneralSuccessCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@Validated
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin/notice")
+@PreAuthorize("hasRole('ADMIN')") // 클래스 레벨에 선언하여 모든 메서드에 관리자 권한 강제
+public class AdminNoticeController implements AdminNoticeControllerDocs {
+    private final AdminNoticeService adminNoticeService;
+
+    // 공지사항 등록
+    @PostMapping
+    public ApiResponse<Void> createNotice(
+            @AuthenticationPrincipal(expression = "user") User user,
+            NoticeRequestDTO.CreateNoticeDTO request) {
+        adminNoticeService.createNotice(user.getId(), request);
+        return ApiResponse.onSuccess(GeneralSuccessCode.CREATED, null);
+    }
+}

--- a/src/main/java/com/example/bookiibookii/domain/support/notice/controller/AdminNoticeControllerDocs.java
+++ b/src/main/java/com/example/bookiibookii/domain/support/notice/controller/AdminNoticeControllerDocs.java
@@ -6,8 +6,10 @@ import com.example.bookiibookii.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "Admin Notice", description = "관리자용 공지 관련 API")
 public interface AdminNoticeControllerDocs {
@@ -20,7 +22,7 @@ public interface AdminNoticeControllerDocs {
     })
     ApiResponse<Void> createNotice(
             @AuthenticationPrincipal(expression = "user") User user,
-            NoticeRequestDTO.CreateNoticeDTO request);
+            @Valid @RequestBody NoticeRequestDTO.CreateNoticeDTO request);
 
     @Operation(
             summary = "공지 수정 API",
@@ -28,11 +30,11 @@ public interface AdminNoticeControllerDocs {
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "공지 수정 성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "NOTICE401_1", description = "공지글을 찾을 수 없습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "NOTICE404_1", description = "공지글을 찾을 수 없습니다."),
     })
     ApiResponse<Void> updateNotice(
             @PathVariable Long noticeId,
-            NoticeRequestDTO.UpdateNoticeDTO request);
+            @RequestBody NoticeRequestDTO.UpdateNoticeDTO request);
 
     @Operation(
             summary = "공지 삭제 API",
@@ -40,7 +42,7 @@ public interface AdminNoticeControllerDocs {
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "공지 삭제 성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "NOTICE401_1", description = "공지글을 찾을 수 없습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "NOTICE404_1", description = "공지글을 찾을 수 없습니다."),
     })
     ApiResponse<Void> deleteNotice(@PathVariable Long noticeId);
 }

--- a/src/main/java/com/example/bookiibookii/domain/support/notice/controller/AdminNoticeControllerDocs.java
+++ b/src/main/java/com/example/bookiibookii/domain/support/notice/controller/AdminNoticeControllerDocs.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
 
 @Tag(name = "Admin Notice", description = "관리자용 공지 관련 API")
 public interface AdminNoticeControllerDocs {
@@ -30,7 +31,16 @@ public interface AdminNoticeControllerDocs {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "NOTICE401_1", description = "공지글을 찾을 수 없습니다."),
     })
     ApiResponse<Void> updateNotice(
-            Long noticeId,
+            @PathVariable Long noticeId,
             NoticeRequestDTO.UpdateNoticeDTO request);
 
+    @Operation(
+            summary = "공지 삭제 API",
+            description = "공지글을 삭제하는 API입니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "공지 삭제 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "NOTICE401_1", description = "공지글을 찾을 수 없습니다."),
+    })
+    ApiResponse<Void> deleteNotice(@PathVariable Long noticeId);
 }

--- a/src/main/java/com/example/bookiibookii/domain/support/notice/controller/AdminNoticeControllerDocs.java
+++ b/src/main/java/com/example/bookiibookii/domain/support/notice/controller/AdminNoticeControllerDocs.java
@@ -1,15 +1,12 @@
 package com.example.bookiibookii.domain.support.notice.controller;
 
 import com.example.bookiibookii.domain.support.notice.dto.req.NoticeRequestDTO;
-import com.example.bookiibookii.domain.support.notice.dto.res.NoticeResponseDTO;
 import com.example.bookiibookii.domain.user.entity.User;
 import com.example.bookiibookii.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "Admin Notice", description = "관리자용 공지 관련 API")
 public interface AdminNoticeControllerDocs {
@@ -23,5 +20,17 @@ public interface AdminNoticeControllerDocs {
     ApiResponse<Void> createNotice(
             @AuthenticationPrincipal(expression = "user") User user,
             NoticeRequestDTO.CreateNoticeDTO request);
+
+    @Operation(
+            summary = "공지 수정 API",
+            description = "공지글을 수정하는 API입니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "공지 수정 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "NOTICE401_1", description = "공지글을 찾을 수 없습니다."),
+    })
+    ApiResponse<Void> updateNotice(
+            Long noticeId,
+            NoticeRequestDTO.UpdateNoticeDTO request);
 
 }

--- a/src/main/java/com/example/bookiibookii/domain/support/notice/controller/AdminNoticeControllerDocs.java
+++ b/src/main/java/com/example/bookiibookii/domain/support/notice/controller/AdminNoticeControllerDocs.java
@@ -1,0 +1,27 @@
+package com.example.bookiibookii.domain.support.notice.controller;
+
+import com.example.bookiibookii.domain.support.notice.dto.req.NoticeRequestDTO;
+import com.example.bookiibookii.domain.support.notice.dto.res.NoticeResponseDTO;
+import com.example.bookiibookii.domain.user.entity.User;
+import com.example.bookiibookii.global.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "Admin Notice", description = "관리자용 공지 관련 API")
+public interface AdminNoticeControllerDocs {
+    @Operation(
+            summary = "공지 등록 API",
+            description = "공지글을 등록하는 API입니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "공지 등록 성공")
+    })
+    ApiResponse<Void> createNotice(
+            @AuthenticationPrincipal(expression = "user") User user,
+            NoticeRequestDTO.CreateNoticeDTO request);
+
+}

--- a/src/main/java/com/example/bookiibookii/domain/support/notice/controller/NoticeController.java
+++ b/src/main/java/com/example/bookiibookii/domain/support/notice/controller/NoticeController.java
@@ -1,7 +1,7 @@
-package com.example.bookiibookii.domain.support.controller;
+package com.example.bookiibookii.domain.support.notice.controller;
 
-import com.example.bookiibookii.domain.support.dto.res.NoticeResponseDTO;
-import com.example.bookiibookii.domain.support.service.NoticeService;
+import com.example.bookiibookii.domain.support.notice.dto.res.NoticeResponseDTO;
+import com.example.bookiibookii.domain.support.notice.service.NoticeService;
 import com.example.bookiibookii.global.apiPayload.ApiResponse;
 import com.example.bookiibookii.global.apiPayload.code.GeneralSuccessCode;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/example/bookiibookii/domain/support/notice/controller/NoticeControllerDocs.java
+++ b/src/main/java/com/example/bookiibookii/domain/support/notice/controller/NoticeControllerDocs.java
@@ -1,6 +1,6 @@
-package com.example.bookiibookii.domain.support.controller;
+package com.example.bookiibookii.domain.support.notice.controller;
 
-import com.example.bookiibookii.domain.support.dto.res.NoticeResponseDTO;
+import com.example.bookiibookii.domain.support.notice.dto.res.NoticeResponseDTO;
 import com.example.bookiibookii.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;

--- a/src/main/java/com/example/bookiibookii/domain/support/notice/dto/req/NoticeRequestDTO.java
+++ b/src/main/java/com/example/bookiibookii/domain/support/notice/dto/req/NoticeRequestDTO.java
@@ -1,14 +1,21 @@
 package com.example.bookiibookii.domain.support.notice.dto.req;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
 
 public class NoticeRequestDTO {
     public record CreateNoticeDTO(
-            @NotNull
+            @NotBlank(message = "제목은 필수 입력 사항입니다.")
             String title,
-            @NotNull
+            @NotBlank(message = "내용은 필수 입력 사항입니다.")
             String content,
             String summary,
             String image
-    ){}
+    ) {}
+
+    public record UpdateNoticeDTO(
+            String title,
+            String content,
+            String summary,
+            String image
+    ) {}
 }

--- a/src/main/java/com/example/bookiibookii/domain/support/notice/dto/req/NoticeRequestDTO.java
+++ b/src/main/java/com/example/bookiibookii/domain/support/notice/dto/req/NoticeRequestDTO.java
@@ -8,14 +8,12 @@ public class NoticeRequestDTO {
             String title,
             @NotBlank(message = "내용은 필수 입력 사항입니다.")
             String content,
-            String summary,
-            String image
+            String summary
     ) {}
 
     public record UpdateNoticeDTO(
             String title,
             String content,
-            String summary,
-            String image
+            String summary
     ) {}
 }

--- a/src/main/java/com/example/bookiibookii/domain/support/notice/dto/req/NoticeRequestDTO.java
+++ b/src/main/java/com/example/bookiibookii/domain/support/notice/dto/req/NoticeRequestDTO.java
@@ -1,0 +1,14 @@
+package com.example.bookiibookii.domain.support.notice.dto.req;
+
+import jakarta.validation.constraints.NotNull;
+
+public class NoticeRequestDTO {
+    public record CreateNoticeDTO(
+            @NotNull
+            String title,
+            @NotNull
+            String content,
+            String summary,
+            String image
+    ){}
+}

--- a/src/main/java/com/example/bookiibookii/domain/support/notice/dto/res/NoticeResponseDTO.java
+++ b/src/main/java/com/example/bookiibookii/domain/support/notice/dto/res/NoticeResponseDTO.java
@@ -9,7 +9,6 @@ public class NoticeResponseDTO {
             Long id,
             String title,
             String content,
-            String image,
             @JsonFormat(pattern = "yyyy.MM.dd HH:mm")
             LocalDateTime createdAt
     ) {}

--- a/src/main/java/com/example/bookiibookii/domain/support/notice/dto/res/NoticeResponseDTO.java
+++ b/src/main/java/com/example/bookiibookii/domain/support/notice/dto/res/NoticeResponseDTO.java
@@ -1,4 +1,4 @@
-package com.example.bookiibookii.domain.support.dto.res;
+package com.example.bookiibookii.domain.support.notice.dto.res;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 

--- a/src/main/java/com/example/bookiibookii/domain/support/notice/entity/Notice.java
+++ b/src/main/java/com/example/bookiibookii/domain/support/notice/entity/Notice.java
@@ -29,9 +29,6 @@ public class Notice extends BaseEntity {
     @Column(name = "content", length = 2000, nullable = false)
     private String content;
 
-    @Column(name = "image")
-    private String image;
-
     public void updateTitle(String title) {
         this.title = title;
     }
@@ -40,8 +37,5 @@ public class Notice extends BaseEntity {
     }
     public void updateSummary(String summary) {
         this.summary = summary;
-    }
-    public void updateImage(String image) {
-        this.image = image;
     }
 }

--- a/src/main/java/com/example/bookiibookii/domain/support/notice/entity/Notice.java
+++ b/src/main/java/com/example/bookiibookii/domain/support/notice/entity/Notice.java
@@ -1,6 +1,5 @@
-package com.example.bookiibookii.domain.support.entity;
+package com.example.bookiibookii.domain.support.notice.entity;
 
-import com.example.bookiibookii.domain.user.entity.User;
 import com.example.bookiibookii.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;

--- a/src/main/java/com/example/bookiibookii/domain/support/notice/entity/Notice.java
+++ b/src/main/java/com/example/bookiibookii/domain/support/notice/entity/Notice.java
@@ -31,4 +31,17 @@ public class Notice extends BaseEntity {
 
     @Column(name = "image")
     private String image;
+
+    public void updateTitle(String title) {
+        this.title = title;
+    }
+    public void updateContent(String content) {
+        this.content = content;
+    }
+    public void updateSummary(String summary) {
+        this.summary = summary;
+    }
+    public void updateImage(String image) {
+        this.image = image;
+    }
 }

--- a/src/main/java/com/example/bookiibookii/domain/support/notice/exception/NoticeException.java
+++ b/src/main/java/com/example/bookiibookii/domain/support/notice/exception/NoticeException.java
@@ -1,0 +1,10 @@
+package com.example.bookiibookii.domain.support.notice.exception;
+
+import com.example.bookiibookii.global.apiPayload.code.BaseCode;
+import com.example.bookiibookii.global.apiPayload.exception.GeneralException;
+
+public class NoticeException extends GeneralException {
+    public NoticeException(BaseCode code) {
+        super(code);
+    }
+}

--- a/src/main/java/com/example/bookiibookii/domain/support/notice/exception/code/NoticeErrorCode.java
+++ b/src/main/java/com/example/bookiibookii/domain/support/notice/exception/code/NoticeErrorCode.java
@@ -1,0 +1,18 @@
+package com.example.bookiibookii.domain.support.notice.exception.code;
+
+import com.example.bookiibookii.global.apiPayload.code.BaseCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum NoticeErrorCode implements BaseCode {
+    NOTICE_NOT_FOUND(HttpStatus.NOT_FOUND,
+            "NOTICE404_1",
+            "공지글을 찾을 수 없습니다."),
+    ;
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/example/bookiibookii/domain/support/notice/repository/NoticeRepository.java
+++ b/src/main/java/com/example/bookiibookii/domain/support/notice/repository/NoticeRepository.java
@@ -1,6 +1,6 @@
-package com.example.bookiibookii.domain.support.repository;
+package com.example.bookiibookii.domain.support.notice.repository;
 
-import com.example.bookiibookii.domain.support.entity.Notice;
+import com.example.bookiibookii.domain.support.notice.entity.Notice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/src/main/java/com/example/bookiibookii/domain/support/notice/service/AdminNoticeService.java
+++ b/src/main/java/com/example/bookiibookii/domain/support/notice/service/AdminNoticeService.java
@@ -2,6 +2,8 @@ package com.example.bookiibookii.domain.support.notice.service;
 
 import com.example.bookiibookii.domain.support.notice.dto.req.NoticeRequestDTO;
 import com.example.bookiibookii.domain.support.notice.entity.Notice;
+import com.example.bookiibookii.domain.support.notice.exception.NoticeException;
+import com.example.bookiibookii.domain.support.notice.exception.code.NoticeErrorCode;
 import com.example.bookiibookii.domain.support.notice.repository.NoticeRepository;
 import com.example.bookiibookii.domain.user.entity.User;
 import com.example.bookiibookii.domain.user.exception.UserException;
@@ -31,5 +33,23 @@ public class AdminNoticeService {
                 .build();
 
         noticeRepository.save(notice);
+    }
+
+    public void updateNotice(Long noticeId, NoticeRequestDTO.UpdateNoticeDTO request) {
+        Notice notice = noticeRepository.findById(noticeId)
+                .orElseThrow(() -> new NoticeException(NoticeErrorCode.NOTICE_NOT_FOUND));
+
+        if (request.title() != null) {
+            notice.updateTitle(request.title());
+        }
+        if (request.content() != null) {
+            notice.updateContent(request.content());
+        }
+        if (request.summary() != null) {
+            notice.updateSummary(request.summary());
+        }
+        if (request.image() != null) {
+            notice.updateImage(request.image());
+        }
     }
 }

--- a/src/main/java/com/example/bookiibookii/domain/support/notice/service/AdminNoticeService.java
+++ b/src/main/java/com/example/bookiibookii/domain/support/notice/service/AdminNoticeService.java
@@ -1,0 +1,35 @@
+package com.example.bookiibookii.domain.support.notice.service;
+
+import com.example.bookiibookii.domain.support.notice.dto.req.NoticeRequestDTO;
+import com.example.bookiibookii.domain.support.notice.entity.Notice;
+import com.example.bookiibookii.domain.support.notice.repository.NoticeRepository;
+import com.example.bookiibookii.domain.user.entity.User;
+import com.example.bookiibookii.domain.user.exception.UserException;
+import com.example.bookiibookii.domain.user.exception.code.UserErrorCode;
+import com.example.bookiibookii.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AdminNoticeService {
+    private final UserRepository userRepository;
+    private final NoticeRepository noticeRepository;
+
+    public void createNotice(Long userId, NoticeRequestDTO.CreateNoticeDTO request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(UserErrorCode.NOT_FOUND));
+
+        Notice notice = Notice.builder()
+                .userId(user.getId())
+                .title(request.title())
+                .content(request.content())
+                .summary(request.summary())
+                .image(request.image())
+                .build();
+
+        noticeRepository.save(notice);
+    }
+}

--- a/src/main/java/com/example/bookiibookii/domain/support/notice/service/AdminNoticeService.java
+++ b/src/main/java/com/example/bookiibookii/domain/support/notice/service/AdminNoticeService.java
@@ -52,4 +52,11 @@ public class AdminNoticeService {
             notice.updateImage(request.image());
         }
     }
+
+    public void deleteNotice(Long noticeId) {
+        Notice notice = noticeRepository.findById(noticeId)
+                .orElseThrow(() -> new NoticeException(NoticeErrorCode.NOTICE_NOT_FOUND));
+
+        noticeRepository.deleteById(noticeId);
+    }
 }

--- a/src/main/java/com/example/bookiibookii/domain/support/notice/service/AdminNoticeService.java
+++ b/src/main/java/com/example/bookiibookii/domain/support/notice/service/AdminNoticeService.java
@@ -29,7 +29,6 @@ public class AdminNoticeService {
                 .title(request.title())
                 .content(request.content())
                 .summary(request.summary())
-                .image(request.image())
                 .build();
 
         noticeRepository.save(notice);
@@ -47,9 +46,6 @@ public class AdminNoticeService {
         }
         if (request.summary() != null) {
             notice.updateSummary(request.summary());
-        }
-        if (request.image() != null) {
-            notice.updateImage(request.image());
         }
     }
 

--- a/src/main/java/com/example/bookiibookii/domain/support/notice/service/NoticeService.java
+++ b/src/main/java/com/example/bookiibookii/domain/support/notice/service/NoticeService.java
@@ -1,8 +1,8 @@
-package com.example.bookiibookii.domain.support.service;
+package com.example.bookiibookii.domain.support.notice.service;
 
-import com.example.bookiibookii.domain.support.dto.res.NoticeResponseDTO;
-import com.example.bookiibookii.domain.support.entity.Notice;
-import com.example.bookiibookii.domain.support.repository.NoticeRepository;
+import com.example.bookiibookii.domain.support.notice.dto.res.NoticeResponseDTO;
+import com.example.bookiibookii.domain.support.notice.entity.Notice;
+import com.example.bookiibookii.domain.support.notice.repository.NoticeRepository;
 import com.example.bookiibookii.global.apiPayload.code.GeneralErrorCode;
 import com.example.bookiibookii.global.apiPayload.exception.GeneralException;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/example/bookiibookii/domain/support/notice/service/NoticeService.java
+++ b/src/main/java/com/example/bookiibookii/domain/support/notice/service/NoticeService.java
@@ -39,7 +39,6 @@ public class NoticeService {
                 notice.getId(),
                 notice.getTitle(),
                 notice.getContent(),
-                notice.getImage(),
                 notice.getCreatedAt()
         );
     }

--- a/src/main/java/com/example/bookiibookii/global/security/SecurityConfig.java
+++ b/src/main/java/com/example/bookiibookii/global/security/SecurityConfig.java
@@ -4,6 +4,7 @@ import com.example.bookiibookii.global.auth.jwt.JwtAuthFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -13,6 +14,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
+@EnableMethodSecurity
 public class SecurityConfig {
     private final JwtAuthFilter jwtAuthFilter;
 


### PR DESCRIPTION
## 개요
<!---- 자신이 완료한 이슈를 닫아주세요 -->
- closed #364 //이슈 번호는 추적을 위해 필요합니다!
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
Admin 권한으로만 접근 가능한 Notice 도메인을 분리했습니다.
Notice 생성, Notice 수정, Notice 삭제 API를 구현했습니다. 
Notice 삭제에는 임시로 Hard Delete를 적용시켰으며, Soft Delete 적용 관련해선 논의가 필요할 것 같습니다.

<!---- Resolves: #364 -->

## PR 유형
어떤 변경 사항이 있나요?

- [X] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

📣 **To Reviewers**
---
<!-- 전달사항 -->

- Reviewers : 팀 선택
- Labels : 작업 유형, 자기 자신


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 관리자용 공지사항 관리 API 추가 — 공지 생성·수정·삭제 기능 제공
* **개선사항**
  * 공지 생성 시 제목·내용 검증 적용
  * 공지 조회/조작 실패 시 명확한 오류 응답(공지 없음) 제공
  * 관리자 권한 기반 접근 제어 및 메서드 수준 보안 적용
  * 공지 상세 응답에서 이미지 필드 제거(응답 구조 변경)
* **리팩토링**
  * 공지 관련 모듈 구조 정리 및 책임 분리
<!-- end of auto-generated comment: release notes by coderabbit.ai -->