### PR TITLE
[Feat]#525 교환 장소 좌표 및 직접교환 약속장소 스냅샷 구조 설계

### DIFF
--- a/src/main/java/com/example/bookiibookii/domain/group/entity/GroupPlace.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/entity/GroupPlace.java
@@ -19,6 +19,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.math.BigDecimal;
+
 @Entity
 @Table(name = "group_place")
 @Getter
@@ -46,8 +48,14 @@ public class GroupPlace extends BaseEntity {
     @Column(name = "address", nullable = false, length = 200)
     private String address;
 
-    @Column(name = "zip_code", nullable = false, length = 10)
+    @Column(name = "zip_code", length = 10)
     private String zipCode;
+
+    @Column(name = "x", precision = 16, scale = 10)
+    private BigDecimal x;
+
+    @Column(name = "y", precision = 16, scale = 10)
+    private BigDecimal y;
 
     @Column(name = "address_detail", length = 200)
     private String addressDetail;

--- a/src/main/java/com/example/bookiibookii/domain/group/entity/Meeting.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/entity/Meeting.java
@@ -64,10 +64,10 @@ public class Meeting extends BaseEntity {
     @Column(name = "zip_code", length = 10)
     private String zipCode;
 
-    @Column(name = "x", precision = 16, scale = 10)
+    @Column(name = "x", nullable = false, precision = 16, scale = 10)
     private BigDecimal x;
 
-    @Column(name = "y", precision = 16, scale = 10)
+    @Column(name = "y", nullable = false, precision = 16, scale = 10)
     private BigDecimal y;
 
     @Column(name = "address_detail", length = 200)

--- a/src/main/java/com/example/bookiibookii/domain/group/entity/Meeting.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/entity/Meeting.java
@@ -1,6 +1,5 @@
 package com.example.bookiibookii.domain.group.entity;
 
-import com.example.bookiibookii.domain.location.entity.Location;
 import com.example.bookiibookii.domain.tracker.enums.ExchangeRound;
 import com.example.bookiibookii.global.entity.BaseEntity;
 import jakarta.persistence.Column;
@@ -21,6 +20,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.Objects;
 
@@ -55,9 +55,20 @@ public class Meeting extends BaseEntity {
     @Column(name = "exchange_round", nullable = false, length = 30)
     private ExchangeRound exchangeRound;
 
-    @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "location_id", nullable = false)
-    private Location location;
+    @Column(name = "place_name", nullable = false, length = 100)
+    private String placeName;
+
+    @Column(name = "address", nullable = false, length = 200)
+    private String address;
+
+    @Column(name = "zip_code", length = 10)
+    private String zipCode;
+
+    @Column(name = "x", precision = 16, scale = 10)
+    private BigDecimal x;
+
+    @Column(name = "y", precision = 16, scale = 10)
+    private BigDecimal y;
 
     @Column(name = "address_detail", length = 200)
     private String addressDetail;
@@ -69,31 +80,50 @@ public class Meeting extends BaseEntity {
             Groups group,
             MatchedMember createdBy,
             ExchangeRound exchangeRound,
-            Location location,
+            String placeName,
+            String address,
+            String zipCode,
+            BigDecimal x,
+            BigDecimal y,
             String addressDetail,
             LocalDateTime scheduledAt
     ) {
-        validate(group, createdBy, exchangeRound, location, scheduledAt);
+        validate(group, createdBy, exchangeRound, placeName, address, x, y, scheduledAt);
 
         return Meeting.builder()
                 .group(group)
                 .createdBy(createdBy)
                 .exchangeRound(exchangeRound)
-                .location(location)
+                .placeName(placeName)
+                .address(address)
+                .zipCode(zipCode)
+                .x(x)
+                .y(y)
                 .addressDetail(addressDetail)
                 .scheduledAt(scheduledAt)
                 .build();
     }
 
     public void update(
-            Location location,
+            String placeName,
+            String address,
+            String zipCode,
+            BigDecimal x,
+            BigDecimal y,
             String addressDetail,
             LocalDateTime scheduledAt
     ) {
-        Objects.requireNonNull(location, "location must not be null");
+        Objects.requireNonNull(placeName, "placeName must not be null");
+        Objects.requireNonNull(address, "address must not be null");
+        Objects.requireNonNull(x, "x must not be null");
+        Objects.requireNonNull(y, "y must not be null");
         Objects.requireNonNull(scheduledAt, "scheduledAt must not be null");
 
-        this.location = location;
+        this.placeName = placeName;
+        this.address = address;
+        this.zipCode = zipCode;
+        this.x = x;
+        this.y = y;
         this.addressDetail = addressDetail;
         this.scheduledAt = scheduledAt;
     }
@@ -102,13 +132,19 @@ public class Meeting extends BaseEntity {
             Groups group,
             MatchedMember createdBy,
             ExchangeRound exchangeRound,
-            Location location,
+            String placeName,
+            String address,
+            BigDecimal x,
+            BigDecimal y,
             LocalDateTime scheduledAt
     ) {
         Objects.requireNonNull(group, "group must not be null");
         Objects.requireNonNull(createdBy, "createdBy must not be null");
         Objects.requireNonNull(exchangeRound, "exchangeRound must not be null");
-        Objects.requireNonNull(location, "location must not be null");
+        Objects.requireNonNull(placeName, "placeName must not be null");
+        Objects.requireNonNull(address, "address must not be null");
+        Objects.requireNonNull(x, "x must not be null");
+        Objects.requireNonNull(y, "y must not be null");
         Objects.requireNonNull(scheduledAt, "scheduledAt must not be null");
     }
 }

--- a/src/main/java/com/example/bookiibookii/domain/group/repository/MeetingRepository.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/repository/MeetingRepository.java
@@ -23,7 +23,6 @@ public interface MeetingRepository extends JpaRepository<Meeting, Long> {
         join fetch m.group g
         join fetch m.createdBy cb
         join fetch cb.user
-        join fetch m.location
         where g.id = :groupId
           and m.exchangeRound = :exchangeRound
     """)
@@ -38,7 +37,6 @@ public interface MeetingRepository extends JpaRepository<Meeting, Long> {
         join fetch m.group g
         join fetch m.createdBy cb
         join fetch cb.user
-        join fetch m.location
         where g.id = :groupId
           and m.exchangeRound = :exchangeRound
     """)

--- a/src/main/java/com/example/bookiibookii/domain/group/service/GroupService.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/service/GroupService.java
@@ -199,16 +199,20 @@ public class GroupService {
                 throw new GroupException(GroupErrorCode.NOT_MY_DELIVERY_ADDRESS);
             }
 
-            return GroupPlace.builder()
+            GroupPlace groupPlace = GroupPlace.builder()
                     .group(group)
                     .sourceType(GroupPlaceSourceType.USER_DELIVERY)
                     .placeName(userDelivery.getLocation().getPlaceName())
                     .address(userDelivery.getLocation().getAddress())
                     .zipCode(userDelivery.getLocation().getZipCode())
+                    .x(userDelivery.getLocation().getX())
+                    .y(userDelivery.getLocation().getY())
                     .addressDetail(userDelivery.getAddressDetail())
                     .receiverName(userDelivery.getReceiverName())
                     .phoneNumber(userDelivery.getPhone())
                     .build();
+            validateDeliveryGroupPlace(groupPlace);
+            return groupPlace;
         }
 
         if (request.getTradeType() == TradeType.DIRECT) {
@@ -220,17 +224,45 @@ public class GroupService {
                 throw new GroupException(GroupErrorCode.NOT_MY_EXCHANGE_PLACE);
             }
 
-            return GroupPlace.builder()
+            GroupPlace groupPlace = GroupPlace.builder()
                     .group(group)
                     .sourceType(GroupPlaceSourceType.USER_EXCHANGE)
                     .placeName(userExchange.getLocation().getPlaceName())
                     .address(userExchange.getLocation().getAddress())
                     .zipCode(userExchange.getLocation().getZipCode())
+                    .x(userExchange.getLocation().getX())
+                    .y(userExchange.getLocation().getY())
                     .addressDetail(userExchange.getAddressDetail())
                     .build();
+            validateDirectGroupPlace(groupPlace);
+            return groupPlace;
         }
 
         throw new GroupException(GroupErrorCode.INVALID_GROUP_SELECTED_PLACE);
+    }
+
+    private void validateDeliveryGroupPlace(GroupPlace groupPlace) {
+        if (groupPlace.getSourceType() != GroupPlaceSourceType.USER_DELIVERY
+                || isBlank(groupPlace.getReceiverName())
+                || isBlank(groupPlace.getPhoneNumber())
+                || isBlank(groupPlace.getAddress())
+                || isBlank(groupPlace.getZipCode())) {
+            throw new GroupException(GroupErrorCode.INVALID_GROUP_SELECTED_PLACE);
+        }
+    }
+
+    private void validateDirectGroupPlace(GroupPlace groupPlace) {
+        if (groupPlace.getSourceType() != GroupPlaceSourceType.USER_EXCHANGE
+                || isBlank(groupPlace.getPlaceName())
+                || isBlank(groupPlace.getAddress())
+                || groupPlace.getX() == null
+                || groupPlace.getY() == null) {
+            throw new GroupException(GroupErrorCode.INVALID_GROUP_SELECTED_PLACE);
+        }
+    }
+
+    private boolean isBlank(String value) {
+        return value == null || value.isBlank();
     }
 
     private void validateRules(List<RuleDTO> rules) {

--- a/src/main/java/com/example/bookiibookii/domain/location/dto/req/UserDeliveryReqDTO.java
+++ b/src/main/java/com/example/bookiibookii/domain/location/dto/req/UserDeliveryReqDTO.java
@@ -10,31 +10,31 @@ public class UserDeliveryReqDTO {
     @Schema(name = "UserDeliveryAddReqDTO")
     public record AddReqDTO(
             @JsonProperty("placeName")
-            @Schema(description = "장소 이름")
+            @Schema(description = "장소 이름", example = "우리집", requiredMode = Schema.RequiredMode.REQUIRED)
             @NotBlank(message = "장소 이름은 필수입니다.")
             String placeName,
 
             @JsonProperty("address")
-            @Schema(description = "주소")
+            @Schema(description = "주소", example = "서울특별시 강남구 강남대로 396", requiredMode = Schema.RequiredMode.REQUIRED)
             @NotBlank(message = "주소는 필수입니다.")
             String address,
 
             @JsonProperty("zipCode")
-            @Schema(description = "우편번호")
+            @Schema(description = "우편번호", example = "06232", requiredMode = Schema.RequiredMode.REQUIRED)
             @NotBlank(message = "우편번호는 필수입니다.")
             String zipCode,
 
             @JsonProperty("addressDetail")
-            @Schema(description = "상세 주소")
+            @Schema(description = "상세 주소", example = "101동 1001호")
             String addressDetail,
 
             @JsonProperty("receiverName")
-            @Schema(description = "수취인 이름")
+            @Schema(description = "수취인 이름", example = "홍길동", requiredMode = Schema.RequiredMode.REQUIRED)
             @NotBlank(message = "배송지 등록을 위해 수취인 이름은 필수로 입력되어야 합니다.")
             String receiverName,
 
             @JsonProperty("phone")
-            @Schema(description = "전화번호", example = "010-1234-5678")
+            @Schema(description = "전화번호", example = "010-1234-5678", requiredMode = Schema.RequiredMode.REQUIRED)
             @NotBlank(message = "배송지 등록을 위해 전화번호는 필수로 입력되어야 합니다.")
             @Pattern(regexp = "^\\d{2,3}-\\d{3,4}-\\d{4}$", message = "전화번호 형식이 올바르지 않습니다.")
             String phone

--- a/src/main/java/com/example/bookiibookii/domain/location/dto/req/UserExchangeReqDTO.java
+++ b/src/main/java/com/example/bookiibookii/domain/location/dto/req/UserExchangeReqDTO.java
@@ -1,6 +1,8 @@
 package com.example.bookiibookii.domain.location.dto.req;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
@@ -23,10 +25,14 @@ public class UserExchangeReqDTO {
 
             @Schema(description = "X 좌표(경도)", example = "127.027621", requiredMode = Schema.RequiredMode.REQUIRED)
             @NotNull(message = "X 좌표는 필수입니다.")
+            @DecimalMin(value = "-180.0", message = "X 좌표는 -180 이상이어야 합니다.")
+            @DecimalMax(value = "180.0", message = "X 좌표는 180 이하여야 합니다.")
             BigDecimal x,
 
             @Schema(description = "Y 좌표(위도)", example = "37.497942", requiredMode = Schema.RequiredMode.REQUIRED)
             @NotNull(message = "Y 좌표는 필수입니다.")
+            @DecimalMin(value = "-90.0", message = "Y 좌표는 -90 이상이어야 합니다.")
+            @DecimalMax(value = "90.0", message = "Y 좌표는 90 이하여야 합니다.")
             BigDecimal y,
 
             @Schema(description = "상세 주소/설명", example = "11번 출구 앞")

--- a/src/main/java/com/example/bookiibookii/domain/location/dto/req/UserExchangeReqDTO.java
+++ b/src/main/java/com/example/bookiibookii/domain/location/dto/req/UserExchangeReqDTO.java
@@ -2,20 +2,34 @@ package com.example.bookiibookii.domain.location.dto.req;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.math.BigDecimal;
 
 public class UserExchangeReqDTO {
 
     @Schema(name = "UserExchangeAddReqDTO")
     public record AddReqDTO(
+            @Schema(description = "장소 이름", example = "강남역", requiredMode = Schema.RequiredMode.REQUIRED)
             @NotBlank(message = "장소 이름은 필수입니다.")
             String placeName,
 
+            @Schema(description = "주소", example = "서울특별시 강남구 강남대로 396", requiredMode = Schema.RequiredMode.REQUIRED)
             @NotBlank(message = "주소는 필수입니다.")
             String address,
 
-            @NotBlank(message = "우편번호는 필수입니다.")
+            @Schema(description = "우편번호(선택)", example = "06232", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
             String zipCode,
 
+            @Schema(description = "X 좌표(경도)", example = "127.027621", requiredMode = Schema.RequiredMode.REQUIRED)
+            @NotNull(message = "X 좌표는 필수입니다.")
+            BigDecimal x,
+
+            @Schema(description = "Y 좌표(위도)", example = "37.497942", requiredMode = Schema.RequiredMode.REQUIRED)
+            @NotNull(message = "Y 좌표는 필수입니다.")
+            BigDecimal y,
+
+            @Schema(description = "상세 주소/설명", example = "11번 출구 앞")
             String addressDetail
     ) {}
 }

--- a/src/main/java/com/example/bookiibookii/domain/location/dto/res/UserExchangeResDTO.java
+++ b/src/main/java/com/example/bookiibookii/domain/location/dto/res/UserExchangeResDTO.java
@@ -2,6 +2,8 @@ package com.example.bookiibookii.domain.location.dto.res;
 
 import com.example.bookiibookii.domain.location.entity.UserExchange;
 
+import java.math.BigDecimal;
+
 public class UserExchangeResDTO {
 
     public record UserExchangeDto(
@@ -9,6 +11,8 @@ public class UserExchangeResDTO {
             String placeName,
             String address,
             String zipCode,
+            BigDecimal x,
+            BigDecimal y,
             String addressDetail,
             boolean isDefault
     ) {
@@ -18,6 +22,8 @@ public class UserExchangeResDTO {
                     ue.getLocation().getPlaceName(),
                     ue.getLocation().getAddress(),
                     ue.getLocation().getZipCode(),
+                    ue.getLocation().getX(),
+                    ue.getLocation().getY(),
                     ue.getAddressDetail(),
                     ue.isDefault()
             );

--- a/src/main/java/com/example/bookiibookii/domain/location/entity/Location.java
+++ b/src/main/java/com/example/bookiibookii/domain/location/entity/Location.java
@@ -4,6 +4,8 @@ import com.example.bookiibookii.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.math.BigDecimal;
+
 @Entity
 @Table(name = "location")
 @Getter
@@ -23,6 +25,24 @@ public class Location extends BaseEntity {
     @Column(name = "address", nullable = false, unique = true, length = 200)
     private String address;
 
-    @Column(name = "zip_code", nullable = false, length = 10)
+    @Column(name = "zip_code", length = 10)
     private String zipCode;
+
+    @Column(name = "x", precision = 16, scale = 10)
+    private BigDecimal x;
+
+    @Column(name = "y", precision = 16, scale = 10)
+    private BigDecimal y;
+
+    public void fillMissingDetails(String zipCode, BigDecimal x, BigDecimal y) {
+        if (this.zipCode == null && zipCode != null) {
+            this.zipCode = zipCode;
+        }
+        if (this.x == null && x != null) {
+            this.x = x;
+        }
+        if (this.y == null && y != null) {
+            this.y = y;
+        }
+    }
 }

--- a/src/main/java/com/example/bookiibookii/domain/location/entity/Location.java
+++ b/src/main/java/com/example/bookiibookii/domain/location/entity/Location.java
@@ -22,7 +22,7 @@ public class Location extends BaseEntity {
     @Column(name = "place_name", nullable = false, length = 100)
     private String placeName;
 
-    @Column(name = "address", nullable = false, unique = true, length = 200)
+    @Column(name = "address", nullable = false, length = 200)
     private String address;
 
     @Column(name = "zip_code", length = 10)
@@ -34,15 +34,9 @@ public class Location extends BaseEntity {
     @Column(name = "y", precision = 16, scale = 10)
     private BigDecimal y;
 
-    public void fillMissingDetails(String zipCode, BigDecimal x, BigDecimal y) {
+    public void fillMissingDetails(String zipCode) {
         if (this.zipCode == null && zipCode != null) {
             this.zipCode = zipCode;
-        }
-        if (this.x == null && x != null) {
-            this.x = x;
-        }
-        if (this.y == null && y != null) {
-            this.y = y;
         }
     }
 }

--- a/src/main/java/com/example/bookiibookii/domain/location/exception/code/LocationErrorCode.java
+++ b/src/main/java/com/example/bookiibookii/domain/location/exception/code/LocationErrorCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum LocationErrorCode implements BaseCode {
     NOT_FOUND(HttpStatus.NOT_FOUND, "LOCATION404_1", "장소를 찾을 수 없습니다."),
-    LOCATION_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "LOCATION400_1", "최대 2개까지 등록 가능합니다.");
+    LOCATION_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "LOCATION400_1", "최대 2개까지 등록 가능합니다."),
+    EXCHANGE_COORDINATES_REQUIRED(HttpStatus.BAD_REQUEST, "LOCATION400_2", "희망 교환 장소는 좌표가 필요합니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/example/bookiibookii/domain/location/repository/LocationRepository.java
+++ b/src/main/java/com/example/bookiibookii/domain/location/repository/LocationRepository.java
@@ -4,9 +4,10 @@ import com.example.bookiibookii.domain.location.entity.Location;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.math.BigDecimal;
 import java.util.Optional;
 
 @Repository
 public interface LocationRepository extends JpaRepository<Location, Long> {
-    Optional<Location> findByAddress(String address);
+    Optional<Location> findByAddressAndXAndY(String address, BigDecimal x, BigDecimal y);
 }

--- a/src/main/java/com/example/bookiibookii/domain/location/service/LocationService.java
+++ b/src/main/java/com/example/bookiibookii/domain/location/service/LocationService.java
@@ -8,6 +8,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigDecimal;
+
 @Service
 @RequiredArgsConstructor
 public class LocationService {
@@ -16,7 +18,16 @@ public class LocationService {
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public Location findOrCreate(String placeName, String address, String zipCode) {
+        return findOrCreate(placeName, address, zipCode, null, null);
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public Location findOrCreate(String placeName, String address, String zipCode, BigDecimal x, BigDecimal y) {
         return locationRepository.findByAddress(address)
+                .map(location -> {
+                    location.fillMissingDetails(zipCode, x, y);
+                    return location;
+                })
                 .orElseGet(() -> {
                     try {
                         return locationRepository.saveAndFlush(
@@ -24,10 +35,14 @@ public class LocationService {
                                         .placeName(placeName)
                                         .address(address)
                                         .zipCode(zipCode)
+                                        .x(x)
+                                        .y(y)
                                         .build()
                         );
                     } catch (DataIntegrityViolationException e) {
-                        return locationRepository.findByAddress(address).orElseThrow();
+                        Location location = locationRepository.findByAddress(address).orElseThrow();
+                        location.fillMissingDetails(zipCode, x, y);
+                        return location;
                     }
                 });
     }

--- a/src/main/java/com/example/bookiibookii/domain/location/service/LocationService.java
+++ b/src/main/java/com/example/bookiibookii/domain/location/service/LocationService.java
@@ -23,9 +23,9 @@ public class LocationService {
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public Location findOrCreate(String placeName, String address, String zipCode, BigDecimal x, BigDecimal y) {
-        return locationRepository.findByAddress(address)
+        return locationRepository.findByAddressAndXAndY(address, x, y)
                 .map(location -> {
-                    location.fillMissingDetails(zipCode, x, y);
+                    location.fillMissingDetails(zipCode);
                     return location;
                 })
                 .orElseGet(() -> {
@@ -40,8 +40,8 @@ public class LocationService {
                                         .build()
                         );
                     } catch (DataIntegrityViolationException e) {
-                        Location location = locationRepository.findByAddress(address).orElseThrow();
-                        location.fillMissingDetails(zipCode, x, y);
+                        Location location = locationRepository.findByAddressAndXAndY(address, x, y).orElseThrow();
+                        location.fillMissingDetails(zipCode);
                         return location;
                     }
                 });

--- a/src/main/java/com/example/bookiibookii/domain/location/service/UserExchangeService.java
+++ b/src/main/java/com/example/bookiibookii/domain/location/service/UserExchangeService.java
@@ -36,6 +36,8 @@ public class UserExchangeService {
 
     @Transactional
     public void addExchange(Long userId, UserExchangeReqDTO.AddReqDTO req) {
+        validateExchangeCoordinates(req);
+
         User user = userRepository.findByIdForUpdate(userId)
                 .orElseThrow(() -> new UserException(UserErrorCode.NOT_FOUND));
 
@@ -44,7 +46,7 @@ public class UserExchangeService {
             throw new LocationException(LocationErrorCode.LOCATION_LIMIT_EXCEEDED);
         }
 
-        Location location = locationService.findOrCreate(req.placeName(), req.address(), req.zipCode());
+        Location location = locationService.findOrCreate(req.placeName(), req.address(), req.zipCode(), req.x(), req.y());
 
         userExchangeRepository.save(
                 UserExchange.builder()
@@ -58,11 +60,13 @@ public class UserExchangeService {
 
     @Transactional
     public void updateExchange(Long userId, Long userExchangeId, UserExchangeReqDTO.AddReqDTO req) {
+        validateExchangeCoordinates(req);
+
         UserExchange userExchange = userExchangeRepository
                 .findByIdAndUser_Id(userExchangeId, userId)
                 .orElseThrow(() -> new LocationException(LocationErrorCode.NOT_FOUND));
 
-        Location location = locationService.findOrCreate(req.placeName(), req.address(), req.zipCode());
+        Location location = locationService.findOrCreate(req.placeName(), req.address(), req.zipCode(), req.x(), req.y());
         userExchange.update(location, req.addressDetail());
     }
 
@@ -86,5 +90,11 @@ public class UserExchangeService {
             throw new LocationException(LocationErrorCode.NOT_FOUND);
         }
         userExchangeRepository.updateDefaultExchange(userId, userExchangeId);
+    }
+
+    private void validateExchangeCoordinates(UserExchangeReqDTO.AddReqDTO req) {
+        if (req.x() == null || req.y() == null) {
+            throw new LocationException(LocationErrorCode.EXCHANGE_COORDINATES_REQUIRED);
+        }
     }
 }

--- a/src/main/java/com/example/bookiibookii/domain/tracker/controller/MeetingControllerDocs.java
+++ b/src/main/java/com/example/bookiibookii/domain/tracker/controller/MeetingControllerDocs.java
@@ -8,6 +8,7 @@ import com.example.bookiibookii.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -49,6 +50,40 @@ public interface MeetingControllerDocs {
     })
     ApiResponse<MeetingResponseDTO> createMeeting(
             @Parameter(description = "그룹 식별자(ID)", example = "1") @PathVariable Long groupId,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    required = true,
+                    content = @Content(
+                            schema = @Schema(implementation = MeetingRequestDTO.class),
+                            examples = {
+                                    @ExampleObject(
+                                            name = "default-place 응답 기반 스냅샷 입력",
+                                            value = """
+                                            {
+                                              "placeName": "스타벅스 강남점",
+                                              "address": "서울특별시 강남구 강남대로 100",
+                                              "x": 127.027621,
+                                              "y": 37.497942,
+                                              "addressDetail": "2층",
+                                              "scheduledAt": "2026-05-20T14:30:00"
+                                            }
+                                            """
+                                    ),
+                                    @ExampleObject(
+                                            name = "새 장소 직접 입력",
+                                            value = """
+                                            {
+                                              "placeName": "강남역",
+                                              "address": "서울특별시 강남구 강남대로 396",
+                                              "x": 127.027621,
+                                              "y": 37.497942,
+                                              "addressDetail": "11번 출구 앞",
+                                              "scheduledAt": "2026-05-20T14:30:00"
+                                            }
+                                            """
+                                    )
+                            }
+                    )
+            )
             @RequestBody @Valid MeetingRequestDTO request,
             @Parameter(hidden = true) @AuthenticationPrincipal(expression = "user") User user
     );
@@ -60,7 +95,7 @@ public interface MeetingControllerDocs {
             HOST가 groupId 기준으로 현재 등록된 직접교환 약속을 수정합니다.
             
             - 프론트가 meetingId를 들고 있지 않아도 됩니다.
-            - 수정 가능 필드: locationId, addressDetail, scheduledAt
+            - 수정 가능 필드: placeName, address, zipCode, x, y, addressDetail, scheduledAt
             """
     )
     @ApiResponses({
@@ -75,6 +110,40 @@ public interface MeetingControllerDocs {
     })
     ApiResponse<MeetingResponseDTO> updateMeeting(
             @Parameter(description = "그룹 식별자(ID)", example = "1") @PathVariable Long groupId,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    required = true,
+                    content = @Content(
+                            schema = @Schema(implementation = MeetingRequestDTO.class),
+                            examples = {
+                                    @ExampleObject(
+                                            name = "default-place 응답 기반 스냅샷 입력",
+                                            value = """
+                                            {
+                                              "placeName": "스타벅스 강남점",
+                                              "address": "서울특별시 강남구 강남대로 100",
+                                              "x": 127.027621,
+                                              "y": 37.497942,
+                                              "addressDetail": "2층",
+                                              "scheduledAt": "2026-05-20T14:30:00"
+                                            }
+                                            """
+                                    ),
+                                    @ExampleObject(
+                                            name = "새 장소 직접 입력",
+                                            value = """
+                                            {
+                                              "placeName": "강남역",
+                                              "address": "서울특별시 강남구 강남대로 396",
+                                              "x": 127.027621,
+                                              "y": 37.497942,
+                                              "addressDetail": "11번 출구 앞",
+                                              "scheduledAt": "2026-05-20T14:30:00"
+                                            }
+                                            """
+                                    )
+                            }
+                    )
+            )
             @RequestBody @Valid MeetingRequestDTO request,
             @Parameter(hidden = true) @AuthenticationPrincipal(expression = "user") User user
     );

--- a/src/main/java/com/example/bookiibookii/domain/tracker/dto/req/MeetingRequestDTO.java
+++ b/src/main/java/com/example/bookiibookii/domain/tracker/dto/req/MeetingRequestDTO.java
@@ -2,27 +2,50 @@ package com.example.bookiibookii.domain.tracker.dto.req;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
 @Schema(
         description = "직접 교환 약속 등록/수정 요청",
         example = """
         {
-          "locationId": 1,
-          "addressDetail": "2층 창가 자리",
+          "placeName": "스타벅스 강남점",
+          "address": "서울특별시 강남구 강남대로 100",
+          "x": 127.027621,
+          "y": 37.497942,
+          "addressDetail": "2층",
           "scheduledAt": "2026-05-20T14:30:00"
         }
         """
 )
 public record MeetingRequestDTO(
-        @Schema(description = "Location ID", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
-        @NotNull(message = "장소 ID는 필수입니다.")
-        Long locationId,
+        @Schema(description = "장소명", example = "강남역", requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotBlank(message = "장소 이름은 필수입니다.")
+        @Size(max = 100, message = "장소 이름은 100자 이내로 입력해주세요.")
+        String placeName,
 
-        @Schema(description = "Location에는 없는 상세 주소", example = "2층 창가 자리")
+        @Schema(description = "주소", example = "서울특별시 강남구 강남대로 396", requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotBlank(message = "주소는 필수입니다.")
+        @Size(max = 200, message = "주소는 200자 이내로 입력해주세요.")
+        String address,
+
+        @Schema(description = "우편번호(선택)", example = "06232", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+        @Size(max = 10, message = "우편번호는 10자 이내로 입력해주세요.")
+        String zipCode,
+
+        @Schema(description = "X 좌표(경도)", example = "127.027621", requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotNull(message = "X 좌표는 필수입니다.")
+        BigDecimal x,
+
+        @Schema(description = "Y 좌표(위도)", example = "37.497942", requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotNull(message = "Y 좌표는 필수입니다.")
+        BigDecimal y,
+
+        @Schema(description = "약속별 상세 주소/설명", example = "2층 창가 자리")
         @Size(max = 200, message = "상세 주소는 200자 이내로 입력해주세요.")
         String addressDetail,
 

--- a/src/main/java/com/example/bookiibookii/domain/tracker/dto/req/MeetingRequestDTO.java
+++ b/src/main/java/com/example/bookiibookii/domain/tracker/dto/req/MeetingRequestDTO.java
@@ -2,6 +2,8 @@ package com.example.bookiibookii.domain.tracker.dto.req;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -39,10 +41,14 @@ public record MeetingRequestDTO(
 
         @Schema(description = "X 좌표(경도)", example = "127.027621", requiredMode = Schema.RequiredMode.REQUIRED)
         @NotNull(message = "X 좌표는 필수입니다.")
+        @DecimalMin(value = "-180.0", message = "X 좌표는 -180 이상이어야 합니다.")
+        @DecimalMax(value = "180.0", message = "X 좌표는 180 이하여야 합니다.")
         BigDecimal x,
 
         @Schema(description = "Y 좌표(위도)", example = "37.497942", requiredMode = Schema.RequiredMode.REQUIRED)
         @NotNull(message = "Y 좌표는 필수입니다.")
+        @DecimalMin(value = "-90.0", message = "Y 좌표는 -90 이상이어야 합니다.")
+        @DecimalMax(value = "90.0", message = "Y 좌표는 90 이하여야 합니다.")
         BigDecimal y,
 
         @Schema(description = "약속별 상세 주소/설명", example = "2층 창가 자리")

--- a/src/main/java/com/example/bookiibookii/domain/tracker/dto/res/MeetingDefaultPlaceResponseDTO.java
+++ b/src/main/java/com/example/bookiibookii/domain/tracker/dto/res/MeetingDefaultPlaceResponseDTO.java
@@ -4,6 +4,8 @@ import com.example.bookiibookii.domain.group.entity.GroupPlace;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
+import java.math.BigDecimal;
+
 @Builder
 @Schema(description = "직접 교환 기본 장소 응답")
 public record MeetingDefaultPlaceResponseDTO(
@@ -16,6 +18,12 @@ public record MeetingDefaultPlaceResponseDTO(
         @Schema(description = "우편번호", example = "12345")
         String zipCode,
 
+        @Schema(description = "X 좌표(경도)", example = "127.027621")
+        BigDecimal x,
+
+        @Schema(description = "Y 좌표(위도)", example = "37.497942")
+        BigDecimal y,
+
         @Schema(description = "상세 주소", example = "2층")
         String addressDetail
 ) {
@@ -24,6 +32,8 @@ public record MeetingDefaultPlaceResponseDTO(
                 .placeName(groupPlace.getPlaceName())
                 .address(groupPlace.getAddress())
                 .zipCode(groupPlace.getZipCode())
+                .x(groupPlace.getX())
+                .y(groupPlace.getY())
                 .addressDetail(groupPlace.getAddressDetail())
                 .build();
     }

--- a/src/main/java/com/example/bookiibookii/domain/tracker/dto/res/MeetingResponseDTO.java
+++ b/src/main/java/com/example/bookiibookii/domain/tracker/dto/res/MeetingResponseDTO.java
@@ -6,6 +6,7 @@ import com.example.bookiibookii.domain.tracker.enums.ExchangeRound;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
 @Builder
@@ -39,22 +40,25 @@ public record MeetingResponseDTO(
     @Builder
     @Schema(description = "약속 장소 정보")
     public record LocationInfo(
-            @Schema(description = "Location ID", example = "1")
-            Long locationId,
             @Schema(description = "장소명", example = "강남역")
             String placeName,
             @Schema(description = "주소", example = "서울특별시 강남구 강남대로 396")
             String address,
             @Schema(description = "우편번호", example = "06232")
-            String zipCode
+            String zipCode,
+            @Schema(description = "X 좌표(경도)", example = "127.027621")
+            BigDecimal x,
+            @Schema(description = "Y 좌표(위도)", example = "37.497942")
+            BigDecimal y
     ) {
 
         private static LocationInfo from(Meeting meeting) {
             return LocationInfo.builder()
-                    .locationId(meeting.getLocation().getId())
-                    .placeName(meeting.getLocation().getPlaceName())
-                    .address(meeting.getLocation().getAddress())
-                    .zipCode(meeting.getLocation().getZipCode())
+                    .placeName(meeting.getPlaceName())
+                    .address(meeting.getAddress())
+                    .zipCode(meeting.getZipCode())
+                    .x(meeting.getX())
+                    .y(meeting.getY())
                     .build();
         }
     }

--- a/src/main/java/com/example/bookiibookii/domain/tracker/service/MeetingService.java
+++ b/src/main/java/com/example/bookiibookii/domain/tracker/service/MeetingService.java
@@ -13,10 +13,6 @@ import com.example.bookiibookii.domain.group.repository.GroupsRepository;
 import com.example.bookiibookii.domain.group.repository.GroupPlaceRepository;
 import com.example.bookiibookii.domain.group.repository.MatchedMemberRepository;
 import com.example.bookiibookii.domain.group.repository.MeetingRepository;
-import com.example.bookiibookii.domain.location.entity.Location;
-import com.example.bookiibookii.domain.location.exception.LocationException;
-import com.example.bookiibookii.domain.location.exception.code.LocationErrorCode;
-import com.example.bookiibookii.domain.location.repository.LocationRepository;
 import com.example.bookiibookii.domain.memberbook.entity.MemberBook;
 import com.example.bookiibookii.domain.tracker.dto.req.MeetingRequestDTO;
 import com.example.bookiibookii.domain.tracker.dto.res.MeetingDefaultPlaceResponseDTO;
@@ -43,7 +39,6 @@ public class MeetingService {
     private final MeetingRepository meetingRepository;
     private final GroupsRepository groupsRepository;
     private final MatchedMemberRepository matchedMemberRepository;
-    private final LocationRepository locationRepository;
     private final GroupPlaceRepository groupPlaceRepository;
 
     @Transactional
@@ -58,8 +53,18 @@ public class MeetingService {
             throw new TrackerException(TrackerErrorCode.MEETING_ALREADY_EXISTS);
         }
 
-        Location location = getLocation(request.locationId());
-        Meeting meeting = Meeting.create(group, me, exchangeRound, location, request.addressDetail(), request.scheduledAt());
+        Meeting meeting = Meeting.create(
+                group,
+                me,
+                exchangeRound,
+                request.placeName(),
+                request.address(),
+                request.zipCode(),
+                request.x(),
+                request.y(),
+                request.addressDetail(),
+                request.scheduledAt()
+        );
 
         try {
             meeting = meetingRepository.save(meeting);
@@ -82,8 +87,15 @@ public class MeetingService {
         MatchedMember me = findMe(members, user.getId());
         validateHost(me);
 
-        Location location = getLocation(request.locationId());
-        meeting.update(location, request.addressDetail(), request.scheduledAt());
+        meeting.update(
+                request.placeName(),
+                request.address(),
+                request.zipCode(),
+                request.x(),
+                request.y(),
+                request.addressDetail(),
+                request.scheduledAt()
+        );
 
         return MeetingResponseDTO.from(meeting);
     }
@@ -213,11 +225,6 @@ public class MeetingService {
             case RETURNING -> ExchangeRound.RETURN_EXCHANGE;
             default -> throw new TrackerException(TrackerErrorCode.INVALID_MEETING_PHASE);
         };
-    }
-
-    private Location getLocation(Long locationId) {
-        return locationRepository.findById(locationId)
-                .orElseThrow(() -> new LocationException(LocationErrorCode.NOT_FOUND));
     }
 
     private void completeMeetingPhase(List<MatchedMember> members) {


### PR DESCRIPTION
## 개요
<!---- 자신이 완료한 이슈를 닫아주세요 -->
- closed #525 

- 직접교환 약속 등록 API에서 locationId 입력 방식을 제거하고, Meeting 장소 스냅샷 입력 방식으로 단순화했습니다.
- Location, GroupPlace, Meeting에 좌표 x,y 필드를 추가했으며, 배송지는 zipCode 중심, 직접교환 장소는 x/y 중심으로 검증됩니다.
- UserExchange는 x/y 필수, zipCode 선택으로 변경됐고, UserDelivery는 기존 배송지 필수값을 유지합니다.
- 직접교환 기본 장소 조회 응답에 x,y가 추가됐고, 약속 조회 응답은 Meeting 스냅샷 기준으로 내려갑니다.

<!---- Resolves: #(Isuue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

📣 **To Reviewers**
---
<!-- 전달사항 -->

- Reviewers : 팀 선택
- Labels : 작업 유형, 자기 자신


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * 모임 장소와 그룹 거래 장소에 좌표 정보(경도/위도) 지원 추가
  * 교환 희망 장소에 필수 좌표 검증 추가

* **설명서**
  * API 문서에 모임 생성/수정 시 위치 관련 요청 필드 및 예시 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->