### PR TITLE
[Fix]#528 그룹 생성시 받는 필드 변경

### DIFF
--- a/src/main/java/com/example/bookiibookii/domain/group/controller/GroupControllerDocs.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/controller/GroupControllerDocs.java
@@ -27,20 +27,36 @@ public interface GroupControllerDocs {
             summary = "그룹 생성 API",
             description = """
                     새로운 독서 그룹을 생성합니다.
-                    selectedPlaceId는 tradeType에 따라 의미가 다릅니다.
-                    - DELIVERY: 내 배송지 id
-                    - DIRECT: 내 희망교환장소 id
-                    그룹 생성 시 선택 장소는 그룹 장소 스냅샷으로 복사 저장됩니다.
+                    장소 선택 필드는 tradeType에 따라 하나만 전달합니다.
+                    - DIRECT: userExchangeId에 /api/mypage/addresses/exchanges 응답의 userExchangeId(id)를 전달합니다.
+                    - DELIVERY: userDeliveryId에 /api/mypage/addresses/deliveries 응답의 userDeliveryId(id)를 전달합니다.
+                    locationId는 받지 않으며, 그룹 생성 시 선택 장소는 group_place 스냅샷으로 복사 저장됩니다.
+                    
+                    DIRECT 예시:
+                    {
+                      "tradeType": "DIRECT",
+                      "userExchangeId": 1
+                    }
+                    
+                    DELIVERY 예시:
+                    {
+                      "tradeType": "DELIVERY",
+                      "userDeliveryId": 1
+                    }
                     """
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "GROUP400_4", description = "도서 미선택"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "GROUP400_23", description = "선택 장소 필수"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "GROUP400_25", description = "DIRECT 요청에 userExchangeId 누락"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "GROUP400_26", description = "DIRECT 요청에 userDeliveryId 전달"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "GROUP400_27", description = "DELIVERY 요청에 userDeliveryId 누락"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "GROUP400_28", description = "DELIVERY 요청에 userExchangeId 전달"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "GROUP400_24", description = "교환 방식과 선택 장소 불일치"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "GROUP403_5", description = "본인 배송지가 아님"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "GROUP403_6", description = "본인 희망교환장소가 아님"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "GROUP404_7", description = "선택 장소 없음")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "GROUP404_8", description = "직접교환 장소 없음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "GROUP404_9", description = "배송지 없음")
     })
     ApiResponse<GroupResponseDTO.CreateResultDTO> createGroup(
             @AuthenticationPrincipal User host,

--- a/src/main/java/com/example/bookiibookii/domain/group/dto/req/GroupRequestDTO.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/dto/req/GroupRequestDTO.java
@@ -27,8 +27,10 @@ public class GroupRequestDTO {
         @NotNull(message = "교환 방식은 필수입니다.")
         @Schema(description = "교환 방식 (DIRECT: 직거래, DELIVERY: 택배 교환)", example = "DIRECT")
         private TradeType tradeType;
-        @Schema(description = "그룹 생성 시 선택한 장소 id. DELIVERY는 내 배송지 id, DIRECT는 내 희망교환장소 id입니다.", example = "1")
-        private Long selectedPlaceId;
+        @Schema(description = "택배 교환(DELIVERY) 그룹 생성 시 선택한 내 배송지 ID(user_delivery.user_delivery_id). DIRECT 요청에서는 전달하지 않습니다.", example = "1")
+        private Long userDeliveryId;
+        @Schema(description = "직거래(DIRECT) 그룹 생성 시 선택한 내 희망교환장소 ID(user_exchange.user_exchange_id). DELIVERY 요청에서는 전달하지 않습니다.", example = "1")
+        private Long userExchangeId;
         @NotBlank(message = "그룹명은 필수입니다.")
         @Schema(description = "그룹명", example = "같이 읽어요")
         private String groupName;

--- a/src/main/java/com/example/bookiibookii/domain/group/exception/code/GroupErrorCode.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/exception/code/GroupErrorCode.java
@@ -41,6 +41,10 @@ public enum GroupErrorCode implements BaseCode {
     READING_STYLE_TAG_REQUIRED(HttpStatus.BAD_REQUEST, "GROUP400_22", "독서 스타일 규칙은 1개 이상 선택해야 합니다."),
     GROUP_SELECTED_PLACE_REQUIRED(HttpStatus.BAD_REQUEST, "GROUP400_23", "그룹 생성 시 선택 장소가 필요합니다."),
     INVALID_GROUP_SELECTED_PLACE(HttpStatus.BAD_REQUEST, "GROUP400_24", "그룹 교환 방식과 선택 장소가 일치하지 않습니다."),
+    USER_EXCHANGE_ID_REQUIRED(HttpStatus.BAD_REQUEST, "GROUP400_25", "직거래 그룹 생성 시 userExchangeId가 필요합니다."),
+    USER_DELIVERY_ID_NOT_ALLOWED_FOR_DIRECT(HttpStatus.BAD_REQUEST, "GROUP400_26", "직거래 그룹 생성 시 userDeliveryId는 전달할 수 없습니다."),
+    USER_DELIVERY_ID_REQUIRED(HttpStatus.BAD_REQUEST, "GROUP400_27", "택배 교환 그룹 생성 시 userDeliveryId가 필요합니다."),
+    USER_EXCHANGE_ID_NOT_ALLOWED_FOR_DELIVERY(HttpStatus.BAD_REQUEST, "GROUP400_28", "택배 교환 그룹 생성 시 userExchangeId는 전달할 수 없습니다."),
 
     // 403 Forbidden
     MEMBER_NOT_HOST(HttpStatus.FORBIDDEN, "GROUP403_1", "Host만 접근 가능한 메뉴입니다."),
@@ -51,7 +55,9 @@ public enum GroupErrorCode implements BaseCode {
     NOT_MY_EXCHANGE_PLACE(HttpStatus.FORBIDDEN, "GROUP403_6", "본인의 희망교환장소만 선택할 수 있습니다."),
 
     // 404 Not Found
-    GROUP_SELECTED_PLACE_NOT_FOUND(HttpStatus.NOT_FOUND, "GROUP404_7", "그룹 생성 시 선택한 장소를 찾을 수 없습니다.")
+    GROUP_SELECTED_PLACE_NOT_FOUND(HttpStatus.NOT_FOUND, "GROUP404_7", "그룹 생성 시 선택한 장소를 찾을 수 없습니다."),
+    DIRECT_EXCHANGE_PLACE_NOT_FOUND(HttpStatus.NOT_FOUND, "GROUP404_8", "직접교환 장소를 먼저 등록해주세요."),
+    DELIVERY_ADDRESS_NOT_FOUND(HttpStatus.NOT_FOUND, "GROUP404_9", "배송지를 먼저 등록해주세요.")
 
 ;
 

--- a/src/main/java/com/example/bookiibookii/domain/group/service/GroupService.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/service/GroupService.java
@@ -169,9 +169,7 @@ public class GroupService {
             throw new GroupException(GroupErrorCode.INVALID_GROUP_TYPE);
         }
 
-        if (request.getSelectedPlaceId() == null) {
-            throw new GroupException(GroupErrorCode.GROUP_SELECTED_PLACE_REQUIRED);
-        }
+        validateGroupPlaceSelection(request);
 
         // 소개글 선택 입력 — 값이 있을 때만 검증
         if (request.getGroupComment() != null && !request.getGroupComment().isBlank()) {
@@ -184,6 +182,30 @@ public class GroupService {
         }
     }
 
+    private void validateGroupPlaceSelection(GroupRequestDTO.CreateDTO request) {
+        if (request.getTradeType() == TradeType.DIRECT) {
+            if (request.getUserDeliveryId() != null) {
+                throw new GroupException(GroupErrorCode.USER_DELIVERY_ID_NOT_ALLOWED_FOR_DIRECT);
+            }
+            if (request.getUserExchangeId() == null) {
+                throw new GroupException(GroupErrorCode.USER_EXCHANGE_ID_REQUIRED);
+            }
+            return;
+        }
+
+        if (request.getTradeType() == TradeType.DELIVERY) {
+            if (request.getUserExchangeId() != null) {
+                throw new GroupException(GroupErrorCode.USER_EXCHANGE_ID_NOT_ALLOWED_FOR_DELIVERY);
+            }
+            if (request.getUserDeliveryId() == null) {
+                throw new GroupException(GroupErrorCode.USER_DELIVERY_ID_REQUIRED);
+            }
+            return;
+        }
+
+        throw new GroupException(GroupErrorCode.INVALID_GROUP_SELECTED_PLACE);
+    }
+
     private void validatePolicy(User host, GroupRequestDTO.CreateDTO request) {
         // 규칙 검증 (모든 트레이드 타입 공통)
         validateRules(request.getRules());
@@ -192,8 +214,8 @@ public class GroupService {
     private GroupPlace createGroupPlace(Groups group, User host, GroupRequestDTO.CreateDTO request) {
         if (request.getTradeType() == TradeType.DELIVERY) {
             UserDelivery userDelivery = userDeliveryRepository
-                    .findById(request.getSelectedPlaceId())
-                    .orElseThrow(() -> new GroupException(GroupErrorCode.GROUP_SELECTED_PLACE_NOT_FOUND));
+                    .findById(request.getUserDeliveryId())
+                    .orElseThrow(() -> new GroupException(GroupErrorCode.DELIVERY_ADDRESS_NOT_FOUND));
 
             if (!userDelivery.getUser().getId().equals(host.getId())) {
                 throw new GroupException(GroupErrorCode.NOT_MY_DELIVERY_ADDRESS);
@@ -217,8 +239,8 @@ public class GroupService {
 
         if (request.getTradeType() == TradeType.DIRECT) {
             UserExchange userExchange = userExchangeRepository
-                    .findById(request.getSelectedPlaceId())
-                    .orElseThrow(() -> new GroupException(GroupErrorCode.GROUP_SELECTED_PLACE_NOT_FOUND));
+                    .findById(request.getUserExchangeId())
+                    .orElseThrow(() -> new GroupException(GroupErrorCode.DIRECT_EXCHANGE_PLACE_NOT_FOUND));
 
             if (!userExchange.getUser().getId().equals(host.getId())) {
                 throw new GroupException(GroupErrorCode.NOT_MY_EXCHANGE_PLACE);


### PR DESCRIPTION
## 개요
<!---- 자신이 완료한 이슈를 닫아주세요 -->
- closed #528 
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
기존 그룹 생성 로직에서도 tradeType에 따라 userDeliveryId 또는 userExchangeId를 사용하고 있었지만, 
요청 필드명이 selectedPlaceId로 되어 있어 locationId나 groupPlaceId로 혼동될 수 있다고 판단했습니다. 

따라서 단일 selectedPlaceId 필드를 제거하고, 
교환 방식에 맞게 userDeliveryId, userExchangeId를 명시적으로 받도록 변경했습니다.
DELIVERY 타입 → userDeliveryId
DIRECT 타입 → userExchangeId

<!---- Resolves: #(Isuue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [x] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

📣 **To Reviewers**
---
<!-- 전달사항 -->

- Reviewers : 팀 선택
- Labels : 작업 유형, 자기 자신


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * 그룹 생성 API 문서를 업데이트하여 거래 유형별 필드 요구사항을 명확히 표시했습니다.

* **Bug Fixes**
  * 거래 유형(배송/직거래)에 따른 필드 검증 로직을 개선하여 API 요청의 일관성을 강화했습니다.
  * 새로운 에러 코드를 추가하여 잘못된 필드 조합이나 누락된 항목에 대한 오류 처리를 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->