### PR TITLE
[Fix]#522 책 후기 작성 후 상대 후기 대기 상태 추가

### DIFF
--- a/src/main/java/com/example/bookiibookii/domain/review/service/ReviewService.java
+++ b/src/main/java/com/example/bookiibookii/domain/review/service/ReviewService.java
@@ -62,8 +62,12 @@ public class ReviewService {
 
         Groups group = groupsRepository.findByIdForUpdate(groupId)
                 .orElseThrow(() -> new GroupException(GroupErrorCode.GROUP_NOT_FOUND));
-        MatchedMember me = getMatchedMember(group.getId(), user.getId());
+        List<MatchedMember> members = matchedMemberRepository.findAllByGroupIdForUpdate(group.getId());
+        validatePairGroup(members);
+
+        MatchedMember me = findMe(members, user.getId());
         MemberBook currentMemberBook = getCurrentMemberBook(me);
+        ReadingStatus currentStatus = validateBookReviewReadingStatus(me.getReadingStatus());
 
         if (bookReviewRepository.existsByMatchedMember_IdAndMemberBook_Id(me.getId(), currentMemberBook.getId())) {
             throw new ReviewException(ReviewErrorCode.REVIEW_ALREADY_EXISTS);
@@ -81,21 +85,12 @@ public class ReviewService {
         );
 
         try {
-            bookReview = bookReviewRepository.save(bookReview);
+            bookReview = bookReviewRepository.saveAndFlush(bookReview);
         } catch (DataIntegrityViolationException e) {
             throw new ReviewException(ReviewErrorCode.REVIEW_ALREADY_EXISTS);
         }
 
-        ReadingStatus currentStatus = me.getReadingStatus();
-        if (currentStatus == ReadingStatus.MY_BOOK_REVIEWING) {
-            me.updateReadingStatus(ReadingStatus.EXCHANGING);
-        } else if (currentStatus == ReadingStatus.PARTNER_BOOK_REVIEWING) {
-            me.updateReadingStatus(ReadingStatus.RETURNING);
-        } else {
-            throw new ReviewException(ReviewErrorCode.INVALID_REVIEW_READING_STATUS);
-        }
-
-        updateExchangeStatusIfAllMembersReady(group.getId(), group.getTradeType());
+        updateReadingStatusIfAllBookReviewsWritten(group.getId(), group.getTradeType(), members, currentStatus);
 
         return BookReviewResponseDTO.from(bookReview);
     }
@@ -372,6 +367,44 @@ public class ReviewService {
     private MatchedMember getMatchedMember(Long groupId, Long userId) {
         return matchedMemberRepository.findByGroup_IdAndUser_Id(groupId, userId)
                 .orElseThrow(() -> new ReviewException(ReviewErrorCode.NOT_GROUP_MEMBER));
+    }
+
+    private ReadingStatus validateBookReviewReadingStatus(ReadingStatus readingStatus) {
+        if (readingStatus == ReadingStatus.MY_BOOK_REVIEWING
+                || readingStatus == ReadingStatus.PARTNER_BOOK_REVIEWING) {
+            return readingStatus;
+        }
+        throw new ReviewException(ReviewErrorCode.INVALID_REVIEW_READING_STATUS);
+    }
+
+    private void updateReadingStatusIfAllBookReviewsWritten(
+            Long groupId,
+            TradeType tradeType,
+            List<MatchedMember> members,
+            ReadingStatus reviewStatus
+    ) {
+        boolean allMembersInSameReviewStatus = members.stream()
+                .allMatch(member -> member.getReadingStatus() == reviewStatus);
+        boolean allCurrentBookReviewsWritten = members.stream()
+                .allMatch(this::existsCurrentBookReview);
+
+        if (!allMembersInSameReviewStatus || !allCurrentBookReviewsWritten) {
+            return;
+        }
+
+        ReadingStatus nextStatus = reviewStatus == ReadingStatus.MY_BOOK_REVIEWING
+                ? ReadingStatus.EXCHANGING
+                : ReadingStatus.RETURNING;
+        members.forEach(member -> member.updateReadingStatus(nextStatus));
+        updateExchangeStatusIfAllMembersReady(groupId, tradeType);
+    }
+
+    private boolean existsCurrentBookReview(MatchedMember matchedMember) {
+        MemberBook currentMemberBook = getCurrentMemberBook(matchedMember);
+        return bookReviewRepository.existsByMatchedMember_IdAndMemberBook_Id(
+                matchedMember.getId(),
+                currentMemberBook.getId()
+        );
     }
 
     private void validatePairGroup(List<MatchedMember> matchedMembers) {

--- a/src/main/java/com/example/bookiibookii/domain/tracker/controller/TrackerControllerDocs.java
+++ b/src/main/java/com/example/bookiibookii/domain/tracker/controller/TrackerControllerDocs.java
@@ -27,7 +27,7 @@ public interface TrackerControllerDocs {
             - summary는 같은 조회 조건으로 내려가는 items의 displayStatus 기준으로 계산됩니다.
             - readingCount: READING
             - exchangingCount: TRACKING_REQUIRED, SHIPPING, RETURN_TRACKING_REQUIRED, RETURNING, MEETING_REQUIRED, EXCHANGING
-            - reviewCount: REVIEW_WRITING, EXCHANGE_REVIEW_WRITING
+            - reviewCount: REVIEW_WRITING, REVIEW_WAITING_PARTNER, EXCHANGE_REVIEW_WRITING
             """
     )
     ApiResponse<TrackerListResDTO> getTrackerList(

--- a/src/main/java/com/example/bookiibookii/domain/tracker/converter/TrackerConverter.java
+++ b/src/main/java/com/example/bookiibookii/domain/tracker/converter/TrackerConverter.java
@@ -125,6 +125,7 @@ public class TrackerConverter {
         return switch (displayStatus) {
             case READING -> "읽는 중";
             case REVIEW_WRITING -> "후기 작성";
+            case REVIEW_WAITING_PARTNER -> "후기 수정";
 
             case TRACKING_REQUIRED -> "운송장 등록";
             case SHIPPING -> "배송 중";

--- a/src/main/java/com/example/bookiibookii/domain/tracker/enums/TrackerDisplayStatus.java
+++ b/src/main/java/com/example/bookiibookii/domain/tracker/enums/TrackerDisplayStatus.java
@@ -5,6 +5,7 @@ public enum TrackerDisplayStatus {
 
     READING,              // 읽는 중
     REVIEW_WRITING,       // 후기 작성
+    REVIEW_WAITING_PARTNER, // 내 후기 작성 완료, 파트너 후기 대기
 
     TRACKING_REQUIRED,    // 운송장 등록 필요
     SHIPPING,             // 배송 중

--- a/src/main/java/com/example/bookiibookii/domain/tracker/resolver/TrackerDisplayStatusResolver.java
+++ b/src/main/java/com/example/bookiibookii/domain/tracker/resolver/TrackerDisplayStatusResolver.java
@@ -12,7 +12,8 @@ public class TrackerDisplayStatusResolver {
     public TrackerDisplayStatus resolve(
             ReadingStatus readingStatus,
             ExchangeStatus exchangeStatus,
-            TradeType tradeType
+            TradeType tradeType,
+            boolean currentBookReviewWritten
     ) {
         if (readingStatus == null) {
             return TrackerDisplayStatus.READING;
@@ -23,7 +24,9 @@ public class TrackerDisplayStatusResolver {
                     TrackerDisplayStatus.READING;
 
             case MY_BOOK_REVIEWING, PARTNER_BOOK_REVIEWING ->
-                    TrackerDisplayStatus.REVIEW_WRITING;
+                    currentBookReviewWritten
+                            ? TrackerDisplayStatus.REVIEW_WAITING_PARTNER
+                            : TrackerDisplayStatus.REVIEW_WRITING;
 
             case EXCHANGING ->
                     resolveFirstExchangeStatus(exchangeStatus, tradeType);
@@ -40,6 +43,14 @@ public class TrackerDisplayStatusResolver {
             case COMPLETED ->
                     TrackerDisplayStatus.EXCHANGE_REVIEW_WRITING;
         };
+    }
+
+    public TrackerDisplayStatus resolve(
+            ReadingStatus readingStatus,
+            ExchangeStatus exchangeStatus,
+            TradeType tradeType
+    ) {
+        return resolve(readingStatus, exchangeStatus, tradeType, false);
     }
 
     private TrackerDisplayStatus resolveFirstExchangeStatus(

--- a/src/main/java/com/example/bookiibookii/domain/tracker/service/TrackerService.java
+++ b/src/main/java/com/example/bookiibookii/domain/tracker/service/TrackerService.java
@@ -8,6 +8,7 @@ import com.example.bookiibookii.domain.group.exception.GroupException;
 import com.example.bookiibookii.domain.group.exception.code.GroupErrorCode;
 import com.example.bookiibookii.domain.group.repository.GroupsRepository;
 import com.example.bookiibookii.domain.group.repository.MatchedMemberRepository;
+import com.example.bookiibookii.domain.review.repository.BookReviewRepository;
 import com.example.bookiibookii.domain.tracker.converter.TrackerConverter;
 import com.example.bookiibookii.domain.tracker.dto.req.ExtendReadingPeriodReqDTO;
 import com.example.bookiibookii.domain.tracker.dto.req.ReadingProgressRequestDTO;
@@ -41,6 +42,7 @@ public class TrackerService {
     private final TrackerDueDateResolver trackerDueDateResolver;
     private final UserProfileImageUrlResolver userProfileImageUrlResolver;
     private final TrackerStepAssembler trackerStepAssembler;
+    private final BookReviewRepository bookReviewRepository;
 
     // 트래커 리스트 조회
     public TrackerListResDTO getTrackerList(User user) {
@@ -58,7 +60,8 @@ public class TrackerService {
                     TrackerDisplayStatus displayStatus = trackerDisplayStatusResolver.resolve(
                             me.getReadingStatus(),
                             me.getExchangeStatus(),
-                            me.getGroup().getTradeType()
+                            me.getGroup().getTradeType(),
+                            isCurrentBookReviewWritten(me)
                     );
 
                     return TrackerConverter.toListItem(
@@ -100,7 +103,8 @@ public class TrackerService {
         TrackerDisplayStatus displayStatus = trackerDisplayStatusResolver.resolve(
                 me.getReadingStatus(),
                 me.getExchangeStatus(),
-                me.getGroup().getTradeType()
+                me.getGroup().getTradeType(),
+                isCurrentBookReviewWritten(me)
         );
 
         return TrackerConverter.toDetail(
@@ -238,6 +242,7 @@ public class TrackerService {
 
     private boolean isReviewStatus(TrackerDisplayStatus displayStatus) {
         return displayStatus == TrackerDisplayStatus.REVIEW_WRITING
+                || displayStatus == TrackerDisplayStatus.REVIEW_WAITING_PARTNER
                 || displayStatus == TrackerDisplayStatus.EXCHANGE_REVIEW_WRITING;
     }
 
@@ -253,5 +258,15 @@ public class TrackerService {
     private MatchedMember getMyMatchedMember(Long groupId, Long userId) {
         return matchedMemberRepository.findByGroup_IdAndUser_Id(groupId, userId)
                 .orElseThrow(() -> new TrackerException(TrackerErrorCode.NOT_GROUP_MEMBER));
+    }
+
+    private boolean isCurrentBookReviewWritten(MatchedMember me) {
+        if (me.getCurrentMemberBook() == null) {
+            return false;
+        }
+        return bookReviewRepository.existsByMatchedMember_IdAndMemberBook_Id(
+                me.getId(),
+                me.getCurrentMemberBook().getId()
+        );
     }
 }


### PR DESCRIPTION
## 개요
<!---- 자신이 완료한 이슈를 닫아주세요 -->
- closed #522 
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 책 후기 생성 시 한 명만 후기를 작성한 경우 바로 다음 교환 단계로 넘어가지 않도록 수정했습니다.
- 내가 현재 책 후기를 작성했지만 상대가 아직 작성하지 않은 경우, REVIEW_WAITING_PARTNER displayStatus가 내려가도록 추가했습니다.
- 두 명 모두 현재 책 후기를 작성한 경우에만 기존 교환 단계로 전환되도록 수정했습니다.

<!---- Resolves: #(Isuue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

📣 **To Reviewers**
---
<!-- 전달사항 -->

- Reviewers : 팀 선택
- Labels : 작업 유형, 자기 자신


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 후기 작성 완료 후 파트너의 후기를 기다리는 상태에 대한 새로운 상태 표시 추가

* **Bug Fixes**
  * 후기 작성 시 두 사용자의 검증 및 상태 전환 로직 개선
  * 트래커의 후기 상태 계산 및 표시 정확도 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->