### PR TITLE
[Chore]#507 Discord 웹훅 서버 에러 알림 연동

### DIFF
--- a/src/main/java/com/example/bookiibookii/BookiibookiiApplication.java
+++ b/src/main/java/com/example/bookiibookii/BookiibookiiApplication.java
@@ -1,6 +1,7 @@
 package com.example.bookiibookii;
 
 import com.example.bookiibookii.global.aws.AwsS3Properties;
+import com.example.bookiibookii.global.notification.DiscordWebhookProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -10,7 +11,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @SpringBootApplication
 @EnableJpaAuditing
 @EnableScheduling
-@EnableConfigurationProperties(AwsS3Properties.class)
+@EnableConfigurationProperties({AwsS3Properties.class, DiscordWebhookProperties.class})
 public class BookiibookiiApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/example/bookiibookii/global/apiPayload/handler/GeneralExceptionAdvice.java
+++ b/src/main/java/com/example/bookiibookii/global/apiPayload/handler/GeneralExceptionAdvice.java
@@ -4,6 +4,9 @@ import com.example.bookiibookii.global.apiPayload.ApiResponse;
 import com.example.bookiibookii.global.apiPayload.code.BaseCode;
 import com.example.bookiibookii.global.apiPayload.code.GeneralErrorCode;
 import com.example.bookiibookii.global.apiPayload.exception.GeneralException;
+import com.example.bookiibookii.global.notification.DiscordWebhookService;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -17,7 +20,10 @@ import java.util.List;
 
 @Slf4j
 @RestControllerAdvice
+@RequiredArgsConstructor
 public class GeneralExceptionAdvice {
+
+    private final DiscordWebhookService discordWebhookService;
 
     // 서비스 로직에서 의도적으로 발생시키는 예외
     // GeneralException을 상속한 모든 커스텀 예외 처리
@@ -38,8 +44,11 @@ public class GeneralExceptionAdvice {
     // 예상하지 못한 서버 예외 처리
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiResponse<String>> handleException(
-            Exception ex
+            Exception ex,
+            HttpServletRequest request
     ) {
+        discordWebhookService.sendUnexpectedExceptionAlert(request, ex);
+
         log.error("Unexpected exception occurred: {}", ex.getMessage(), ex);
         BaseCode code = GeneralErrorCode.INTERNAL_SERVER_ERROR;
         return ResponseEntity.status(code.getStatus())

--- a/src/main/java/com/example/bookiibookii/global/config/RestClientConfig.java
+++ b/src/main/java/com/example/bookiibookii/global/config/RestClientConfig.java
@@ -1,0 +1,21 @@
+package com.example.bookiibookii.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+public class RestClientConfig {
+
+    @Bean
+    public RestClient discordWebhookRestClient() {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(3000);
+        factory.setReadTimeout(5000);
+
+        return RestClient.builder()
+                .requestFactory(factory)
+                .build();
+    }
+}

--- a/src/main/java/com/example/bookiibookii/global/notification/DiscordWebhookProperties.java
+++ b/src/main/java/com/example/bookiibookii/global/notification/DiscordWebhookProperties.java
@@ -1,0 +1,9 @@
+package com.example.bookiibookii.global.notification;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "discord.webhook")
+public record DiscordWebhookProperties(
+        boolean enabled,
+        String url
+) {}

--- a/src/main/java/com/example/bookiibookii/global/notification/DiscordWebhookRequest.java
+++ b/src/main/java/com/example/bookiibookii/global/notification/DiscordWebhookRequest.java
@@ -1,0 +1,5 @@
+package com.example.bookiibookii.global.notification;
+
+public record DiscordWebhookRequest(
+        String content
+) {}

--- a/src/main/java/com/example/bookiibookii/global/notification/DiscordWebhookService.java
+++ b/src/main/java/com/example/bookiibookii/global/notification/DiscordWebhookService.java
@@ -1,0 +1,126 @@
+package com.example.bookiibookii.global.notification;
+
+import com.example.bookiibookii.domain.user.entity.User;
+import com.example.bookiibookii.global.auth.CustomUserDetails;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.servlet.HandlerMapping;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DiscordWebhookService {
+
+    private static final int DISCORD_CONTENT_LIMIT = 1900;
+    private static final Pattern PHONE_NUMBER_PATTERN = Pattern.compile("\\b\\d{2,3}[-. ]?\\d{3,4}[-. ]?\\d{4}\\b");
+    private static final Pattern SENSITIVE_KEY_VALUE_PATTERN = Pattern.compile(
+            "(?i)(address|phone|receiver|recipient|recipientName|trackingNumber|invoiceNo|waybill|운송장번호|운송장|주소|전화번호|수령인)\\s*[:=]\\s*[^,\\n\\r}]+"
+    );
+
+    private final DiscordWebhookProperties properties;
+    private final RestClient restClient = RestClient.create();
+
+    public void sendUnexpectedExceptionAlert(HttpServletRequest request, Exception exception) {
+        if (!properties.enabled() || properties.url() == null || properties.url().isBlank()) {
+            return;
+        }
+
+        try {
+            restClient.post()
+                    .uri(properties.url())
+                    .body(new DiscordWebhookRequest(createMessage(request, exception)))
+                    .retrieve()
+                    .toBodilessEntity();
+        } catch (Exception e) {
+            // 웹훅 실패가 500 으로 이어지지 않도록 삼킴
+            log.warn("Discord webhook alert failed", e);
+        }
+    }
+
+    String createMessage(HttpServletRequest request, Exception exception) {
+        String groupId = extractGroupId(request).map(String::valueOf).orElse("unknown");
+        String userId = extractUserId().map(String::valueOf).orElse("anonymous");
+        String message = sanitize(exception.getMessage());
+        String uri = sanitize(request.getRequestURI());
+
+        String content = """
+                [Unexpected Server Error]
+                method: %s
+                uri: %s
+                exception: %s
+                message: %s
+                userId: %s
+                groupId: %s
+                """.formatted(
+                request.getMethod(),
+                uri == null || uri.isBlank() ? "unknown" : uri,
+                exception.getClass().getName(),
+                message == null || message.isBlank() ? "(empty)" : message,
+                userId,
+                groupId
+        );
+
+        return truncate(content);
+    }
+
+    private Optional<Long> extractUserId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return Optional.empty();
+        }
+
+        Object principal = authentication.getPrincipal();
+        if (principal instanceof CustomUserDetails customUserDetails) {
+            return Optional.ofNullable(customUserDetails.getUser())
+                    .map(User::getId);
+        }
+        if (principal instanceof User user) {
+            return Optional.ofNullable(user.getId());
+        }
+
+        return Optional.empty();
+    }
+
+    private Optional<Long> extractGroupId(HttpServletRequest request) {
+        Object attribute = request.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE);
+        if (!(attribute instanceof Map<?, ?> pathVariables)) {
+            return Optional.empty();
+        }
+
+        Object groupId = pathVariables.get("groupId");
+        if (groupId == null) {
+            return Optional.empty();
+        }
+
+        try {
+            return Optional.of(Long.parseLong(groupId.toString()));
+        } catch (NumberFormatException e) {
+            return Optional.empty();
+        }
+    }
+
+    private String sanitize(String value) {
+        if (value == null) {
+            return null;
+        }
+
+        String masked = PHONE_NUMBER_PATTERN.matcher(value).replaceAll("[masked-phone]");
+        return SENSITIVE_KEY_VALUE_PATTERN.matcher(masked).replaceAll("$1=[masked]");
+    }
+
+    private String truncate(String content) {
+        if (content.length() <= DISCORD_CONTENT_LIMIT) {
+            return content;
+        }
+        return content.substring(0, DISCORD_CONTENT_LIMIT) + "...(truncated)";
+    }
+}

--- a/src/main/java/com/example/bookiibookii/global/notification/DiscordWebhookService.java
+++ b/src/main/java/com/example/bookiibookii/global/notification/DiscordWebhookService.java
@@ -27,7 +27,7 @@ public class DiscordWebhookService {
     );
 
     private final DiscordWebhookProperties properties;
-    private final RestClient restClient = RestClient.create();
+    private final RestClient discordWebhookRestClient;
 
     public void sendUnexpectedExceptionAlert(HttpServletRequest request, Exception exception) {
         if (!properties.enabled() || properties.url() == null || properties.url().isBlank()) {
@@ -35,7 +35,7 @@ public class DiscordWebhookService {
         }
 
         try {
-            restClient.post()
+            discordWebhookRestClient.post()
                     .uri(properties.url())
                     .body(new DiscordWebhookRequest(createMessage(request, exception)))
                     .retrieve()

--- a/src/main/resources/application-v1.yml
+++ b/src/main/resources/application-v1.yml
@@ -53,3 +53,8 @@ aws:
 
 server:
   forward-headers-strategy: framework
+
+discord:
+  webhook:
+    enabled: true
+    url: ${DISCORD_WEBHOOK_URL}

--- a/src/main/resources/application-v1.yml
+++ b/src/main/resources/application-v1.yml
@@ -56,5 +56,5 @@ server:
 
 discord:
   webhook:
-    enabled: true
+    enabled: ${DISCORD_WEBHOOK_ENABLED:false}
     url: ${DISCORD_WEBHOOK_URL}


### PR DESCRIPTION
## 개요
<!---- 자신이 완료한 이슈를 닫아주세요 -->
- closed #507 
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- Discord 웹훅을 이용한 서버 에러 알림 기능을 추가했습니다.
- 서버에서 예상하지 못한 500 에러가 발생했을 때 지정된 Discord 채널로 알림을 전송하도록 구성했습니다.
- 웹훅 URL은 환경변수로 관리하도록 설정했습니다.

<!---- Resolves: #(Isuue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

📣 **To Reviewers**
---
<!-- 전달사항 -->

- Reviewers : 팀 선택
- Labels : 작업 유형, 자기 자신


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* Discord 웹훅 통합을 추가하여 예상치 못한 서버 에러 발생 시 실시간 알림을 수신할 수 있도록 개선했습니다. 민감 정보는 자동으로 마스킹되며, 웹훅 전송 실패는 사용자 경험에 영향을 주지 않습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bookiibookii/bookiibookii-server/pull/508?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->