### PR TITLE
[Refator]#380 DELIVERY 로직 삭제 및 MemberStatus 추가

### DIFF
--- a/src/main/java/com/example/bookiibookii/domain/group/dto/req/GroupRequestDTO.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/dto/req/GroupRequestDTO.java
@@ -39,8 +39,8 @@ public class GroupRequestDTO {
         private String customTag;
         @Schema(description = "그룹 타입 (RELAY: 이어읽기, TOGETHER: 함께읽기)", example = "TOGETHER")
         private GroupType groupType;   // RELAY, TOGETHER
-        @Schema(description = "교환 방식 (DELIVERY: 택배, DIRECT: 직거래, NONE: 함께읽기 시)", example = "DIRECT")
-        private TradeType tradeType;   // DELIVERY, DIRECT
+        @Schema(description = "교환 방식 (DIRECT: 직거래, NONE: 함께읽기 시)", example = "DIRECT")
+        private TradeType tradeType;   // DIRECT, NONE
         @Schema(description = "선호 지역 (직거래 시 필수)", example = "서울 동작구 상도동")
         private String preferRegion;
         @Schema(description = "상세 만남 장소 (직거래 시)", example = "상도역 1번 출구 스타벅스")
@@ -68,7 +68,7 @@ public class GroupRequestDTO {
     public record FilterDTO(
             @Schema(description = "그룹 타입 필터 ", example = "[\"TOGETHER\"]")
             List<GroupType> groupTypes,
-            @Schema(description = "거래 방식 필터 ", example = "[\"DELIVERY\", \"DIRECT\"]")
+            @Schema(description = "거래 방식 필터 ", example = "[\"DIRECT\"]")
             List<TradeType> tradeTypes,
             @Schema(description = "장소 필터 (지역 이름 리스트)", example = "[\"동작구\", \"관악구\"]")
             List<String> meetPlace,

--- a/src/main/java/com/example/bookiibookii/domain/group/entity/Groups.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/entity/Groups.java
@@ -63,7 +63,7 @@ public class Groups extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     @Column(name = "trade_type")
-    private TradeType tradeType;//DIRECT, DELIVERY
+    private TradeType tradeType;//DIRECT, NONE
 
     @Column(name = "prefer_region")
     private String preferRegion;

--- a/src/main/java/com/example/bookiibookii/domain/group/entity/MatchedMember.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/entity/MatchedMember.java
@@ -34,9 +34,6 @@ public class MatchedMember extends BaseEntity {
     @Column(name = "role")
     private RoleStatus role;
 
-    @Column(name = "matched_order", nullable = false)
-    private Integer matchedOrder; // 1, 2, 3... 순서 저장
-
     @Column(name = "current_reading_rate", nullable = false)
     private Integer currentReadingRate = 0;
 

--- a/src/main/java/com/example/bookiibookii/domain/group/entity/MatchedMember.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/entity/MatchedMember.java
@@ -1,5 +1,6 @@
 package com.example.bookiibookii.domain.group.entity;
 
+import com.example.bookiibookii.domain.group.enums.MemberStatus;
 import com.example.bookiibookii.domain.group.enums.RoleStatus;
 import com.example.bookiibookii.domain.user.entity.User;
 import com.example.bookiibookii.global.entity.BaseEntity;
@@ -44,6 +45,15 @@ public class MatchedMember extends BaseEntity {
 
     @Column(name = "is_review_written", nullable = false)
     private boolean isReviewWritten = false; // 리뷰 작성 여부 추가
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    @Builder.Default // 빌더 사용 시 기본값 유지
+    private MemberStatus status = MemberStatus.JOINED;
+
+    // 상태 변경 편의 메서드
+    public void kick() { this.status = MemberStatus.KICKED; }
+    public void leave() { this.status = MemberStatus.LEFT; }
 
     public void markReviewAsWritten() {
         this.isReviewWritten = true;

--- a/src/main/java/com/example/bookiibookii/domain/group/entity/MatchedMember.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/entity/MatchedMember.java
@@ -34,8 +34,8 @@ public class MatchedMember extends BaseEntity {
     @Column(name = "role")
     private RoleStatus role;
 
-    @Column(name = "reading_order", nullable = false)
-    private Integer readingOrder; // 1, 2, 3... 순서 저장
+    @Column(name = "matched_order", nullable = false)
+    private Integer matchedOrder; // 1, 2, 3... 순서 저장
 
     @Column(name = "current_reading_rate", nullable = false)
     private Integer currentReadingRate = 0;

--- a/src/main/java/com/example/bookiibookii/domain/group/enums/MemberStatus.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/enums/MemberStatus.java
@@ -1,0 +1,7 @@
+package com.example.bookiibookii.domain.group.enums;
+
+public enum MemberStatus {
+    JOINED, //참여중
+    KICKED, //강퇴됨
+    LEFT //스스로 나감
+}

--- a/src/main/java/com/example/bookiibookii/domain/group/enums/TradeType.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/enums/TradeType.java
@@ -1,5 +1,5 @@
 package com.example.bookiibookii.domain.group.enums;
 
 public enum TradeType {
-    DELIVERY, DIRECT, NONE
+    DIRECT, NONE
 }

--- a/src/main/java/com/example/bookiibookii/domain/group/repository/MatchedMemberRepository.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/repository/MatchedMemberRepository.java
@@ -24,7 +24,7 @@ public interface MatchedMemberRepository extends JpaRepository<MatchedMember, Lo
 
     @Query("SELECT mm FROM MatchedMember mm " +
             "JOIN FETCH mm.group g " +
-            "WHERE g.groupId = :groupId AND mm.readingOrder = :readingOrder")
+            "WHERE g.groupId = :groupId AND mm.matchedOrder = :matchedOrder")
     Optional<MatchedMember> findByGroupAndOrder(@Param("groupId") Long groupId, @Param("readingOrder") int readingOrder);
 
     //현재까지의 참여맴버 수
@@ -35,7 +35,7 @@ public interface MatchedMemberRepository extends JpaRepository<MatchedMember, Lo
             "JOIN FETCH mm.user u " +
             "LEFT JOIN FETCH u.userImage " +
             "WHERE mm.group = :group " +
-            "ORDER BY mm.readingOrder ASC")
+            "ORDER BY mm.matchedOrder ASC")
     List<MatchedMember> findAllByGroupOrderByReadingOrderAsc(@Param("group") Groups group);
     //참여 취소를 위한 조회 메서드
     Optional<MatchedMember> findByGroup_GroupIdAndUser_Id(Long groupId, Long userId);

--- a/src/main/java/com/example/bookiibookii/domain/group/repository/MatchedMemberRepository.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/repository/MatchedMemberRepository.java
@@ -36,7 +36,7 @@ public interface MatchedMemberRepository extends JpaRepository<MatchedMember, Lo
             "LEFT JOIN FETCH u.userImage " +
             "WHERE mm.group = :group " +
             "ORDER BY mm.matchedOrder ASC")
-    List<MatchedMember> findAllByGroupOrderByReadingOrderAsc(@Param("group") Groups group);
+    List<MatchedMember> findAllByGroupOrderByMatchedOrderAsc(@Param("group") Groups group);
     //참여 취소를 위한 조회 메서드
     Optional<MatchedMember> findByGroup_GroupIdAndUser_Id(Long groupId, Long userId);
 

--- a/src/main/java/com/example/bookiibookii/domain/group/repository/MatchedMemberRepository.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/repository/MatchedMemberRepository.java
@@ -15,28 +15,16 @@ import java.util.Optional;
 
 
 public interface MatchedMemberRepository extends JpaRepository<MatchedMember, Long> {
-
-//    @Query("SELECT mm FROM MatchedMember mm " +
-//            "JOIN FETCH mm.group g " +
-//            "JOIN FETCH g.tracker t " +  // g.getTracker()를 탐색하는 방식
-//            "WHERE mm.user.id = :userId")
-//    List<MatchedMember> findAllByUserIdWithTracker(@Param("userId") Long userId);
-
-    @Query("SELECT mm FROM MatchedMember mm " +
-            "JOIN FETCH mm.group g " +
-            "WHERE g.groupId = :groupId AND mm.matchedOrder = :matchedOrder")
-    Optional<MatchedMember> findByGroupAndOrder(@Param("groupId") Long groupId, @Param("matchedOrder") int matchedOrder);
-
     //현재까지의 참여맴버 수
     long countByGroup(Groups groups);
 
-    //참여맴버 리스트(읽는 순서대로 정렬) - User, UserImage fetch join으로 N+1 방지
+    //참여맴버 리스트(참여 시간 순서대로 정렬) - User, UserImage fetch join으로 N+1 방지
     @Query("SELECT mm FROM MatchedMember mm " +
             "JOIN FETCH mm.user u " +
             "LEFT JOIN FETCH u.userImage " +
             "WHERE mm.group = :group " +
-            "ORDER BY mm.matchedOrder ASC")
-    List<MatchedMember> findAllByGroupOrderByMatchedOrderAsc(@Param("group") Groups group);
+            "ORDER BY mm.createdAt ASC")
+    List<MatchedMember> findAllByGroupOrderByCreatedAtAsc(@Param("group") Groups group);
     //참여 취소를 위한 조회 메서드
     Optional<MatchedMember> findByGroup_GroupIdAndUser_Id(Long groupId, Long userId);
 
@@ -59,6 +47,12 @@ public interface MatchedMemberRepository extends JpaRepository<MatchedMember, Lo
     List<WriterRow> findWriterRowsByGroupId(@Param("groupId") Long groupId);
 
     List<MatchedMember> findAllByGroup_GroupId(Long groupId);
+
+    // 참여 시간 순 정렬 (TrackerService에서 순서 계산용)
+    List<MatchedMember> findAllByGroup_GroupIdOrderByCreatedAtAsc(Long groupId);
+
+    // 가장 먼저 참여한 멤버 조회 (호스트)
+    Optional<MatchedMember> findFirstByGroup_GroupIdOrderByCreatedAtAsc(Long groupId);
 
 
     interface WriterRow {

--- a/src/main/java/com/example/bookiibookii/domain/group/repository/MatchedMemberRepository.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/repository/MatchedMemberRepository.java
@@ -25,7 +25,7 @@ public interface MatchedMemberRepository extends JpaRepository<MatchedMember, Lo
     @Query("SELECT mm FROM MatchedMember mm " +
             "JOIN FETCH mm.group g " +
             "WHERE g.groupId = :groupId AND mm.matchedOrder = :matchedOrder")
-    Optional<MatchedMember> findByGroupAndOrder(@Param("groupId") Long groupId, @Param("readingOrder") int readingOrder);
+    Optional<MatchedMember> findByGroupAndOrder(@Param("groupId") Long groupId, @Param("matchedOrder") int matchedOrder);
 
     //현재까지의 참여맴버 수
     long countByGroup(Groups groups);

--- a/src/main/java/com/example/bookiibookii/domain/group/service/ApplicationService.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/service/ApplicationService.java
@@ -117,12 +117,11 @@ public class ApplicationService {
             // 신청서 수락 상태로 업데이트
             application.updateStatus(ApplicationStatus.ACCEPTED);
 
-            // 확정 멤버(MatchedMember) 추가 (readingOrder는 현재 인원 + 1)
+            // 확정 멤버(MatchedMember) 추가
             MatchedMember newMember = MatchedMember.builder()
                     .group(group)
                     .user(application.getGuest())
                     .role(RoleStatus.GUEST)
-                    .matchedOrder((int) currentTotalCount + 1)
                     .currentReadingRate(0)
                     .build();
             matchedMemberRepository.save(newMember);

--- a/src/main/java/com/example/bookiibookii/domain/group/service/ApplicationService.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/service/ApplicationService.java
@@ -122,7 +122,7 @@ public class ApplicationService {
                     .group(group)
                     .user(application.getGuest())
                     .role(RoleStatus.GUEST)
-                    .readingOrder((int) currentTotalCount + 1)
+                    .matchedOrder((int) currentTotalCount + 1)
                     .currentReadingRate(0)
                     .build();
             matchedMemberRepository.save(newMember);

--- a/src/main/java/com/example/bookiibookii/domain/group/service/GroupService.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/service/GroupService.java
@@ -172,11 +172,10 @@ public class GroupService {
 
         // 방장을 MatchedMember의 첫 번째 멤버로 등록
         MatchedMember hostMember = MatchedMember.builder()
-                .group(savedGroup)           // 엔티티의 private Groups group;
-                .user(host)                // 엔티티의 private User user;
-                .role(RoleStatus.HOST)       // 엔티티의 RoleStatus 타입 사용
-                .matchedOrder(1)             // 엔티티의 private Integer readingOrder;
-                .currentReadingRate(0)      // 초기 독서율 0으로 세팅
+                .group(savedGroup)
+                .user(host)
+                .role(RoleStatus.HOST)
+                .currentReadingRate(0)
                 .build();
 
         matchedMemberRepository.save(hostMember);
@@ -379,7 +378,7 @@ public class GroupService {
         }
 
         // 2. 해당 그룹에 참여가 확정된 멤버 리스트를 조회 (동그란 멤버 아이콘 리스트용)
-        List<MatchedMember> matchedMembers = matchedMemberRepository.findAllByGroupOrderByMatchedOrderAsc(group);
+        List<MatchedMember> matchedMembers = matchedMemberRepository.findAllByGroupOrderByCreatedAtAsc(group);
         int waitingCount = (int) applicationRepository.countByGroupGroupIdAndApplicationStatus(groupId, ApplicationStatus.PENDING);
 
         // 4. 대기 인원이 정원의 3배 이상일 경우 'HOT' 배지 활성화 여부 판단

--- a/src/main/java/com/example/bookiibookii/domain/group/service/GroupService.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/service/GroupService.java
@@ -175,7 +175,7 @@ public class GroupService {
                 .group(savedGroup)           // 엔티티의 private Groups group;
                 .user(host)                // 엔티티의 private User user;
                 .role(RoleStatus.HOST)       // 엔티티의 RoleStatus 타입 사용
-                .readingOrder(1)             // 엔티티의 private Integer readingOrder;
+                .matchedOrder(1)             // 엔티티의 private Integer readingOrder;
                 .currentReadingRate(0)      // 초기 독서율 0으로 세팅
                 .build();
 

--- a/src/main/java/com/example/bookiibookii/domain/group/service/GroupService.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/service/GroupService.java
@@ -379,9 +379,7 @@ public class GroupService {
         }
 
         // 2. 해당 그룹에 참여가 확정된 멤버 리스트를 조회 (동그란 멤버 아이콘 리스트용)
-        List<MatchedMember> matchedMembers = matchedMemberRepository.findAllByGroupOrderByReadingOrderAsc(group);
-
-        // 3. 현재 '대기 중'인 신청자 수를 카운트 (방장 버튼의 숫자 표시 및 HOT 배지 계산용)
+        List<MatchedMember> matchedMembers = matchedMemberRepository.findAllByGroupOrderByMatchedOrderAsc(group);
         int waitingCount = (int) applicationRepository.countByGroupGroupIdAndApplicationStatus(groupId, ApplicationStatus.PENDING);
 
         // 4. 대기 인원이 정원의 3배 이상일 경우 'HOT' 배지 활성화 여부 판단

--- a/src/main/java/com/example/bookiibookii/domain/group/service/GroupService.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/service/GroupService.java
@@ -240,15 +240,6 @@ public class GroupService {
                 throw new GroupException(GroupErrorCode.USER_LOCATION_NOT_FOUND);
             }
         }
-
-        // 택배 교환(DELIVERY) 시: 등록된 배송지(Address) 존재 여부 확인
-        if (request.getTradeType() == TradeType.DELIVERY) {
-            // addressRepository를 통해 해당 유저의 주소가 등록되어 있는지 확인
-            boolean hasAddress = addressRepository.existsByUserId(host.getId());
-            if (!hasAddress) {
-                throw new GroupException(GroupErrorCode.ADDRESS_NOT_FOUND);
-            }
-        }
     }
 
 
@@ -556,9 +547,6 @@ public class GroupService {
     private String determinePictureBadge(Groups group) {
         // '함께읽기' 타입이면 그대로 배지 노출
         if (group.getGroupType() == GroupType.TOGETHER) return "함께읽기";
-
-        // '이어읽기' 중 '택배'면 택배 노출
-        if (group.getTradeType() == TradeType.DELIVERY) return "택배";
 
         // '이어읽기' 중 '직접교환'이면 지역 정보 노출 (예: 서울 마포구 -> 마포구)
         String region = group.getPreferRegion();

--- a/src/main/java/com/example/bookiibookii/domain/tracker/converter/TrackerConverter.java
+++ b/src/main/java/com/example/bookiibookii/domain/tracker/converter/TrackerConverter.java
@@ -52,38 +52,17 @@ public class TrackerConverter {
                 .readingPeriod(tracker.getGroup().getReadingPeriod())
                 .remainingDays(remainingDays);
 
-        // 2. TradeType에 따른 분기 처리
-        TradeType tradeType = tracker.getGroup().getTradeType();
-
-        if (tradeType == TradeType.DELIVERY) {
-            if (partnerAddress != null) {
-                // DeliveryInfo 빌더 생성
-                TrackerDetailResponseDTO.DeliveryInfo.DeliveryInfoBuilder deliveryBuilder = TrackerDetailResponseDTO.DeliveryInfo.builder()
-                        .receiverName(partnerAddress.getReceiverName())
-                        .receiverPhone(partnerAddress.getPhone())
-                        .receiverAddress(String.format("[%s] %s %s",
-                                partnerAddress.getZipCode(),
-                                partnerAddress.getAddress(),
-                                partnerAddress.getAddressDetail()))
-                        .isVerified(tracker.getIsVerified());
-
-                // 운송 정보 추출
-                if (latestHistory != null) {
-                    deliveryBuilder.deliveryCompany(latestHistory.getDeliveryCompany())
-                            .trackingNumber(latestHistory.getTrackingNumber());
-                }
-
-                builder.deliveryInfo(deliveryBuilder.build());
-            }
-        } else if (tradeType == TradeType.DIRECT) {
-            // 직접 교환일 경우: 최신 약속 정보 세팅
+        // 2. 직접 교환(DIRECT)에 따른 정보 세팅
+        // v1에서는 DELIVERY 타입을 지원하지 않으므로 DIRECT 관련 로직만 유지합니다.
+        if (tracker.getGroup().getTradeType() == TradeType.DIRECT) {
             if (latestMeeting != null) {
+                // 약속이 잡힌 경우: 약속 시간과 장소 노출
                 builder.meetingInfo(TrackerDetailResponseDTO.MeetingInfo.builder()
                         .meetingTime(latestMeeting.getMeetingTime())
                         .meetingPlace(latestMeeting.getMeetingPlace())
                         .build());
             } else {
-                // 약속 전이면 호스트가 설정한 기본 장소 노출
+                // 약속 전인 경우: 호스트가 설정한 선호 지역(기본 장소) 노출
                 builder.meetingInfo(TrackerDetailResponseDTO.MeetingInfo.builder()
                         .meetingPlace(tracker.getGroup().getPreferRegion())
                         .build());

--- a/src/main/java/com/example/bookiibookii/domain/tracker/service/TrackerService.java
+++ b/src/main/java/com/example/bookiibookii/domain/tracker/service/TrackerService.java
@@ -205,47 +205,24 @@ public class TrackerService {
     //트래커 상세 조회
     @Transactional(readOnly = true)
     public TrackerDetailResponseDTO getTrackerDetailByGroupId(Long groupId, User user) {
-        // 1. 권한 검증 및 트래커 조회
         validateGroupMember(groupId, user.getId());
         Tracker tracker = trackerRepository.findByGroupId(groupId)
                 .orElseThrow(() -> new TrackerException(TrackerErrorCode.TRACKER_NOT_FOUND));
 
-           // 2. 1:1 파트너(상대방) 정보 조회
         MatchedMember partnerMember = findPartnerForRelay(groupId, user.getId());
         User partnerUser = partnerMember.getUser();
 
-        // 3. TradeType에 따라 필요한 추가 데이터 수집
+        // v1: 배송 관련 변수(partnerAddress, latestHistory)는 더 이상 필요 없습니다.
         Meeting latestMeeting = null;
-        Address partnerAddress = null;
-        TrackerHistory latestHistory = null;
 
+        // 직거래(DIRECT)일 때만 약속 정보를 조회합니다.
         if (tracker.getGroup().getTradeType() == TradeType.DIRECT) {
-            // [직접 교환] 최신 약속 정보 조회
-//            latestMeeting = meetingRepository.findLatestByGroupIdNative(groupId).orElse(null);
             latestMeeting = meetingRepository.findByGroupIdAndStatusNative(groupId, tracker.getTrackerStatus().toString()).orElse(null);
-        } else if(tracker.getGroup().getTradeType() == TradeType.DELIVERY ) {
-            // [배송] 상대방 주소 및 최신 히스토리(송장번호 등) 조회
-            partnerAddress = addressRepository.findByUserId(partnerUser.getId()).orElse(null);
-
-            List<TrackerStatus> shippingHistoryStatuses = List.of(
-                    TrackerStatus.SHIPPING_TO_GUEST,
-                    TrackerStatus.SHIPPING_TO_HOST,
-                    TrackerStatus.RECEIVED,
-                    TrackerStatus.RETURNED
-            );
-
-            // 현재 트래커 상태가 위 리스트에 포함될 때만 히스토리 조회
-            TrackerStatus currentStatus = tracker.getTrackerStatus();
-
-            if (shippingHistoryStatuses.contains(currentStatus) || currentStatus == TrackerStatus.GUEST_READING) {
-                // 가장 최근의 배송/수령 히스토리를 가져옵니다.
-                latestHistory = trackerHistoryRepository.findLatestShippingHistory(tracker, shippingHistoryStatuses)
-                        .orElse(null);
-            }
         }
 
-        // 4. 수집된 모든 정보를 컨버터에 전달
-        return trackerConverter.toDetailResponse(tracker, latestMeeting, partnerAddress, partnerUser, latestHistory);
+        // 컨버터 호출 시 partnerAddress와 latestHistory 자리에 null을 넘깁니다.
+        // (나중에 TrackerConverter에서도 이 파라미터들을 제거하면 더 좋습니다.)
+        return trackerConverter.toDetailResponse(tracker, latestMeeting, null, partnerUser, null);
     }
 
     /**

--- a/src/main/java/com/example/bookiibookii/domain/tracker/service/TrackerService.java
+++ b/src/main/java/com/example/bookiibookii/domain/tracker/service/TrackerService.java
@@ -159,8 +159,8 @@ public class TrackerService {
         Groups group = groupsRepository.findById(event.groupId())
                 .orElseThrow(() -> new GroupException(GroupErrorCode.GROUP_NOT_FOUND));
 
-        // 3. 첫 번째 주자(호스트, 순서 1번)의 MatchedMember 조회
-        MatchedMember firstOwner = matchedMemberRepository.findByGroupAndOrder(event.groupId(), 1)
+        // 3. 첫 번째 주자(호스트)의 MatchedMember 조회
+        MatchedMember firstOwner = matchedMemberRepository.findFirstByGroup_GroupIdOrderByCreatedAtAsc(event.groupId())
                 .orElseThrow(() -> new TrackerException(TrackerErrorCode.FIRST_MEMBER_NOT_FOUND));
 
         TrackerStatus trackerStatus;
@@ -406,13 +406,8 @@ public class TrackerService {
             throw new TrackerException(TrackerErrorCode.NOT_TRACKER_OWNER);
         }
 
-        int totalCapacity = tracker.getGroup().getMaxCapacity();
-        // 다음 순서 계산 (예: 4명일 때 1->2->3->4->1)
-        int nextOrder = (bookOwner.getMatchedOrder() % totalCapacity) + 1;
-
         // 다음 주자(receiver) 조회
-        MatchedMember nextOwner = matchedMemberRepository.findByGroupAndOrder(groupId, nextOrder)
-                .orElseThrow(() -> new TrackerException(TrackerErrorCode.NEXT_MEMBER_NOT_FOUND));
+        MatchedMember nextOwner = findNextMember(groupId, bookOwner.getId());
 
         // 엔티티에 판단 위임 (위에 작성한 메서드 호출)
         tracker.updateShippingStatus(bookOwner, nextOwner);
@@ -681,11 +676,7 @@ public class TrackerService {
         meetingRepository.saveAndFlush(meeting);
 
         if (isDoneStatus) {
-            int totalCapacity = tracker.getGroup().getMaxCapacity();
-            int nextOrder = (bookOwner.getMatchedOrder() % totalCapacity) + 1;
-
-            MatchedMember nextOwner = matchedMemberRepository.findByGroupAndOrder(groupId, nextOrder)
-                    .orElseThrow(() -> new TrackerException(TrackerErrorCode.NEXT_MEMBER_NOT_FOUND));
+            MatchedMember nextOwner = findNextMember(groupId, bookOwner.getId());
 
             TrackerHistory meetingHistory = tracker.createHistorySnapshot(
                     bookOwner.getId(),
@@ -731,11 +722,7 @@ public class TrackerService {
     private void processStatusTransition(Tracker tracker) {
         MatchedMember currentOwner = tracker.getBookOwner();
         Long groupId = tracker.getGroup().getGroupId();
-        int totalCapacity = tracker.getGroup().getMaxCapacity();
-
-        int nextOrder = (currentOwner.getMatchedOrder() % totalCapacity) + 1;
-        MatchedMember nextOwner = matchedMemberRepository.findByGroupAndOrder(groupId, nextOrder)
-                .orElseThrow(() -> new TrackerException(TrackerErrorCode.NEXT_MEMBER_NOT_FOUND));
+        MatchedMember nextOwner = findNextMember(groupId, currentOwner.getId());
 
         TrackerStatus nextStatus = (currentOwner.getRole() == RoleStatus.HOST)
                 ? TrackerStatus.RECEIVED : TrackerStatus.RETURNED;
@@ -779,6 +766,17 @@ public class TrackerService {
 
         // 5. 엔티티 메서드 호출 (isVerified = true)
         tracker.verifyReception();
+    }
+
+    // 현재 멤버의 다음 주자를 createdAt 순서 기준으로 조회 (순환)
+    private MatchedMember findNextMember(Long groupId, Long currentMemberId) {
+        List<MatchedMember> members = matchedMemberRepository.findAllByGroup_GroupIdOrderByCreatedAtAsc(groupId);
+        for (int i = 0; i < members.size(); i++) {
+            if (members.get(i).getId().equals(currentMemberId)) {
+                return members.get((i + 1) % members.size());
+            }
+        }
+        throw new TrackerException(TrackerErrorCode.NEXT_MEMBER_NOT_FOUND);
     }
 
 }

--- a/src/main/java/com/example/bookiibookii/domain/tracker/service/TrackerService.java
+++ b/src/main/java/com/example/bookiibookii/domain/tracker/service/TrackerService.java
@@ -408,7 +408,7 @@ public class TrackerService {
 
         int totalCapacity = tracker.getGroup().getMaxCapacity();
         // 다음 순서 계산 (예: 4명일 때 1->2->3->4->1)
-        int nextOrder = (bookOwner.getReadingOrder() % totalCapacity) + 1;
+        int nextOrder = (bookOwner.getMatchedOrder() % totalCapacity) + 1;
 
         // 다음 주자(receiver) 조회
         MatchedMember nextOwner = matchedMemberRepository.findByGroupAndOrder(groupId, nextOrder)
@@ -682,7 +682,7 @@ public class TrackerService {
 
         if (isDoneStatus) {
             int totalCapacity = tracker.getGroup().getMaxCapacity();
-            int nextOrder = (bookOwner.getReadingOrder() % totalCapacity) + 1;
+            int nextOrder = (bookOwner.getMatchedOrder() % totalCapacity) + 1;
 
             MatchedMember nextOwner = matchedMemberRepository.findByGroupAndOrder(groupId, nextOrder)
                     .orElseThrow(() -> new TrackerException(TrackerErrorCode.NEXT_MEMBER_NOT_FOUND));
@@ -733,7 +733,7 @@ public class TrackerService {
         Long groupId = tracker.getGroup().getGroupId();
         int totalCapacity = tracker.getGroup().getMaxCapacity();
 
-        int nextOrder = (currentOwner.getReadingOrder() % totalCapacity) + 1;
+        int nextOrder = (currentOwner.getMatchedOrder() % totalCapacity) + 1;
         MatchedMember nextOwner = matchedMemberRepository.findByGroupAndOrder(groupId, nextOrder)
                 .orElseThrow(() -> new TrackerException(TrackerErrorCode.NEXT_MEMBER_NOT_FOUND));
 


### PR DESCRIPTION
## 개요

<!---- Resolves: #(Isuue Number) -->
closed #380 

Enum 클래스 정비
TradeType: DELIVERY 옵션을 삭제하고 DIRECT, NONE 체제로 변경했습니다.
MemberStatus: 그룹 참여 상태(JOINED, KICKED, LEFT) 관리를 위한 신규 Enum을 생성했습니다.

엔티티 수정
MatchedMember: 유저의 참여 상태를 추적하기 위해 status 필드를 추가했습니다. (기본값: JOINED)

트래커 서비스 리팩토링 (TrackerService)
getTrackerDetailByGroupId 등에서 DELIVERY 타입일 때 수행하던 배송 정보 조회 및 주소 처리 로직을 제거했습니다.

추후 작업필요
현재 트래커(Tracker)에서 사용하던 DELIVERY 관련 로직은 우선 해당 Enum이 사용된 부분 위주로만 수정된 상태입니다.
v1의 직거래 및 함께읽기 로직이 완전히 안착된 후, 트래커 내부의 전반적인 로직 정비 및 코드 다이어트가 추가로 필요합니다.

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

📣 **To Reviewers**
---
<!-- 전달사항 -->

- Reviewers : 팀 선택
- Labels : 작업 유형, 자기 자신


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 그룹 멤버 상태 관리 추가 — 참여(JOINED), 강제퇴장(KICKED), 자발적 이탈(LEFT) 및 관련 동작 지원

* **변경 사항**
  * 거래 방식에서 택배(DELIVERY) 제거 — 거래 방식은 직거래(DIRECT) 및 함께읽기(NONE)로 단순화
  * 상세 조회에서 택배·배송 정보 노출 중단 — 직거래인 경우에만 모임(미팅) 정보 제공
  * 참가자 정렬 및 호스트 선정이 가입 시간 기반으로 변경되어 목록/순서가 변경될 수 있음

* **문서**
  * API 스키마 예시 및 설명을 새로운 거래 방식 표기 및 기본값으로 업데이트
<!-- end of auto-generated comment: release notes by coderabbit.ai -->