### PR TITLE
[Feat] #455 그룹홈 구현

### DIFF
--- a/src/main/java/com/example/bookiibookii/domain/aladin/config/AladinClient.java
+++ b/src/main/java/com/example/bookiibookii/domain/aladin/config/AladinClient.java
@@ -43,6 +43,21 @@ public class AladinClient {
                 .body(AladinItemSearchResponse.class);
     }
 
+    public AladinItemSearchResponse fetchBestsellers(int maxResults) {
+        return restClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/ItemList.aspx")
+                        .queryParam("ttbkey", aladinKey)
+                        .queryParam("QueryType", "Bestseller")
+                        .queryParam("MaxResults", maxResults)
+                        .queryParam("SearchTarget", "Book")
+                        .queryParam("output", "JS")
+                        .queryParam("Version", "20131101")
+                        .build())
+                .retrieve()
+                .body(AladinItemSearchResponse.class);
+    }
+
     public AladinBookItem lookupBookByIsbn13(String isbn13) {
         AladinItemLookupResponse raw = restClient.get()
                 .uri(uriBuilder -> uriBuilder

--- a/src/main/java/com/example/bookiibookii/domain/aladin/entity/BestsellerIsbn.java
+++ b/src/main/java/com/example/bookiibookii/domain/aladin/entity/BestsellerIsbn.java
@@ -1,0 +1,23 @@
+package com.example.bookiibookii.domain.aladin.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "bestseller_isbn")
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class BestsellerIsbn {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 13)
+    private String isbn13;
+
+    @Column(nullable = false)
+    private Integer rank;
+}

--- a/src/main/java/com/example/bookiibookii/domain/aladin/repository/BestsellerIsbnRepository.java
+++ b/src/main/java/com/example/bookiibookii/domain/aladin/repository/BestsellerIsbnRepository.java
@@ -1,0 +1,13 @@
+package com.example.bookiibookii.domain.aladin.repository;
+
+import com.example.bookiibookii.domain.aladin.entity.BestsellerIsbn;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+
+public interface BestsellerIsbnRepository extends JpaRepository<BestsellerIsbn, Long> {
+
+    @Query("SELECT b.isbn13 FROM BestsellerIsbn b ORDER BY b.rank ASC")
+    List<String> findAllIsbn13OrderByRank();
+}

--- a/src/main/java/com/example/bookiibookii/domain/aladin/scheduler/BestsellerScheduler.java
+++ b/src/main/java/com/example/bookiibookii/domain/aladin/scheduler/BestsellerScheduler.java
@@ -1,0 +1,53 @@
+package com.example.bookiibookii.domain.aladin.scheduler;
+
+import com.example.bookiibookii.domain.aladin.config.AladinClient;
+import com.example.bookiibookii.domain.aladin.entity.BestsellerIsbn;
+import com.example.bookiibookii.domain.aladin.repository.BestsellerIsbnRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class BestsellerScheduler {
+
+    private static final int BESTSELLER_LIMIT = 10;
+
+    private final AladinClient aladinClient;
+    private final BestsellerIsbnRepository bestsellerIsbnRepository;
+
+    @Scheduled(cron = "0 0 0 * * MON", zone = "Asia/Seoul")
+    @Transactional
+    public void refreshBestsellers() {
+        log.info("[Scheduler] 베스트셀러 갱신 시작");
+
+        AladinClient.AladinItemSearchResponse response = aladinClient.fetchBestsellers(BESTSELLER_LIMIT);
+
+        if (response == null || response.item() == null || response.item().isEmpty()) {
+            log.warn("[Scheduler] 베스트셀러 응답 없음 — 기존 데이터 유지");
+            return;
+        }
+
+        List<BestsellerIsbn> newList = new ArrayList<>();
+        List<AladinClient.AladinBookItem> items = response.item();
+        for (int i = 0; i < items.size(); i++) {
+            String isbn13 = items.get(i).isbn13();
+            if (isbn13 == null || isbn13.isBlank()) continue;
+            newList.add(BestsellerIsbn.builder()
+                    .isbn13(isbn13)
+                    .rank(i + 1)
+                    .build());
+        }
+
+        bestsellerIsbnRepository.deleteAll();
+        bestsellerIsbnRepository.saveAll(newList);
+
+        log.info("[Scheduler] 베스트셀러 갱신 완료 ({}건)", newList.size());
+    }
+}

--- a/src/main/java/com/example/bookiibookii/domain/group/controller/GroupController.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/controller/GroupController.java
@@ -91,5 +91,13 @@ public class GroupController implements GroupControllerDocs {
         return ApiResponse.onSuccess(GeneralSuccessCode.REQUEST_OK, result);
     }
 
+    //그룹 홈 화면 조회 API
+    @GetMapping("/home")
+    public ApiResponse<GroupResponseDTO.HomeResponseDTO> getHome(
+            @AuthenticationPrincipal(expression = "user") User user) {
+        GroupResponseDTO.HomeResponseDTO result = groupService.getHome(user);
+        return ApiResponse.onSuccess(GeneralSuccessCode.REQUEST_OK, result);
+    }
+
 
 }

--- a/src/main/java/com/example/bookiibookii/domain/group/controller/GroupControllerDocs.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/controller/GroupControllerDocs.java
@@ -102,4 +102,18 @@ public interface GroupControllerDocs {
     })
     ApiResponse<List<String>> getPopularKeywords();
 
+    @Operation(summary = "그룹 홈 화면 조회 API",
+            description = """
+                    그룹 홈 화면의 섹션별 추천 그룹을 한 번에 조회합니다.
+                    - newGroups: 최근 생성된 모집 중 그룹 (최대 5개)
+                    - categorySection: 새로고침마다 랜덤 카테고리 1개를 골라 해당 카테고리 그룹 추천 (최대 9개). 추천 가능한 카테고리가 없으면 category=null
+                    - regionSection: 사용자 교환 장소(구/군) 기반 직접교환 그룹 (최대 15개). 교환 장소 미설정 시 region=null
+                    """)
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "성공")
+    })
+    ApiResponse<GroupResponseDTO.HomeResponseDTO> getHome(
+            @AuthenticationPrincipal User user
+    );
+
 }

--- a/src/main/java/com/example/bookiibookii/domain/group/dto/res/GroupResponseDTO.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/dto/res/GroupResponseDTO.java
@@ -183,10 +183,17 @@ public class GroupResponseDTO {
             List<HomeGroupCardDTO> groups
     ) {}
 
+    /** 섹션3 — 베스트셀러 기반 그룹 추천 */
+    @Builder
+    public record BestsellerSectionDTO(
+            List<HomeGroupCardDTO> groups
+    ) {}
+
     @Builder
     public record HomeResponseDTO(
             List<HomeGroupCardDTO> newGroups,
             CategorySectionDTO categorySection,
+            BestsellerSectionDTO bestsellerSection,
             RegionSectionDTO regionSection
     ) {}
 }

--- a/src/main/java/com/example/bookiibookii/domain/group/dto/res/GroupResponseDTO.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/dto/res/GroupResponseDTO.java
@@ -156,4 +156,37 @@ public class GroupResponseDTO {
             GroupStatus groupStatus,
             List<String> groupTags
     ){}
+
+    // ===== 그룹 홈 화면 (GET /api/groups/home) =====
+
+    /** 홈 화면 전 섹션 공통 그룹 카드 */
+    @Builder
+    public record HomeGroupCardDTO(
+            Long groupId,
+            String groupName,
+            String hostNickname,
+            String bookImage,
+            Integer readingPeriod
+    ) {}
+
+    /** 섹션2 — 카테고리 추천 그룹. category가 null이면 추천 가능한 카테고리 없음 */
+    @Builder
+    public record CategorySectionDTO(
+            String category,
+            List<HomeGroupCardDTO> groups
+    ) {}
+
+    /** 섹션5 — 위치 기반 직접교환 그룹. region이 null이면 사용자 교환 장소 미설정 */
+    @Builder
+    public record RegionSectionDTO(
+            String region,
+            List<HomeGroupCardDTO> groups
+    ) {}
+
+    @Builder
+    public record HomeResponseDTO(
+            List<HomeGroupCardDTO> newGroups,
+            CategorySectionDTO categorySection,
+            RegionSectionDTO regionSection
+    ) {}
 }

--- a/src/main/java/com/example/bookiibookii/domain/group/repository/GroupQueryRepository.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/repository/GroupQueryRepository.java
@@ -184,4 +184,20 @@ public class GroupQueryRepository {
                 .limit(limit)
                 .fetch();
     }
+
+    /** 섹션3 — 베스트셀러 isbn13 목록에 해당하는 모집 중 그룹 (최신순, 본인 호스트 제외) */
+    public List<Groups> findBestsellerGroups(Long userId, List<String> isbn13List) {
+        if (isbn13List == null || isbn13List.isEmpty()) return List.of();
+        return queryFactory
+                .selectFrom(groups)
+                .join(groups.book, book).fetchJoin()
+                .join(groups.host, user).fetchJoin()
+                .where(
+                        groups.groupStatus.eq(GroupStatus.RECRUITING),
+                        groups.host.id.ne(userId),
+                        book.isbn13.in(isbn13List)
+                )
+                .orderBy(groups.createdAt.desc(), groups.groupId.desc())
+                .fetch();
+    }
 }

--- a/src/main/java/com/example/bookiibookii/domain/group/repository/GroupQueryRepository.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/repository/GroupQueryRepository.java
@@ -9,6 +9,7 @@ import com.example.bookiibookii.domain.group.enums.TradeType;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.*;
@@ -119,5 +120,68 @@ public class GroupQueryRepository {
                 new OrderSpecifier<>(Order.DESC, groups.createdAt),
                 new OrderSpecifier<>(Order.DESC, groups.groupId)
         };
+    }
+
+    // ===== 그룹 홈 화면 (GET /api/groups/home) =====
+
+    /** 섹션1 — 최근 생성된 모집 중 그룹 (최신순, 본인 호스트 제외) */
+    public List<Groups> findRecentGroups(Long userId, int limit) {
+        return queryFactory
+                .selectFrom(groups)
+                .join(groups.book, book).fetchJoin()
+                .join(groups.host, user).fetchJoin()
+                .where(
+                        groups.groupStatus.eq(GroupStatus.RECRUITING),
+                        groups.host.id.ne(userId)
+                )
+                .orderBy(groups.createdAt.desc(), groups.groupId.desc())
+                .limit(limit)
+                .fetch();
+    }
+
+    /** 섹션2 — 모집 중 그룹이 1개 이상 존재하는 카테고리 목록 (본인 호스트 제외, 랜덤 추천 후보군) */
+    public List<CustomCategory> findCategoriesWithRecruitingGroups(Long userId) {
+        return queryFactory
+                .select(book.category).distinct()
+                .from(groups)
+                .join(groups.book, book)
+                .where(
+                        groups.groupStatus.eq(GroupStatus.RECRUITING),
+                        groups.host.id.ne(userId)
+                )
+                .fetch();
+    }
+
+    /** 섹션2 — 특정 카테고리의 모집 중 그룹을 랜덤으로 조회 (본인 호스트 제외) */
+    public List<Groups> findRandomGroupsByCategory(Long userId, CustomCategory category, int limit) {
+        return queryFactory
+                .selectFrom(groups)
+                .join(groups.book, book).fetchJoin()
+                .join(groups.host, user).fetchJoin()
+                .where(
+                        groups.groupStatus.eq(GroupStatus.RECRUITING),
+                        groups.host.id.ne(userId),
+                        book.category.eq(category)
+                )
+                .orderBy(Expressions.numberTemplate(Double.class, "function('rand')").asc())
+                .limit(limit)
+                .fetch();
+    }
+
+    /** 섹션5 — 사용자 지역(구/군)에서 열린 직접교환 모집 중 그룹 (최신순, 본인 호스트 제외) */
+    public List<Groups> findRegionGroups(Long userId, String region, int limit) {
+        return queryFactory
+                .selectFrom(groups)
+                .join(groups.book, book).fetchJoin()
+                .join(groups.host, user).fetchJoin()
+                .where(
+                        groups.groupStatus.eq(GroupStatus.RECRUITING),
+                        groups.host.id.ne(userId),
+                        groups.tradeType.eq(TradeType.DIRECT),
+                        groups.preferRegion.contains(region)
+                )
+                .orderBy(groups.createdAt.desc(), groups.groupId.desc())
+                .limit(limit)
+                .fetch();
     }
 }

--- a/src/main/java/com/example/bookiibookii/domain/group/service/GroupService.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/service/GroupService.java
@@ -23,6 +23,7 @@ import com.example.bookiibookii.domain.user.enums.Tag;
 import com.example.bookiibookii.domain.user.exception.UserException;
 import com.example.bookiibookii.domain.user.exception.code.UserErrorCode;
 import com.example.bookiibookii.domain.user.service.BadWordService;
+import com.example.bookiibookii.domain.aladin.repository.BestsellerIsbnRepository;
 import com.example.bookiibookii.domain.user.service.UserImageS3Service;
 import com.example.bookiibookii.domain.groupbook.service.GroupBookService;
 import com.example.bookiibookii.global.util.RedisUtil;
@@ -36,6 +37,7 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
@@ -62,14 +64,15 @@ public class GroupService {
     private final MeetingRepository meetingRepository;
     private final BadWordService badWordService;
     private final UserExchangeRepository userExchangeRepository;
+    private final BestsellerIsbnRepository bestsellerIsbnRepository;
 
     private static final int PRESIGNED_GET_URL_EXPIRATION_MINUTES = 60;
     private static final Set<Tag> READING_STYLE_TAGS = Set.of(Tag.MEMO, Tag.POSTIT, Tag.PHOTO, Tag.All_ROUNDER);
 
     // 그룹 홈 화면 섹션별 노출 개수
-    private static final int HOME_NEW_GROUP_LIMIT = 5;       // 섹션1: 신규 그룹
-    private static final int HOME_CATEGORY_GROUP_LIMIT = 9;  // 섹션2: 카테고리 추천 (3개씩 3페이지)
-    private static final int HOME_REGION_GROUP_LIMIT = 15;   // 섹션5: 위치 기반 (3개씩 5페이지)
+    private static final int HOME_NEW_GROUP_LIMIT = 5;            // 섹션1: 신규 그룹
+    private static final int HOME_CATEGORY_GROUP_LIMIT = 9;       // 섹션2: 카테고리 추천 (3개씩 3페이지)
+    private static final int HOME_REGION_GROUP_LIMIT = 15;        // 섹션5: 위치 기반 (3개씩 5페이지)
 
     //그룹생성 service
     public GroupResponseDTO.CreateResultDTO createGroup(User host, GroupRequestDTO.CreateDTO request){
@@ -590,12 +593,16 @@ public class GroupService {
         // 섹션2: 카테고리 추천 그룹 (본인 호스트 제외)
         GroupResponseDTO.CategorySectionDTO categorySection = buildCategorySection(userId);
 
+        // 섹션3: 베스트셀러 기반 그룹 추천
+        GroupResponseDTO.BestsellerSectionDTO bestsellerSection = buildBestsellerSection(userId);
+
         // 섹션5: 위치 기반 그룹 (본인 호스트 제외)
         GroupResponseDTO.RegionSectionDTO regionSection = buildRegionSection(userId);
 
         return GroupResponseDTO.HomeResponseDTO.builder()
                 .newGroups(newGroups)
                 .categorySection(categorySection)
+                .bestsellerSection(bestsellerSection)
                 .regionSection(regionSection)
                 .build();
     }
@@ -619,6 +626,34 @@ public class GroupService {
                 .category(picked.getLabel())
                 .groups(groups)
                 .build();
+    }
+
+    // 섹션3: 베스트셀러 순위 순서대로, 책 1권당 그룹 1개씩 노출
+    private GroupResponseDTO.BestsellerSectionDTO buildBestsellerSection(Long userId) {
+        List<String> isbn13List = bestsellerIsbnRepository.findAllIsbn13OrderByRank();
+        if (isbn13List.isEmpty()) {
+            return GroupResponseDTO.BestsellerSectionDTO.builder().groups(List.of()).build();
+        }
+
+        // isbn13별로 그룹 묶은 뒤 각 책에서 랜덤 1개 선택 (새로고침마다 다른 그룹 노출)
+        Map<String, List<Groups>> grouped = groupQueryRepository.findBestsellerGroups(userId, isbn13List)
+                .stream()
+                .collect(Collectors.groupingBy(g -> g.getBook().getIsbn13()));
+
+        Map<String, Groups> groupByIsbn = grouped.entrySet().stream()
+                .collect(Collectors.toMap(
+                        Map.Entry::getKey,
+                        e -> e.getValue().get(ThreadLocalRandom.current().nextInt(e.getValue().size()))
+                ));
+
+        // 베스트셀러 순위 순서 유지하며 카드 조립
+        List<GroupResponseDTO.HomeGroupCardDTO> cards = isbn13List.stream()
+                .map(groupByIsbn::get)
+                .filter(Objects::nonNull)
+                .map(this::toHomeCard)
+                .toList();
+
+        return GroupResponseDTO.BestsellerSectionDTO.builder().groups(cards).build();
     }
 
     // 섹션5: 사용자 교환 장소(구/군)에서 열린 직접교환 그룹을 추천

--- a/src/main/java/com/example/bookiibookii/domain/group/service/GroupService.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/service/GroupService.java
@@ -1,7 +1,10 @@
 package com.example.bookiibookii.domain.group.service;
 
 import com.example.bookiibookii.domain.book.entity.Book;
+import com.example.bookiibookii.domain.book.enums.CustomCategory;
 import com.example.bookiibookii.domain.book.service.BookService;
+import com.example.bookiibookii.domain.location.entity.UserExchange;
+import com.example.bookiibookii.domain.location.repository.UserExchangeRepository;
 import com.example.bookiibookii.domain.group.dto.RuleDTO;
 import com.example.bookiibookii.domain.group.dto.req.GroupRequestDTO;
 import com.example.bookiibookii.domain.group.dto.res.GroupResponseDTO;
@@ -35,6 +38,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 
 import static com.example.bookiibookii.domain.group.enums.GroupNotiType.GROUP_DELETED;
@@ -57,9 +61,15 @@ public class GroupService {
     private final RedisUtil redisUtil;
     private final MeetingRepository meetingRepository;
     private final BadWordService badWordService;
+    private final UserExchangeRepository userExchangeRepository;
 
     private static final int PRESIGNED_GET_URL_EXPIRATION_MINUTES = 60;
     private static final Set<Tag> READING_STYLE_TAGS = Set.of(Tag.MEMO, Tag.POSTIT, Tag.PHOTO, Tag.All_ROUNDER);
+
+    // 그룹 홈 화면 섹션별 노출 개수
+    private static final int HOME_NEW_GROUP_LIMIT = 5;       // 섹션1: 신규 그룹
+    private static final int HOME_CATEGORY_GROUP_LIMIT = 9;  // 섹션2: 카테고리 추천 (3개씩 3페이지)
+    private static final int HOME_REGION_GROUP_LIMIT = 15;   // 섹션5: 위치 기반 (3개씩 5페이지)
 
     //그룹생성 service
     public GroupResponseDTO.CreateResultDTO createGroup(User host, GroupRequestDTO.CreateDTO request){
@@ -562,6 +572,99 @@ public class GroupService {
 
         // 현재 user를 제외한 나머지 멤버 조회
         return matchedMemberQueryRepository.findMemberDtosByGroupId(groupId, userId);
+    }
+
+    // ===== 그룹 홈 화면 조회 =====
+    @Transactional(readOnly = true)
+    public GroupResponseDTO.HomeResponseDTO getHome(User user) {
+        if (user == null) {
+            throw new UserException(UserErrorCode.NOT_FOUND);
+        }
+
+        Long userId = user.getId();
+
+        // 섹션1: 최근 생성된 그룹 (본인 호스트 제외)
+        List<GroupResponseDTO.HomeGroupCardDTO> newGroups = groupQueryRepository.findRecentGroups(userId, HOME_NEW_GROUP_LIMIT)
+                .stream().map(this::toHomeCard).toList();
+
+        // 섹션2: 카테고리 추천 그룹 (본인 호스트 제외)
+        GroupResponseDTO.CategorySectionDTO categorySection = buildCategorySection(userId);
+
+        // 섹션5: 위치 기반 그룹 (본인 호스트 제외)
+        GroupResponseDTO.RegionSectionDTO regionSection = buildRegionSection(userId);
+
+        return GroupResponseDTO.HomeResponseDTO.builder()
+                .newGroups(newGroups)
+                .categorySection(categorySection)
+                .regionSection(regionSection)
+                .build();
+    }
+
+    // 섹션2: 그룹이 존재하는 카테고리 중 랜덤 1개를 골라 해당 카테고리 그룹을 추천
+    private GroupResponseDTO.CategorySectionDTO buildCategorySection(Long userId) {
+        List<CustomCategory> candidates = groupQueryRepository.findCategoriesWithRecruitingGroups(userId);
+        if (candidates.isEmpty()) {
+            return GroupResponseDTO.CategorySectionDTO.builder()
+                    .category(null)
+                    .groups(List.of())
+                    .build();
+        }
+
+        CustomCategory picked = candidates.get(ThreadLocalRandom.current().nextInt(candidates.size()));
+        List<GroupResponseDTO.HomeGroupCardDTO> groups =
+                groupQueryRepository.findRandomGroupsByCategory(userId, picked, HOME_CATEGORY_GROUP_LIMIT)
+                        .stream().map(this::toHomeCard).toList();
+
+        return GroupResponseDTO.CategorySectionDTO.builder()
+                .category(picked.getLabel())
+                .groups(groups)
+                .build();
+    }
+
+    // 섹션5: 사용자 교환 장소(구/군)에서 열린 직접교환 그룹을 추천
+    private GroupResponseDTO.RegionSectionDTO buildRegionSection(Long userId) {
+        List<UserExchange> exchanges = userExchangeRepository.findByUserIdWithLocation(userId);
+        String district = exchanges.isEmpty() ? null
+                : extractDistrict(exchanges.get(0).getLocation().getAddress());
+
+        if (district == null) {
+            return GroupResponseDTO.RegionSectionDTO.builder()
+                    .region(null)
+                    .groups(List.of())
+                    .build();
+        }
+
+        List<GroupResponseDTO.HomeGroupCardDTO> groups =
+                groupQueryRepository.findRegionGroups(userId, district, HOME_REGION_GROUP_LIMIT)
+                        .stream().map(this::toHomeCard).toList();
+
+        return GroupResponseDTO.RegionSectionDTO.builder()
+                .region(district)
+                .groups(groups)
+                .build();
+    }
+
+    // 주소 문자열에서 구/군 토큰 추출 (예: "서울특별시 동작구 흑석로 84" -> "동작구")
+    private String extractDistrict(String address) {
+        if (address == null || address.isBlank()) {
+            return null;
+        }
+        for (String token : address.trim().split("\\s+")) {
+            if (token.endsWith("구") || token.endsWith("군")) {
+                return token;
+            }
+        }
+        return null;
+    }
+
+    private GroupResponseDTO.HomeGroupCardDTO toHomeCard(Groups group) {
+        return GroupResponseDTO.HomeGroupCardDTO.builder()
+                .groupId(group.getGroupId())
+                .groupName(group.getGroupName())
+                .hostNickname(group.getHost().getNickName())
+                .bookImage(group.getBook().getImage())
+                .readingPeriod(group.getReadingPeriod())
+                .build();
     }
 }
 


### PR DESCRIPTION
## 개요
 closes #455 
변경 사항
- GET /api/groups/home 엔드포인트 추가. 그룹 홈 화면에서 사용할 섹션별 추천 그룹을 한 번에 반환한다.
  
   - 섹션1 newGroups — 최근 생성된 모집 중 그룹 최대 5개를 최신순으로 반환.
   - 섹션2 categorySection — 현재 모집 중 그룹이 존재하는 카테고리 중 랜덤 1개를 선택해 해당 카테고리 그룹을 최대 9개 랜덤으로 반환. 호출마다 다른 카테고리가 노출된다.
   - 섹션4 regionSection — 사용자의 UserExchange 교환 장소에서 구/군을 추출해, 해당 지역의 직접교환(DIRECT) 모집 중 그룹을 최대 15개 반환. 교환 장소 미설정 시 region null, 빈 리스트 반환.

  전 섹션 공통으로 본인이 호스트인 그룹은 제외
  베스트셀러 기반 섹션 미구현
<!---- Resolves: #(Isuue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

📣 **To Reviewers**
---
<!-- 전달사항 -->

- Reviewers : 팀 선택
- Labels : 작업 유형, 자기 자신


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 그룹 홈 화면 조회 추가: 신규 그룹, 카테고리 추천, 베스트셀러 기반 추천, 지역별 추천 섹션 제공.
  * 베스트셀러 기반 추천 추가 및 매주 자동 갱신 스케줄러 도입.
  * 사용자의 교환 장소 정보를 활용한 지역 맞춤 그룹 추천 제공.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bookiibookii/bookiibookii-server/pull/456?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->