### PR TITLE
[Fix]#514 RETURNED 추가 및 displayStatus 계산 로직 수정

### DIFF
--- a/src/main/java/com/example/bookiibookii/domain/tracker/enums/ReadingStatus.java
+++ b/src/main/java/com/example/bookiibookii/domain/tracker/enums/ReadingStatus.java
@@ -14,6 +14,7 @@ public enum ReadingStatus {
     PARTNER_BOOK_READING("파트너 책 읽는 중"),
     PARTNER_BOOK_REVIEWING("2차 독서 완료, 후기 작성 중"),
     RETURNING("파트너 책 후기 작성 완료, 2차 교환(반납) 진행 중"),
+    RETURNED("2차 교환(반납) 완료"),
     COMPLETED("릴레이 종료");
 
     private final String description;

--- a/src/main/java/com/example/bookiibookii/domain/tracker/resolver/TrackerDisplayStatusResolver.java
+++ b/src/main/java/com/example/bookiibookii/domain/tracker/resolver/TrackerDisplayStatusResolver.java
@@ -31,6 +31,9 @@ public class TrackerDisplayStatusResolver {
             case RETURNING ->
                     resolveReturnExchangeStatus(exchangeStatus, tradeType);
 
+            case RETURNED ->
+                    TrackerDisplayStatus.EXCHANGE_REVIEW_WRITING;
+
             case EXCHANGED ->
                     TrackerDisplayStatus.READING;
 
@@ -80,13 +83,13 @@ public class TrackerDisplayStatusResolver {
     ) {
         if (tradeType == TradeType.DELIVERY) {
             return switch (safeExchangeStatus(exchangeStatus)) {
-                case TRACKING_REGISTER_WAITING, NOT_STARTED ->
+                case TRACKING_REGISTER_WAITING ->
                         TrackerDisplayStatus.RETURN_TRACKING_REQUIRED;
 
                 case TRACKING_REGISTERED ->
                         TrackerDisplayStatus.RETURNING;
 
-                case RECEIVED_CONFIRMED ->
+                case RECEIVED_CONFIRMED, NOT_STARTED ->
                         TrackerDisplayStatus.EXCHANGE_REVIEW_WRITING;
 
                 default ->
@@ -98,6 +101,9 @@ public class TrackerDisplayStatusResolver {
 
             case MEETING_SCHEDULED, MEETING_COMPLETED ->
                     TrackerDisplayStatus.RETURNING;
+
+            case NOT_STARTED ->
+                    TrackerDisplayStatus.EXCHANGE_REVIEW_WRITING;
 
             default ->
                     TrackerDisplayStatus.MEETING_REQUIRED;

--- a/src/main/java/com/example/bookiibookii/domain/tracker/resolver/TrackerStepAssembler.java
+++ b/src/main/java/com/example/bookiibookii/domain/tracker/resolver/TrackerStepAssembler.java
@@ -32,7 +32,7 @@ public class TrackerStepAssembler {
                         .status(step.status())
                         .title(step.title())
                         .description(step.description())
-                        .completed(isCompleted(currentStatus, exchangeStatus, step.status()))
+                        .completed(isCompleted(currentStatus, exchangeStatus, step.status(), tradeType))
                         .build())
                 .toList();
     }
@@ -73,6 +73,11 @@ public class TrackerStepAssembler {
                         ReadingStatus.RETURNING,
                         "2차 교환하기",
                         "파트너에게 " + partnerBookTitle + "을 발송해주세요"
+                ),
+                step(
+                        ReadingStatus.RETURNED,
+                        "수령 인증 등록",
+                        "파트너가 보낸 책 상태를 확인해주세요"
                 ),
                 step(
                         ReadingStatus.COMPLETED,
@@ -120,6 +125,11 @@ public class TrackerStepAssembler {
                         "파트너와 논의 후 약속을 확정해주세요"
                 ),
                 step(
+                        ReadingStatus.RETURNED,
+                        "교환 인증 등록",
+                        "반드시 파트너와 책을 실제로 교환한 뒤 진행해주세요"
+                ),
+                step(
                         ReadingStatus.COMPLETED,
                         "교환독서 종료",
                         "소중한 교환 후기를 남겨주세요"
@@ -136,13 +146,76 @@ public class TrackerStepAssembler {
                 .build();
     }
 
-    private boolean isCompleted(ReadingStatus currentStatus, ExchangeStatus exchangeStatus, ReadingStatus stepStatus) {
-        if (stepStatus == ReadingStatus.RETURNING
-                && currentStatus == ReadingStatus.RETURNING
-                && exchangeStatus == ExchangeStatus.NOT_STARTED) {
+    private boolean isCompleted(
+            ReadingStatus currentStatus,
+            ExchangeStatus exchangeStatus,
+            ReadingStatus stepStatus,
+            TradeType tradeType
+    ) {
+        if (currentStatus == ReadingStatus.COMPLETED) {
             return true;
         }
+        if (currentStatus == ReadingStatus.EXCHANGING) {
+            return isFirstExchangeStepCompleted(exchangeStatus, stepStatus, tradeType);
+        }
+        if (currentStatus == ReadingStatus.RETURNING) {
+            return isReturnExchangeStepCompleted(exchangeStatus, stepStatus, tradeType);
+        }
         return resolveOrder(currentStatus) > resolveOrder(stepStatus);
+    }
+
+    private boolean isFirstExchangeStepCompleted(
+            ExchangeStatus exchangeStatus,
+            ReadingStatus stepStatus,
+            TradeType tradeType
+    ) {
+        if (stepStatus == ReadingStatus.EXCHANGING) {
+            return tradeType == TradeType.DELIVERY
+                    ? isTrackingRegistered(exchangeStatus)
+                    : isMeetingScheduled(exchangeStatus);
+        }
+        if (stepStatus == ReadingStatus.EXCHANGED) {
+            return tradeType == TradeType.DELIVERY
+                    ? isReceivedConfirmed(exchangeStatus)
+                    : isMeetingCompleted(exchangeStatus);
+        }
+        return resolveOrder(ReadingStatus.EXCHANGING) > resolveOrder(stepStatus);
+    }
+
+    private boolean isReturnExchangeStepCompleted(
+            ExchangeStatus exchangeStatus,
+            ReadingStatus stepStatus,
+            TradeType tradeType
+    ) {
+        if (stepStatus == ReadingStatus.RETURNING) {
+            return tradeType == TradeType.DELIVERY
+                    ? isTrackingRegistered(exchangeStatus) || exchangeStatus == ExchangeStatus.NOT_STARTED
+                    : isMeetingScheduled(exchangeStatus) || exchangeStatus == ExchangeStatus.NOT_STARTED;
+        }
+        if (stepStatus == ReadingStatus.RETURNED) {
+            return tradeType == TradeType.DELIVERY
+                    ? isReceivedConfirmed(exchangeStatus) || exchangeStatus == ExchangeStatus.NOT_STARTED
+                    : isMeetingCompleted(exchangeStatus) || exchangeStatus == ExchangeStatus.NOT_STARTED;
+        }
+        return resolveOrder(ReadingStatus.RETURNING) > resolveOrder(stepStatus);
+    }
+
+    private boolean isTrackingRegistered(ExchangeStatus exchangeStatus) {
+        return exchangeStatus == ExchangeStatus.TRACKING_REGISTERED
+                || exchangeStatus == ExchangeStatus.RECEIVED_CONFIRMED;
+    }
+
+    private boolean isReceivedConfirmed(ExchangeStatus exchangeStatus) {
+        return exchangeStatus == ExchangeStatus.RECEIVED_CONFIRMED;
+    }
+
+    private boolean isMeetingScheduled(ExchangeStatus exchangeStatus) {
+        return exchangeStatus == ExchangeStatus.MEETING_SCHEDULED
+                || exchangeStatus == ExchangeStatus.MEETING_COMPLETED;
+    }
+
+    private boolean isMeetingCompleted(ExchangeStatus exchangeStatus) {
+        return exchangeStatus == ExchangeStatus.MEETING_COMPLETED;
     }
 
     private int resolveOrder(ReadingStatus status) {
@@ -154,7 +227,8 @@ public class TrackerStepAssembler {
             case PARTNER_BOOK_READING -> 5;
             case PARTNER_BOOK_REVIEWING -> 6;
             case RETURNING -> 7;
-            case COMPLETED -> 8;
+            case RETURNED -> 8;
+            case COMPLETED -> 9;
         };
     }
 

--- a/src/main/java/com/example/bookiibookii/domain/tracker/resolver/TrackerStepAssembler.java
+++ b/src/main/java/com/example/bookiibookii/domain/tracker/resolver/TrackerStepAssembler.java
@@ -189,13 +189,13 @@ public class TrackerStepAssembler {
     ) {
         if (stepStatus == ReadingStatus.RETURNING) {
             return tradeType == TradeType.DELIVERY
-                    ? isTrackingRegistered(exchangeStatus) || exchangeStatus == ExchangeStatus.NOT_STARTED
-                    : isMeetingScheduled(exchangeStatus) || exchangeStatus == ExchangeStatus.NOT_STARTED;
+                    ? isTrackingRegistered(exchangeStatus)
+                    : isMeetingScheduled(exchangeStatus);
         }
         if (stepStatus == ReadingStatus.RETURNED) {
             return tradeType == TradeType.DELIVERY
-                    ? isReceivedConfirmed(exchangeStatus) || exchangeStatus == ExchangeStatus.NOT_STARTED
-                    : isMeetingCompleted(exchangeStatus) || exchangeStatus == ExchangeStatus.NOT_STARTED;
+                    ? isReceivedConfirmed(exchangeStatus)
+                    : isMeetingCompleted(exchangeStatus);
         }
         return resolveOrder(ReadingStatus.RETURNING) > resolveOrder(stepStatus);
     }


### PR DESCRIPTION
## 개요
<!---- 자신이 완료한 이슈를 닫아주세요 -->
- closed #514 
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 2차 교환 단계에서 2차 교환 시작과 파트너 리뷰 작성 사이의 누락된 단계를 추가했습니다. 
- 1차 교환의 EXCHANGING -> EXCHANGED 흐름과 상응하도록 
2차 교환도 RETURNING -> RETURNED -> COMPLETED 흐름으로 내려가도록 수정했습니다.
- 새로 추가된 RETURNED 단계에 맞춰 상태 변경 로직과 displayStatus 조립 로직을 수정했습니다.

<!---- Resolves: #(Isuue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

📣 **To Reviewers**
---
<!-- 전달사항 -->

- Reviewers : 팀 선택
- Labels : 작업 유형, 자기 자신


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 반납 완료 상태가 추가되어(2차 교환/반납 완료) 책의 추적 상태가 더 자세히 표시됩니다.
  * 배송·직거래별로 구분된 단계(수령 인증/교환 인증 등)가 추가되어 진행 단계가 명확해졌습니다.

* **버그 수정 / 개선**
  * 단계 완료 판단 로직이 개선되어 교환·반납 흐름에서 단계 표시와 진행률이 보다 정확하게 반영됩니다.
  * 반납 관련 표시가 리뷰 작성 단계로 일관되게 전환되도록 조정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->