### PR TITLE
[Feat]#516 서재 내 후기 관련 API 제작

### DIFF
--- a/src/main/java/com/example/bookiibookii/domain/review/controller/BookReviewController.java
+++ b/src/main/java/com/example/bookiibookii/domain/review/controller/BookReviewController.java
@@ -2,6 +2,7 @@ package com.example.bookiibookii.domain.review.controller;
 
 import com.example.bookiibookii.domain.review.dto.req.ReviewRequestDTO;
 import com.example.bookiibookii.domain.review.dto.res.BookReviewResponseDTO;
+import com.example.bookiibookii.domain.review.dto.res.GroupReviewsResponseDTO;
 import com.example.bookiibookii.domain.review.exception.code.ReviewSuccessCode;
 import com.example.bookiibookii.domain.review.service.ReviewService;
 import com.example.bookiibookii.domain.user.entity.User;
@@ -9,6 +10,7 @@ import com.example.bookiibookii.global.apiPayload.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -22,6 +24,15 @@ import org.springframework.web.bind.annotation.RestController;
 public class BookReviewController implements BookReviewControllerDocs {
 
     private final ReviewService reviewService;
+
+    @GetMapping
+    public ApiResponse<GroupReviewsResponseDTO> getGroupReviews(
+            @PathVariable Long groupId,
+            @AuthenticationPrincipal(expression = "user") User user
+    ) {
+        GroupReviewsResponseDTO response = reviewService.getGroupReviews(groupId, user);
+        return ApiResponse.onSuccess(ReviewSuccessCode.GROUP_REVIEWS_FOUND, response);
+    }
 
     @PostMapping
     public ApiResponse<BookReviewResponseDTO> createBookReview(

--- a/src/main/java/com/example/bookiibookii/domain/review/controller/BookReviewController.java
+++ b/src/main/java/com/example/bookiibookii/domain/review/controller/BookReviewController.java
@@ -3,6 +3,7 @@ package com.example.bookiibookii.domain.review.controller;
 import com.example.bookiibookii.domain.review.dto.req.ReviewRequestDTO;
 import com.example.bookiibookii.domain.review.dto.res.BookReviewResponseDTO;
 import com.example.bookiibookii.domain.review.dto.res.GroupReviewsResponseDTO;
+import com.example.bookiibookii.domain.review.dto.res.MyGroupReviewsResponseDTO;
 import com.example.bookiibookii.domain.review.exception.code.ReviewSuccessCode;
 import com.example.bookiibookii.domain.review.service.ReviewService;
 import com.example.bookiibookii.domain.user.entity.User;
@@ -52,5 +53,15 @@ public class BookReviewController implements BookReviewControllerDocs {
     ) {
         BookReviewResponseDTO response = reviewService.updateMyBookReview(groupId, request, user);
         return ApiResponse.onSuccess(ReviewSuccessCode.BOOK_REVIEW_UPDATED, response);
+    }
+
+    @PatchMapping("/my-group")
+    public ApiResponse<MyGroupReviewsResponseDTO> updateMyGroupReviews(
+            @PathVariable Long groupId,
+            @RequestBody @Valid ReviewRequestDTO.MyGroupReviewsUpdateDTO request,
+            @AuthenticationPrincipal(expression = "user") User user
+    ) {
+        MyGroupReviewsResponseDTO response = reviewService.updateMyGroupReviews(groupId, request, user);
+        return ApiResponse.onSuccess(ReviewSuccessCode.MY_GROUP_REVIEWS_UPDATED, response);
     }
 }

--- a/src/main/java/com/example/bookiibookii/domain/review/controller/BookReviewControllerDocs.java
+++ b/src/main/java/com/example/bookiibookii/domain/review/controller/BookReviewControllerDocs.java
@@ -34,7 +34,7 @@ public interface BookReviewControllerDocs {
             - 그룹 멤버만 조회할 수 있습니다.
             - groupStatus가 COMPLETED인 그룹만 조회할 수 있습니다.
             - bookReviews: 그룹 내 모든 책 리뷰(책 정보, 작성자 정보, 별점, 내용, 작성 일자)
-            - memberReviews: 서로가 서로에게 남긴 파트너 리뷰(그룹명, 독서 기간, 작성자 정보, 코멘트)
+            - memberReviews: 서로가 서로에게 남긴 파트너 리뷰(그룹명, 독서 기간, 작성자 정보, reaction, 코멘트)
             """
     )
     @ApiResponses({

--- a/src/main/java/com/example/bookiibookii/domain/review/controller/BookReviewControllerDocs.java
+++ b/src/main/java/com/example/bookiibookii/domain/review/controller/BookReviewControllerDocs.java
@@ -2,6 +2,7 @@ package com.example.bookiibookii.domain.review.controller;
 
 import com.example.bookiibookii.domain.review.dto.req.ReviewRequestDTO;
 import com.example.bookiibookii.domain.review.dto.res.BookReviewResponseDTO;
+import com.example.bookiibookii.domain.review.dto.res.GroupReviewsResponseDTO;
 import com.example.bookiibookii.domain.user.entity.User;
 import com.example.bookiibookii.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -13,6 +14,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -22,6 +24,33 @@ import org.springframework.web.bind.annotation.RequestMapping;
 @Tag(name = "BookReview", description = "책 리뷰 및 독서카드 관련 API")
 @RequestMapping("/api/groups/{groupId}/reviews")
 public interface BookReviewControllerDocs {
+
+    @GetMapping
+    @Operation(
+            summary = "그룹 리뷰 조회",
+            description = """
+            그룹에 작성된 책 리뷰와 파트너 리뷰를 함께 조회합니다.
+
+            - 그룹 멤버만 조회할 수 있습니다.
+            - groupStatus가 COMPLETED인 그룹만 조회할 수 있습니다.
+            - bookReviews: 그룹 내 모든 책 리뷰(책 정보, 작성자 정보, 별점, 내용, 작성 일자)
+            - memberReviews: 서로가 서로에게 남긴 파트너 리뷰(그룹명, 독서 기간, 작성자 정보, 코멘트)
+            """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "그룹 리뷰 조회 성공",
+                    content = @Content(schema = @Schema(implementation = GroupReviewsResponseDTO.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "그룹이 종료(COMPLETED) 상태가 아님"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "그룹 멤버가 아님"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "그룹을 찾을 수 없음")
+    })
+    ApiResponse<GroupReviewsResponseDTO> getGroupReviews(
+            @Parameter(description = "그룹 식별자(ID)", example = "1") @PathVariable Long groupId,
+            @Parameter(hidden = true) @AuthenticationPrincipal(expression = "user") User user
+    );
 
     @PostMapping
     @Operation(

--- a/src/main/java/com/example/bookiibookii/domain/review/controller/BookReviewControllerDocs.java
+++ b/src/main/java/com/example/bookiibookii/domain/review/controller/BookReviewControllerDocs.java
@@ -3,6 +3,7 @@ package com.example.bookiibookii.domain.review.controller;
 import com.example.bookiibookii.domain.review.dto.req.ReviewRequestDTO;
 import com.example.bookiibookii.domain.review.dto.res.BookReviewResponseDTO;
 import com.example.bookiibookii.domain.review.dto.res.GroupReviewsResponseDTO;
+import com.example.bookiibookii.domain.review.dto.res.MyGroupReviewsResponseDTO;
 import com.example.bookiibookii.domain.user.entity.User;
 import com.example.bookiibookii.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -131,6 +132,61 @@ public interface BookReviewControllerDocs {
     ApiResponse<BookReviewResponseDTO> updateMyBookReview(
             @Parameter(description = "그룹 식별자(ID)", example = "1") @PathVariable Long groupId,
             @RequestBody @Valid ReviewRequestDTO.BookReviewUpsertDTO request,
+            @Parameter(hidden = true) @AuthenticationPrincipal(expression = "user") User user
+    );
+
+    @PatchMapping("/my-group")
+    @Operation(
+            summary = "종료 그룹 내 리뷰 일괄 수정",
+            description = """
+            종료된 그룹에서 내가 작성한 책 리뷰 2건과 파트너 리뷰를 수정합니다.
+
+            - 그룹 멤버만 수정할 수 있습니다.
+            - groupStatus가 COMPLETED인 그룹만 수정할 수 있습니다.
+            - bookReviews: memberBookId 기준으로 별점/코멘트를 부분 수정할 수 있습니다.
+            - memberReview: reaction/comment를 부분 수정할 수 있습니다.
+            - 수정하지 않을 필드는 요청에서 생략하면 기존 값을 유지합니다.
+            - bookReviews, memberReview 중 최소 1개 이상의 수정 항목이 필요합니다.
+            """
+    )
+    @io.swagger.v3.oas.annotations.parameters.RequestBody(
+            required = true,
+            content = @Content(
+                    schema = @Schema(implementation = ReviewRequestDTO.MyGroupReviewsUpdateDTO.class),
+                    examples = @ExampleObject(value = """
+                    {
+                      "bookReviews": [
+                        {
+                          "memberBookId": 100,
+                          "star": 5.0,
+                          "comment": "다시 읽어도 좋았어요"
+                        },
+                        {
+                          "memberBookId": 101,
+                          "star": 4.0
+                        }
+                      ],
+                      "memberReview": {
+                        "reaction": "BOOM_UP",
+                        "comment": "좋았어요"
+                      }
+                    }
+                    """)
+            )
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "내 그룹 리뷰 수정 성공",
+                    content = @Content(schema = @Schema(implementation = MyGroupReviewsResponseDTO.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "수정할 항목 없음, 별점/코멘트 형식 오류, 그룹이 종료(COMPLETED) 상태가 아님"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "그룹 멤버가 아님"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "그룹 또는 리뷰를 찾을 수 없음")
+    })
+    ApiResponse<MyGroupReviewsResponseDTO> updateMyGroupReviews(
+            @Parameter(description = "그룹 식별자(ID)", example = "1") @PathVariable Long groupId,
+            @RequestBody @Valid ReviewRequestDTO.MyGroupReviewsUpdateDTO request,
             @Parameter(hidden = true) @AuthenticationPrincipal(expression = "user") User user
     );
 }

--- a/src/main/java/com/example/bookiibookii/domain/review/dto/req/ReviewRequestDTO.java
+++ b/src/main/java/com/example/bookiibookii/domain/review/dto/req/ReviewRequestDTO.java
@@ -6,6 +6,8 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
+import java.util.List;
+
 public class ReviewRequestDTO {
 
     public record BookReviewUpsertDTO(
@@ -32,4 +34,40 @@ public class ReviewRequestDTO {
             @Size(max = 20, message = "파트너 후기는 20자 이내로 입력해주세요.")
             String comment
     ) {}
+
+    public record MyGroupReviewsUpdateDTO(
+            @Schema(description = "수정할 책 리뷰 목록. memberBookId 기준으로 별점/코멘트를 부분 수정할 수 있습니다.")
+            List<BookReviewUpdateItem> bookReviews,
+
+            @Schema(description = "수정할 파트너 리뷰. reaction/comment를 부분 수정할 수 있습니다.")
+            MemberReviewUpdateItem memberReview
+    ) {
+
+        public record BookReviewUpdateItem(
+                @Schema(description = "수정 대상 memberBook 식별자(ID)", example = "100", requiredMode = Schema.RequiredMode.REQUIRED)
+                @NotNull(message = "memberBookId는 필수입니다.")
+                Long memberBookId,
+
+                @Schema(description = "변경할 별점. 생략 시 기존 값을 유지합니다.", example = "4.5", minimum = "0.0", maximum = "5.0")
+                Double star,
+
+                @Schema(description = "변경할 코멘트. 생략 시 기존 값을 유지합니다.", example = "다시 읽어도 좋았어요", maxLength = 500)
+                @Size(max = 500, message = "책 리뷰는 500자 이내로 입력해주세요.")
+                String comment
+        ) {}
+
+        public record MemberReviewUpdateItem(
+                @Schema(
+                        description = "변경할 파트너 후기 리액션. 생략 시 기존 값을 유지합니다.",
+                        example = "BOOM_UP",
+                        allowableValues = {"BOOM_UP", "BOOM_DOWN"},
+                        nullable = true
+                )
+                MemberReviewReaction reaction,
+
+                @Schema(description = "변경할 파트너 후기 코멘트. 생략 시 기존 값을 유지합니다.", example = "좋았어요", maxLength = 20)
+                @Size(max = 20, message = "파트너 후기는 20자 이내로 입력해주세요.")
+                String comment
+        ) {}
+    }
 }

--- a/src/main/java/com/example/bookiibookii/domain/review/dto/res/GroupReviewsResponseDTO.java
+++ b/src/main/java/com/example/bookiibookii/domain/review/dto/res/GroupReviewsResponseDTO.java
@@ -1,0 +1,58 @@
+package com.example.bookiibookii.domain.review.dto.res;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+@Schema(description = "그룹 리뷰 조회 응답")
+public record GroupReviewsResponseDTO(
+        @Schema(description = "그룹 내 책 리뷰 목록")
+        List<BookReviewItem> bookReviews,
+        @Schema(description = "그룹 내 파트너 리뷰 목록")
+        List<MemberReviewItem> memberReviews
+) {
+
+    @Builder
+    @Schema(description = "책 리뷰 항목")
+    public record BookReviewItem(
+            @Schema(description = "책 식별자(ID)", example = "1")
+            Long bookId,
+            @Schema(description = "책 제목", example = "어린 왕자")
+            String bookTitle,
+            @Schema(description = "책 저자", example = "앙투안 드 생텍쥐페리")
+            String bookAuthor,
+            @Schema(description = "책 표지 이미지 URL", example = "https://example.com/book.jpg")
+            String bookImage,
+            @Schema(description = "작성자 사용자 식별자(ID)", example = "10")
+            Long writerId,
+            @Schema(description = "작성자 닉네임", example = "booklover")
+            String writerNickname,
+            @Schema(description = "작성자 프로필 이미지 Presigned URL")
+            String writerProfileImageUrl,
+            @Schema(description = "별점", example = "4.5")
+            Double star,
+            @Schema(description = "리뷰 내용", example = "문장이 좋아서 오래 기억에 남았어요")
+            String comment,
+            @Schema(description = "작성 일자", example = "2026. 05. 31.")
+            String createdAt
+    ) {}
+
+    @Builder
+    @Schema(description = "파트너 리뷰 항목")
+    public record MemberReviewItem(
+            @Schema(description = "그룹명", example = "5월 교환독서")
+            String groupName,
+            @Schema(description = "그룹 독서 기간(일)", example = "14")
+            Integer readingPeriod,
+            @Schema(description = "작성자 사용자 식별자(ID)", example = "10")
+            Long writerId,
+            @Schema(description = "작성자 닉네임", example = "booklover")
+            String writerNickname,
+            @Schema(description = "작성자 프로필 이미지 Presigned URL")
+            String writerProfileImageUrl,
+            @Schema(description = "파트너에게 남긴 코멘트", example = "좋았어요")
+            String comment
+    ) {}
+}

--- a/src/main/java/com/example/bookiibookii/domain/review/dto/res/GroupReviewsResponseDTO.java
+++ b/src/main/java/com/example/bookiibookii/domain/review/dto/res/GroupReviewsResponseDTO.java
@@ -1,5 +1,6 @@
 package com.example.bookiibookii.domain.review.dto.res;
 
+import com.example.bookiibookii.domain.review.enums.MemberReviewReaction;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
@@ -52,6 +53,8 @@ public record GroupReviewsResponseDTO(
             String writerNickname,
             @Schema(description = "작성자 프로필 이미지 Presigned URL")
             String writerProfileImageUrl,
+            @Schema(description = "파트너 후기 리액션", example = "BOOM_UP", allowableValues = {"BOOM_UP", "BOOM_DOWN"}, nullable = true)
+            MemberReviewReaction reaction,
             @Schema(description = "파트너에게 남긴 코멘트", example = "좋았어요")
             String comment
     ) {}

--- a/src/main/java/com/example/bookiibookii/domain/review/dto/res/MyGroupReviewsResponseDTO.java
+++ b/src/main/java/com/example/bookiibookii/domain/review/dto/res/MyGroupReviewsResponseDTO.java
@@ -1,0 +1,16 @@
+package com.example.bookiibookii.domain.review.dto.res;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+@Schema(description = "내 그룹 리뷰 수정 응답")
+public record MyGroupReviewsResponseDTO(
+        @Schema(description = "수정 후 내 책 리뷰 목록")
+        List<GroupReviewsResponseDTO.BookReviewItem> bookReviews,
+        @Schema(description = "수정 후 내 파트너 리뷰")
+        GroupReviewsResponseDTO.MemberReviewItem memberReview
+) {
+}

--- a/src/main/java/com/example/bookiibookii/domain/review/entity/MemberReview.java
+++ b/src/main/java/com/example/bookiibookii/domain/review/entity/MemberReview.java
@@ -76,4 +76,10 @@ public class MemberReview extends BaseEntity {
             throw new IllegalArgumentException("comment cannot exceed 20 characters");
         }
     }
+
+    public void updateReview(MemberReviewReaction reaction, String comment) {
+        validateComment(comment);
+        this.reaction = reaction;
+        this.comment = comment;
+    }
 }

--- a/src/main/java/com/example/bookiibookii/domain/review/exception/code/ReviewErrorCode.java
+++ b/src/main/java/com/example/bookiibookii/domain/review/exception/code/ReviewErrorCode.java
@@ -16,6 +16,7 @@ public enum ReviewErrorCode implements BaseCode {
     COMMENT_REQUIRED(HttpStatus.BAD_REQUEST, "REVIEW400_4", "코멘트는 필수입니다."),
     INVALID_REVIEW_READING_STATUS(HttpStatus.BAD_REQUEST, "REVIEW400_5", "현재 독서 상태에서는 책 리뷰를 작성할 수 없습니다."),
     INVALID_MEMBER_REVIEW_STATUS(HttpStatus.BAD_REQUEST, "REVIEW400_6", "파트너 후기는 반납 교환이 모두 완료된 후 작성할 수 있습니다."),
+    GROUP_REVIEW_NOT_AVAILABLE(HttpStatus.BAD_REQUEST, "REVIEW400_7", "종료된 그룹의 리뷰만 조회할 수 있습니다."),
 
     // 403
     NOT_GROUP_MEMBER(HttpStatus.FORBIDDEN, "REVIEW403_1", "해당 그룹의 멤버만 리뷰를 작성할 수 있습니다."),

--- a/src/main/java/com/example/bookiibookii/domain/review/exception/code/ReviewErrorCode.java
+++ b/src/main/java/com/example/bookiibookii/domain/review/exception/code/ReviewErrorCode.java
@@ -17,6 +17,7 @@ public enum ReviewErrorCode implements BaseCode {
     INVALID_REVIEW_READING_STATUS(HttpStatus.BAD_REQUEST, "REVIEW400_5", "현재 독서 상태에서는 책 리뷰를 작성할 수 없습니다."),
     INVALID_MEMBER_REVIEW_STATUS(HttpStatus.BAD_REQUEST, "REVIEW400_6", "파트너 후기는 반납 교환이 모두 완료된 후 작성할 수 있습니다."),
     GROUP_REVIEW_NOT_AVAILABLE(HttpStatus.BAD_REQUEST, "REVIEW400_7", "종료된 그룹의 리뷰만 조회할 수 있습니다."),
+    NOTHING_TO_UPDATE(HttpStatus.BAD_REQUEST, "REVIEW400_8", "수정할 항목이 없습니다."),
 
     // 403
     NOT_GROUP_MEMBER(HttpStatus.FORBIDDEN, "REVIEW403_1", "해당 그룹의 멤버만 리뷰를 작성할 수 있습니다."),
@@ -25,7 +26,8 @@ public enum ReviewErrorCode implements BaseCode {
     MATCHED_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "REVIEW404_2", "그룹 매칭 정보를 찾을 수 없습니다."),
     PARTNER_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "REVIEW404_3", "상대 멤버를 찾을 수 없습니다."),
     CURRENT_MEMBER_BOOK_NOT_FOUND(HttpStatus.NOT_FOUND, "REVIEW404_5", "현재 읽고 있는 책을 찾을 수 없습니다."),
-    BOOK_REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "REVIEW404_6", "책 리뷰를 찾을 수 없습니다.");
+    BOOK_REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "REVIEW404_6", "책 리뷰를 찾을 수 없습니다."),
+    MEMBER_REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "REVIEW404_7", "파트너 후기를 찾을 수 없습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/example/bookiibookii/domain/review/exception/code/ReviewSuccessCode.java
+++ b/src/main/java/com/example/bookiibookii/domain/review/exception/code/ReviewSuccessCode.java
@@ -10,7 +10,8 @@ import org.springframework.http.HttpStatus;
 public enum ReviewSuccessCode implements BaseCode {
     BOOK_REVIEW_CREATED(HttpStatus.CREATED, "REVIEW201_2", "책 리뷰가 작성되었습니다."),
     MEMBER_REVIEW_CREATED(HttpStatus.CREATED, "REVIEW201_3", "파트너 후기가 작성되었습니다."),
-    BOOK_REVIEW_UPDATED(HttpStatus.OK, "REVIEW200_4", "책 리뷰가 수정되었습니다.");
+    BOOK_REVIEW_UPDATED(HttpStatus.OK, "REVIEW200_4", "책 리뷰가 수정되었습니다."),
+    GROUP_REVIEWS_FOUND(HttpStatus.OK, "REVIEW200_5", "그룹 리뷰 조회에 성공했습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/example/bookiibookii/domain/review/exception/code/ReviewSuccessCode.java
+++ b/src/main/java/com/example/bookiibookii/domain/review/exception/code/ReviewSuccessCode.java
@@ -11,7 +11,8 @@ public enum ReviewSuccessCode implements BaseCode {
     BOOK_REVIEW_CREATED(HttpStatus.CREATED, "REVIEW201_2", "책 리뷰가 작성되었습니다."),
     MEMBER_REVIEW_CREATED(HttpStatus.CREATED, "REVIEW201_3", "파트너 후기가 작성되었습니다."),
     BOOK_REVIEW_UPDATED(HttpStatus.OK, "REVIEW200_4", "책 리뷰가 수정되었습니다."),
-    GROUP_REVIEWS_FOUND(HttpStatus.OK, "REVIEW200_5", "그룹 리뷰 조회에 성공했습니다.");
+    GROUP_REVIEWS_FOUND(HttpStatus.OK, "REVIEW200_5", "그룹 리뷰 조회에 성공했습니다."),
+    MY_GROUP_REVIEWS_UPDATED(HttpStatus.OK, "REVIEW200_6", "내 리뷰가 수정되었습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/example/bookiibookii/domain/review/repository/BookReviewRepository.java
+++ b/src/main/java/com/example/bookiibookii/domain/review/repository/BookReviewRepository.java
@@ -64,4 +64,20 @@ public interface BookReviewRepository extends JpaRepository<BookReview, Long> {
         ORDER BY br.createdAt ASC
         """)
     List<BookReview> findAllByGroupIdWithDetails(@Param("groupId") Long groupId);
+
+    @Query("""
+        SELECT br FROM BookReview br
+        JOIN FETCH br.memberBook mb
+        JOIN FETCH mb.book
+        JOIN FETCH br.matchedMember mm
+        JOIN FETCH mm.user u
+        LEFT JOIN FETCH u.userImage
+        WHERE mm.id = :matchedMemberId
+        AND mm.group.id = :groupId
+        ORDER BY br.createdAt ASC
+        """)
+    List<BookReview> findAllByMatchedMemberIdAndGroupIdWithDetails(
+            @Param("matchedMemberId") Long matchedMemberId,
+            @Param("groupId") Long groupId
+    );
 }

--- a/src/main/java/com/example/bookiibookii/domain/review/repository/BookReviewRepository.java
+++ b/src/main/java/com/example/bookiibookii/domain/review/repository/BookReviewRepository.java
@@ -52,4 +52,16 @@ public interface BookReviewRepository extends JpaRepository<BookReview, Long> {
         AND mb.removedAt IS NULL
         """)
     boolean existsReviewedBookByUserIdAndBookId(@Param("userId") Long userId, @Param("bookId") Long bookId);
+
+    @Query("""
+        SELECT br FROM BookReview br
+        JOIN FETCH br.memberBook mb
+        JOIN FETCH mb.book
+        JOIN FETCH br.matchedMember mm
+        JOIN FETCH mm.user u
+        LEFT JOIN FETCH u.userImage
+        WHERE mm.group.id = :groupId
+        ORDER BY br.createdAt ASC
+        """)
+    List<BookReview> findAllByGroupIdWithDetails(@Param("groupId") Long groupId);
 }

--- a/src/main/java/com/example/bookiibookii/domain/review/repository/MemberReviewRepository.java
+++ b/src/main/java/com/example/bookiibookii/domain/review/repository/MemberReviewRepository.java
@@ -34,4 +34,17 @@ public interface MemberReviewRepository extends JpaRepository<MemberReview, Long
         ORDER BY mr.createdAt DESC
     """)
     List<MemberReview> findLatestReceivedByUserId(@Param("userId") Long userId, Pageable pageable);
+
+    @Query("""
+        SELECT mr FROM MemberReview mr
+        JOIN FETCH mr.group g
+        JOIN FETCH mr.writer w
+        JOIN FETCH w.user wu
+        LEFT JOIN FETCH wu.userImage
+        JOIN FETCH mr.target t
+        JOIN FETCH t.user tu
+        WHERE g.id = :groupId
+        ORDER BY mr.createdAt ASC
+        """)
+    List<MemberReview> findAllByGroupIdWithDetails(@Param("groupId") Long groupId);
 }

--- a/src/main/java/com/example/bookiibookii/domain/review/repository/MemberReviewRepository.java
+++ b/src/main/java/com/example/bookiibookii/domain/review/repository/MemberReviewRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface MemberReviewRepository extends JpaRepository<MemberReview, Long> {
@@ -47,4 +48,18 @@ public interface MemberReviewRepository extends JpaRepository<MemberReview, Long
         ORDER BY mr.createdAt ASC
         """)
     List<MemberReview> findAllByGroupIdWithDetails(@Param("groupId") Long groupId);
+
+    @Query("""
+        SELECT mr FROM MemberReview mr
+        JOIN FETCH mr.group g
+        JOIN FETCH mr.writer w
+        JOIN FETCH w.user wu
+        LEFT JOIN FETCH wu.userImage
+        WHERE g.id = :groupId
+        AND w.id = :writerMatchedMemberId
+        """)
+    Optional<MemberReview> findByGroupIdAndWriterIdWithDetails(
+            @Param("groupId") Long groupId,
+            @Param("writerMatchedMemberId") Long writerMatchedMemberId
+    );
 }

--- a/src/main/java/com/example/bookiibookii/domain/review/service/ReviewService.java
+++ b/src/main/java/com/example/bookiibookii/domain/review/service/ReviewService.java
@@ -11,6 +11,7 @@ import com.example.bookiibookii.domain.group.repository.MatchedMemberRepository;
 import com.example.bookiibookii.domain.memberbook.entity.MemberBook;
 import com.example.bookiibookii.domain.review.dto.req.ReviewRequestDTO;
 import com.example.bookiibookii.domain.review.dto.res.BookReviewResponseDTO;
+import com.example.bookiibookii.domain.review.dto.res.GroupReviewsResponseDTO;
 import com.example.bookiibookii.domain.review.dto.res.MemberReviewResponseDTO;
 import com.example.bookiibookii.domain.review.entity.BookReview;
 import com.example.bookiibookii.domain.review.entity.MemberReview;
@@ -21,12 +22,14 @@ import com.example.bookiibookii.domain.review.repository.MemberReviewRepository;
 import com.example.bookiibookii.domain.tracker.enums.ExchangeStatus;
 import com.example.bookiibookii.domain.tracker.enums.ReadingStatus;
 import com.example.bookiibookii.domain.tracker.service.DeliveryAddressService;
+import com.example.bookiibookii.domain.tracker.resolver.UserProfileImageUrlResolver;
 import com.example.bookiibookii.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 @Service
@@ -37,12 +40,14 @@ public class ReviewService {
     private static final double RATING_MAX = 5.0;
     private static final int BOOK_COMMENT_MAX_LENGTH = 500;
     private static final int MEMBER_COMMENT_MAX_LENGTH = 20;
+    private static final DateTimeFormatter DATE_FMT = DateTimeFormatter.ofPattern("yyyy. MM. dd.");
 
     private final MatchedMemberRepository matchedMemberRepository;
     private final BookReviewRepository bookReviewRepository;
     private final MemberReviewRepository memberReviewRepository;
     private final GroupsRepository groupsRepository;
     private final DeliveryAddressService deliveryAddressService;
+    private final UserProfileImageUrlResolver userProfileImageUrlResolver;
 
     @Transactional
     public BookReviewResponseDTO createBookReview(
@@ -160,6 +165,69 @@ public class ReviewService {
         bookReview.updateReview(request.star(), request.comment());
 
         return BookReviewResponseDTO.from(bookReview);
+    }
+
+    @Transactional(readOnly = true)
+    public GroupReviewsResponseDTO getGroupReviews(Long groupId, User user) {
+        Groups group = groupsRepository.findByIdWithBookAndHost(groupId)
+                .orElseThrow(() -> new GroupException(GroupErrorCode.GROUP_NOT_FOUND));
+
+        if (!matchedMemberRepository.existsByGroup_IdAndUser_Id(groupId, user.getId())) {
+            throw new ReviewException(ReviewErrorCode.NOT_GROUP_MEMBER);
+        }
+
+        if (group.getGroupStatus() != GroupStatus.COMPLETED) {
+            throw new ReviewException(ReviewErrorCode.GROUP_REVIEW_NOT_AVAILABLE);
+        }
+
+        List<GroupReviewsResponseDTO.BookReviewItem> bookReviews = bookReviewRepository
+                .findAllByGroupIdWithDetails(groupId)
+                .stream()
+                .map(this::toBookReviewItem)
+                .toList();
+
+        List<GroupReviewsResponseDTO.MemberReviewItem> memberReviews = memberReviewRepository
+                .findAllByGroupIdWithDetails(groupId)
+                .stream()
+                .map(this::toMemberReviewItem)
+                .toList();
+
+        return GroupReviewsResponseDTO.builder()
+                .bookReviews(bookReviews)
+                .memberReviews(memberReviews)
+                .build();
+    }
+
+    private GroupReviewsResponseDTO.BookReviewItem toBookReviewItem(BookReview bookReview) {
+        var book = bookReview.getMemberBook().getBook();
+        var writer = bookReview.getMatchedMember().getUser();
+
+        return GroupReviewsResponseDTO.BookReviewItem.builder()
+                .bookId(book.getId())
+                .bookTitle(book.getTitle())
+                .bookAuthor(book.getAuthor())
+                .bookImage(book.getImage())
+                .writerId(writer.getId())
+                .writerNickname(writer.getNickName())
+                .writerProfileImageUrl(userProfileImageUrlResolver.resolve(writer))
+                .star(bookReview.getStar())
+                .comment(bookReview.getComment())
+                .createdAt(bookReview.getCreatedAt().format(DATE_FMT))
+                .build();
+    }
+
+    private GroupReviewsResponseDTO.MemberReviewItem toMemberReviewItem(MemberReview memberReview) {
+        var group = memberReview.getGroup();
+        var writer = memberReview.getWriter().getUser();
+
+        return GroupReviewsResponseDTO.MemberReviewItem.builder()
+                .groupName(group.getGroupName())
+                .readingPeriod(group.getReadingPeriod())
+                .writerId(writer.getId())
+                .writerNickname(writer.getNickName())
+                .writerProfileImageUrl(userProfileImageUrlResolver.resolve(writer))
+                .comment(memberReview.getComment())
+                .build();
     }
 
     private void validateRating(Double rating) {

--- a/src/main/java/com/example/bookiibookii/domain/review/service/ReviewService.java
+++ b/src/main/java/com/example/bookiibookii/domain/review/service/ReviewService.java
@@ -226,6 +226,7 @@ public class ReviewService {
                 .writerId(writer.getId())
                 .writerNickname(writer.getNickName())
                 .writerProfileImageUrl(userProfileImageUrlResolver.resolve(writer))
+                .reaction(memberReview.getReaction())
                 .comment(memberReview.getComment())
                 .build();
     }

--- a/src/main/java/com/example/bookiibookii/domain/review/service/ReviewService.java
+++ b/src/main/java/com/example/bookiibookii/domain/review/service/ReviewService.java
@@ -13,8 +13,10 @@ import com.example.bookiibookii.domain.review.dto.req.ReviewRequestDTO;
 import com.example.bookiibookii.domain.review.dto.res.BookReviewResponseDTO;
 import com.example.bookiibookii.domain.review.dto.res.GroupReviewsResponseDTO;
 import com.example.bookiibookii.domain.review.dto.res.MemberReviewResponseDTO;
+import com.example.bookiibookii.domain.review.dto.res.MyGroupReviewsResponseDTO;
 import com.example.bookiibookii.domain.review.entity.BookReview;
 import com.example.bookiibookii.domain.review.entity.MemberReview;
+import com.example.bookiibookii.domain.review.enums.MemberReviewReaction;
 import com.example.bookiibookii.domain.review.exception.ReviewException;
 import com.example.bookiibookii.domain.review.exception.code.ReviewErrorCode;
 import com.example.bookiibookii.domain.review.repository.BookReviewRepository;
@@ -167,18 +169,32 @@ public class ReviewService {
         return BookReviewResponseDTO.from(bookReview);
     }
 
+    @Transactional
+    public MyGroupReviewsResponseDTO updateMyGroupReviews(
+            Long groupId,
+            ReviewRequestDTO.MyGroupReviewsUpdateDTO request,
+            User user
+    ) {
+        validateCompletedGroupReviewAccess(groupId, user.getId());
+        MatchedMember me = getMatchedMember(groupId, user.getId());
+        validateHasUpdates(request);
+
+        if (request.bookReviews() != null) {
+            for (ReviewRequestDTO.MyGroupReviewsUpdateDTO.BookReviewUpdateItem item : request.bookReviews()) {
+                updateMyBookReviewItem(me, item);
+            }
+        }
+
+        if (request.memberReview() != null) {
+            updateMyMemberReview(groupId, me, request.memberReview());
+        }
+
+        return buildMyGroupReviewsResponse(me.getId(), groupId);
+    }
+
     @Transactional(readOnly = true)
     public GroupReviewsResponseDTO getGroupReviews(Long groupId, User user) {
-        Groups group = groupsRepository.findByIdWithBookAndHost(groupId)
-                .orElseThrow(() -> new GroupException(GroupErrorCode.GROUP_NOT_FOUND));
-
-        if (!matchedMemberRepository.existsByGroup_IdAndUser_Id(groupId, user.getId())) {
-            throw new ReviewException(ReviewErrorCode.NOT_GROUP_MEMBER);
-        }
-
-        if (group.getGroupStatus() != GroupStatus.COMPLETED) {
-            throw new ReviewException(ReviewErrorCode.GROUP_REVIEW_NOT_AVAILABLE);
-        }
+        validateCompletedGroupReviewAccess(groupId, user.getId());
 
         List<GroupReviewsResponseDTO.BookReviewItem> bookReviews = bookReviewRepository
                 .findAllByGroupIdWithDetails(groupId)
@@ -195,6 +211,109 @@ public class ReviewService {
         return GroupReviewsResponseDTO.builder()
                 .bookReviews(bookReviews)
                 .memberReviews(memberReviews)
+                .build();
+    }
+
+    private void validateCompletedGroupReviewAccess(Long groupId, Long userId) {
+        Groups group = groupsRepository.findByIdWithBookAndHost(groupId)
+                .orElseThrow(() -> new GroupException(GroupErrorCode.GROUP_NOT_FOUND));
+
+        if (!matchedMemberRepository.existsByGroup_IdAndUser_Id(groupId, userId)) {
+            throw new ReviewException(ReviewErrorCode.NOT_GROUP_MEMBER);
+        }
+
+        if (group.getGroupStatus() != GroupStatus.COMPLETED) {
+            throw new ReviewException(ReviewErrorCode.GROUP_REVIEW_NOT_AVAILABLE);
+        }
+    }
+
+    private void validateHasUpdates(ReviewRequestDTO.MyGroupReviewsUpdateDTO request) {
+        boolean hasBookUpdates = request.bookReviews() != null
+                && request.bookReviews().stream().anyMatch(this::hasBookReviewChanges);
+
+        boolean hasMemberUpdate = request.memberReview() != null
+                && (request.memberReview().reaction() != null || request.memberReview().comment() != null);
+
+        if (!hasBookUpdates && !hasMemberUpdate) {
+            throw new ReviewException(ReviewErrorCode.NOTHING_TO_UPDATE);
+        }
+    }
+
+    private boolean hasBookReviewChanges(ReviewRequestDTO.MyGroupReviewsUpdateDTO.BookReviewUpdateItem item) {
+        return item.star() != null || item.comment() != null;
+    }
+
+    private void updateMyBookReviewItem(
+            MatchedMember me,
+            ReviewRequestDTO.MyGroupReviewsUpdateDTO.BookReviewUpdateItem item
+    ) {
+        if (!hasBookReviewChanges(item)) {
+            throw new ReviewException(ReviewErrorCode.NOTHING_TO_UPDATE);
+        }
+
+        BookReview bookReview = bookReviewRepository
+                .findByMatchedMember_IdAndMemberBook_Id(me.getId(), item.memberBookId())
+                .orElseThrow(() -> new ReviewException(ReviewErrorCode.BOOK_REVIEW_NOT_FOUND));
+
+        if (!bookReview.getMemberBook().isOwnedBy(me)) {
+            throw new ReviewException(ReviewErrorCode.BOOK_REVIEW_NOT_FOUND);
+        }
+
+        Double newStar = item.star() != null ? item.star() : bookReview.getStar();
+        String newComment = item.comment() != null ? item.comment() : bookReview.getComment();
+
+        if (item.star() != null) {
+            validateRating(item.star());
+        }
+        if (item.comment() != null) {
+            validateCommentLength(item.comment(), BOOK_COMMENT_MAX_LENGTH);
+        }
+
+        bookReview.updateReview(newStar, newComment);
+    }
+
+    private void updateMyMemberReview(
+            Long groupId,
+            MatchedMember me,
+            ReviewRequestDTO.MyGroupReviewsUpdateDTO.MemberReviewUpdateItem item
+    ) {
+        if (item.reaction() == null && item.comment() == null) {
+            throw new ReviewException(ReviewErrorCode.NOTHING_TO_UPDATE);
+        }
+
+        MemberReview memberReview = memberReviewRepository
+                .findByGroupIdAndWriterIdWithDetails(groupId, me.getId())
+                .orElseThrow(() -> new ReviewException(ReviewErrorCode.MEMBER_REVIEW_NOT_FOUND));
+
+        MemberReviewReaction newReaction = item.reaction() != null
+                ? item.reaction()
+                : memberReview.getReaction();
+        String newComment = item.comment() != null
+                ? item.comment()
+                : memberReview.getComment();
+
+        if (item.comment() != null) {
+            validateCommentRequired(item.comment(), MEMBER_COMMENT_MAX_LENGTH);
+        }
+
+        memberReview.updateReview(newReaction, newComment);
+    }
+
+    private MyGroupReviewsResponseDTO buildMyGroupReviewsResponse(Long matchedMemberId, Long groupId) {
+        List<GroupReviewsResponseDTO.BookReviewItem> bookReviews = bookReviewRepository
+                .findAllByMatchedMemberIdAndGroupIdWithDetails(matchedMemberId, groupId)
+                .stream()
+                .map(this::toBookReviewItem)
+                .toList();
+
+        GroupReviewsResponseDTO.MemberReviewItem memberReview = memberReviewRepository
+                .findByGroupIdAndWriterIdWithDetails(groupId, matchedMemberId)
+                .map(this::toMemberReviewItem)
+                .orElse(null);
+
+        return MyGroupReviewsResponseDTO.builder()
+                .bookReviews(bookReviews)
+                .memberReview(memberReview)
                 .build();
     }
 


### PR DESCRIPTION
## 개요
<!---- 자신이 완료한 이슈를 닫아주세요 -->
- closed #516
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
서재 -> 후기 View 를 위한 후기 get API 제작(groupstatus가 completed일 때 가능하도록 설계)
후기 수정(그룹 당 본인이 작성한 책 2권 + 파트너 리뷰) API 제작

<!---- Resolves: #(Isuue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

📣 **To Reviewers**
---
<!-- 전달사항 -->

- Reviewers : 팀 선택
- Labels : 작업 유형, 자기 자신


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* **그룹 리뷰 조회 추가**: 종료된 그룹에서 모든 참가자의 책 리뷰와 멤버 리뷰를 한 번에 확인할 수 있습니다.
* **그룹 리뷰 수정 기능 개선**: 그룹이 종료되었을 때 내 책 리뷰 최대 2건과 파트너 리뷰를 함께 수정할 수 있도록 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->