### PR TITLE
[Mod]#531 독서카드 삭제 로직 수정

### DIFF
--- a/src/main/java/com/example/bookiibookii/domain/memberbook/controller/MemberBookCardControllerDocs.java
+++ b/src/main/java/com/example/bookiibookii/domain/memberbook/controller/MemberBookCardControllerDocs.java
@@ -217,14 +217,15 @@ public interface MemberBookCardControllerDocs {
     );
 
     @Operation(
-            summary = "멤버북 독서카드 내 화면에서 제거",
+            summary = "멤버북 독서카드 삭제",
             description = """
-            그룹 내 공유된 독서카드를 내 화면에서만 숨깁니다. Cards 데이터는 삭제되지 않으며, 다른 멤버는 계속 조회할 수 있습니다.
+            독서카드를 삭제합니다. 삭제 주체에 따라 동작이 다릅니다.
 
             - **엔드포인트**: `DELETE /api/member-books/cards/{cardId}`
-            - `MemberCard`가 없으면 생성하고 `hidden=true`로 설정합니다.
-            - 카드 소유자 또는 그룹 멤버만 호출 가능합니다. 이미 숨긴 카드는 무시됩니다(멱등).
-            - 북마크된 카드는 삭제할 수 없습니다.
+            - **카드 소유자(작성자)**: `Cards.deletedAt`을 설정해 그룹 전체에서 제거합니다. 파트너도 더 이상 조회할 수 없습니다.
+            - **비소유자(파트너)**: `MemberCard.hidden=true`로 본인 화면에서만 숨깁니다. 카드 데이터는 유지됩니다.
+            - 북마크된 카드는 삭제할 수 없습니다 (`MB400_8`). 소유자·비소유자 모두 동일합니다.
+            - 이미 숨긴 카드(비소유자)는 무시됩니다(멱등).
             """
     )
     @ApiResponses({

--- a/src/main/java/com/example/bookiibookii/domain/memberbook/entity/Cards.java
+++ b/src/main/java/com/example/bookiibookii/domain/memberbook/entity/Cards.java
@@ -5,6 +5,7 @@ import com.example.bookiibookii.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -39,6 +40,9 @@ public class Cards extends BaseEntity {
     @Column(name = "quotation", length = 140)
     private String quotation;
 
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
     @OneToOne(mappedBy = "card", cascade = CascadeType.ALL, orphanRemoval = true)
     private CardImages cardImages;
 
@@ -56,5 +60,9 @@ public class Cards extends BaseEntity {
 
     public void updateQuotation(String quotation) {
         this.quotation = quotation;
+    }
+
+    public void markDeleted() {
+        this.deletedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/example/bookiibookii/domain/memberbook/repository/CardsRepository.java
+++ b/src/main/java/com/example/bookiibookii/domain/memberbook/repository/CardsRepository.java
@@ -23,6 +23,7 @@ public interface CardsRepository extends JpaRepository<Cards, Long> {
         JOIN FETCH mb.book
         LEFT JOIN FETCH c.cardImages
         WHERE c.id = :cardId AND mm.user.id = :userId
+        AND c.deletedAt IS NULL
         """)
     Optional<Cards> findByIdAndOwnerUserId(
             @Param("cardId") Long cardId,
@@ -38,6 +39,7 @@ public interface CardsRepository extends JpaRepository<Cards, Long> {
         JOIN FETCH mm.user u
         LEFT JOIN FETCH u.userImage
         WHERE mb.group.id = :groupId
+        AND c.deletedAt IS NULL
         ORDER BY c.createdAt ASC
         """)
     List<Cards> findByGroupIdWithMemberBookAndBookAndCreator(
@@ -54,6 +56,7 @@ public interface CardsRepository extends JpaRepository<Cards, Long> {
         LEFT JOIN FETCH u.userImage
         JOIN FETCH mb.group
         WHERE c.id = :cardId
+        AND c.deletedAt IS NULL
         """)
     Optional<Cards> findByIdWithDetails(@Param("cardId") Long cardId);
 }

--- a/src/main/java/com/example/bookiibookii/domain/memberbook/repository/MemberCardRepository.java
+++ b/src/main/java/com/example/bookiibookii/domain/memberbook/repository/MemberCardRepository.java
@@ -64,6 +64,7 @@ public interface MemberCardRepository extends JpaRepository<MemberCard, Long> {
         JOIN FETCH creatorMm.user u
         LEFT JOIN FETCH u.userImage
         WHERE mm.user.id = :userId AND mc.bookmarked = true AND mc.hidden = false
+        AND c.deletedAt IS NULL
         ORDER BY mc.updatedAt DESC
         """)
     List<MemberCard> findByUserIdAndBookmarkedTrueWithCardDetailsOrderByCreatedAtDesc(

--- a/src/main/java/com/example/bookiibookii/domain/memberbook/service/MemberBookCardService.java
+++ b/src/main/java/com/example/bookiibookii/domain/memberbook/service/MemberBookCardService.java
@@ -241,17 +241,43 @@ public class MemberBookCardService {
     }
 
     /**
-     * 카드를 내 화면에서만 숨김 처리(소프트 삭제). Cards 엔티티는 삭제되지 않으며, 그룹 멤버는 계속 조회할 수 있습니다.
-     * MemberCard가 없으면 생성 후 hidden=true로 설정합니다.
+     * 카드 삭제.
+     * - 소유자: Cards.deletedAt 설정으로 그룹 전체에서 제거
+     * - 비소유자: MemberCard.hidden=true 로 본인 화면에서만 숨김
      */
     public void removeCardFromView(Long cardId, Long userId) {
         Cards card = getCardForDetail(cardId, userId);
+        Long ownerUserId = card.getMemberBook().getMatchedMember().getUser().getId();
+
+        if (ownerUserId.equals(userId)) {
+            deleteCardAsOwner(card, userId);
+            return;
+        }
+
+        hideCardFromMyView(card, userId);
+    }
+
+    private void deleteCardAsOwner(Cards card, Long userId) {
+        Long groupId = card.getMemberBook().getGroup().getId();
+        MatchedMember matchedMember = matchedMemberRepository.findByGroup_IdAndUser_Id(groupId, userId)
+                .orElseThrow(() -> new MemberBookException(MemberBookErrorCode.MATCHED_MEMBER_NOT_FOUND));
+
+        memberCardRepository.findByMatchedMember_IdAndCard_Id(matchedMember.getId(), card.getId())
+                .filter(MemberCard::isBookmarked)
+                .ifPresent(state -> {
+                    throw new MemberBookException(MemberBookErrorCode.BOOKMARKED_CARD_CANNOT_DELETE);
+                });
+
+        card.markDeleted();
+    }
+
+    private void hideCardFromMyView(Cards card, Long userId) {
         Long groupId = card.getMemberBook().getGroup().getId();
 
         MatchedMember matchedMember = matchedMemberRepository.findByGroup_IdAndUser_Id(groupId, userId)
                 .orElseThrow(() -> new MemberBookException(MemberBookErrorCode.MATCHED_MEMBER_NOT_FOUND));
 
-        MemberCard state = memberCardRepository.findByMatchedMember_IdAndCard_Id(matchedMember.getId(), cardId)
+        MemberCard state = memberCardRepository.findByMatchedMember_IdAndCard_Id(matchedMember.getId(), card.getId())
                 .orElseGet(() -> {
                     try {
                         return memberCardRepository.saveAndFlush(
@@ -263,7 +289,7 @@ public class MemberBookCardService {
                                         .build()
                         );
                     } catch (DataIntegrityViolationException e) {
-                        return memberCardRepository.findByMatchedMember_IdAndCard_Id(matchedMember.getId(), cardId)
+                        return memberCardRepository.findByMatchedMember_IdAndCard_Id(matchedMember.getId(), card.getId())
                                 .orElseThrow(() -> new MemberBookException(
                                         MemberBookErrorCode.MEMBER_CARD_STATE_CONFLICT));
                     }

--- a/src/main/java/com/example/bookiibookii/domain/memberbook/service/MemberBookCardService.java
+++ b/src/main/java/com/example/bookiibookii/domain/memberbook/service/MemberBookCardService.java
@@ -250,19 +250,17 @@ public class MemberBookCardService {
         Long ownerUserId = card.getMemberBook().getMatchedMember().getUser().getId();
 
         if (ownerUserId.equals(userId)) {
-            deleteCardAsOwner(card, userId);
+            deleteCardAsOwner(card);
             return;
         }
 
         hideCardFromMyView(card, userId);
     }
 
-    private void deleteCardAsOwner(Cards card, Long userId) {
-        Long groupId = card.getMemberBook().getGroup().getId();
-        MatchedMember matchedMember = matchedMemberRepository.findByGroup_IdAndUser_Id(groupId, userId)
-                .orElseThrow(() -> new MemberBookException(MemberBookErrorCode.MATCHED_MEMBER_NOT_FOUND));
+    private void deleteCardAsOwner(Cards card) {
+        MatchedMember owner = card.getMemberBook().getMatchedMember();
 
-        memberCardRepository.findByMatchedMember_IdAndCard_Id(matchedMember.getId(), card.getId())
+        memberCardRepository.findByMatchedMember_IdAndCard_Id(owner.getId(), card.getId())
                 .filter(MemberCard::isBookmarked)
                 .ifPresent(state -> {
                     throw new MemberBookException(MemberBookErrorCode.BOOKMARKED_CARD_CANNOT_DELETE);


### PR DESCRIPTION
## 개요
<!---- 자신이 완료한 이슈를 닫아주세요 -->
- closed #531 
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
본인 독서카드 삭제에 대한 방침이 바뀌어 해당 부분 수정하였습니다.
원래는 card_state에 기록하였다면 이제는 cards 엔티티에 직접 관련 정보를 넣어서 처리하도록하였습니다.
API 호출시에 본인 독서카드, 상대 독서카드인지에 따라 다르게 처리합니다.
<!---- Resolves: #(Isuue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

📣 **To Reviewers**
---
<!-- 전달사항 -->

- Reviewers : 팀 선택
- Labels : 작업 유형, 자기 자신


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 독서카드 삭제 기능 개선: 소유자는 카드를 완전히 삭제 가능하며, 비소유자는 자신의 화면에서만 숨김 처리
  * 북마크된 카드 삭제 방지: 북마크 상태인 카드는 삭제 불가 제한 추가

* **개선사항**
  * 이미 숨긴 카드에 대한 멱등 처리로 안정성 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->