### PR TITLE
[Feat]#527 홈 추천 섹션 구조 설계

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
+    testRuntimeOnly 'com.h2database:h2'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     // Swagger

--- a/scripts/generate_classic_book_candidates_seed.py
+++ b/scripts/generate_classic_book_candidates_seed.py
@@ -1,0 +1,388 @@
+#!/usr/bin/env python3
+"""
+Generate a one-time MySQL seed file for classic book candidates.
+
+Run from the project root:
+
+    export ALADIN_TTB_KEY=your-key
+    python3 scripts/generate_classic_book_candidates_seed.py
+
+The script only writes SQL to scripts/output/classic_book_candidates_seed.sql.
+It does not connect to or modify a database.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_CSV_PATH = PROJECT_ROOT / "src/main/resources/aladin_classic_cids.csv"
+DEFAULT_OUTPUT_PATH = (
+    PROJECT_ROOT / "scripts/output/classic_book_candidates_seed.sql"
+)
+ALADIN_ITEM_LIST_URL = "https://www.aladin.co.kr/ttb/api/ItemList.aspx"
+SECTION_TYPE = "CLASSIC_BOOK_GROUP"
+SOURCE_TYPE = "ALADIN_CATEGORY_SEED"
+
+
+@dataclass(frozen=True)
+class BookCandidate:
+    isbn13: str
+    title: str
+    author: str
+    item_id: int
+    source_cid: int
+    display_order: int
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate classic book candidate INSERT SQL from Aladin CIDs."
+    )
+    parser.add_argument(
+        "--csv",
+        type=Path,
+        default=DEFAULT_CSV_PATH,
+        help=f"CID CSV path (default: {DEFAULT_CSV_PATH})",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=DEFAULT_OUTPUT_PATH,
+        help=f"SQL output path (default: {DEFAULT_OUTPUT_PATH})",
+    )
+    parser.add_argument(
+        "--max-pages",
+        type=int,
+        default=20,
+        help="Maximum pages fetched per CID (default: 20)",
+    )
+    parser.add_argument(
+        "--sleep",
+        type=float,
+        default=0.2,
+        help="Seconds to wait between API calls (default: 0.2)",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=15.0,
+        help="HTTP request timeout in seconds (default: 15)",
+    )
+    return parser.parse_args()
+
+
+def read_active_classic_cids(csv_path: Path) -> list[int]:
+    if not csv_path.is_file():
+        raise FileNotFoundError(f"CID CSV not found: {csv_path}")
+
+    cids: list[int] = []
+    seen: set[int] = set()
+    with csv_path.open("r", encoding="utf-8-sig", newline="") as csv_file:
+        reader = csv.DictReader(csv_file)
+        required_columns = {"section_type", "cid", "active"}
+        missing_columns = required_columns.difference(reader.fieldnames or [])
+        if missing_columns:
+            missing = ", ".join(sorted(missing_columns))
+            raise ValueError(f"CID CSV is missing required columns: {missing}")
+
+        for line_number, row in enumerate(reader, start=2):
+            if row["section_type"].strip() != SECTION_TYPE:
+                continue
+            if row["active"].strip().lower() not in {"true", "1", "yes", "y"}:
+                continue
+
+            try:
+                cid = int(row["cid"].strip())
+            except (TypeError, ValueError) as error:
+                raise ValueError(
+                    f"Invalid cid at {csv_path}:{line_number}: {row['cid']!r}"
+                ) from error
+
+            if cid > 0 and cid not in seen:
+                cids.append(cid)
+                seen.add(cid)
+
+    if not cids:
+        raise ValueError(f"No active {SECTION_TYPE} CIDs found in {csv_path}")
+    return cids
+
+
+def fetch_page(
+    ttb_key: str,
+    cid: int,
+    start: int,
+    timeout: float,
+    max_attempts: int = 3,
+) -> list[dict[str, Any]]:
+    params = urllib.parse.urlencode(
+        {
+            "ttbkey": ttb_key,
+            "QueryType": "Bestseller",
+            "SearchTarget": "Book",
+            "CategoryId": cid,
+            "output": "js",
+            "Version": "20131101",
+            "MaxResults": 50,
+            "start": start,
+        }
+    )
+    url = f"{ALADIN_ITEM_LIST_URL}?{params}"
+
+    for attempt in range(1, max_attempts + 1):
+        try:
+            request = urllib.request.Request(
+                url,
+                headers={
+                    "Accept": "application/json",
+                    "User-Agent": "bookiibookii-classic-seed-generator/1.0",
+                },
+            )
+            with urllib.request.urlopen(request, timeout=timeout) as response:
+                payload = json.loads(response.read().decode("utf-8-sig"))
+
+            if not isinstance(payload, dict):
+                raise RuntimeError("Aladin API returned a non-object JSON response")
+            if payload.get("errorCode") or payload.get("errorMessage"):
+                raise RuntimeError(
+                    "Aladin API error "
+                    f"{payload.get('errorCode', '')}: "
+                    f"{payload.get('errorMessage', 'unknown error')}"
+                )
+
+            items = payload.get("item", [])
+            if items is None:
+                return []
+            if not isinstance(items, list):
+                raise RuntimeError("Aladin API response field 'item' is not a list")
+            return [item for item in items if isinstance(item, dict)]
+        except (
+            urllib.error.URLError,
+            TimeoutError,
+            json.JSONDecodeError,
+        ) as error:
+            if attempt == max_attempts:
+                raise RuntimeError(
+                    f"Failed to fetch cid={cid}, start={start} "
+                    f"after {max_attempts} attempts: {error}"
+                ) from error
+            wait_seconds = attempt
+            print(
+                f"  retrying cid={cid}, start={start} in {wait_seconds}s: {error}",
+                file=sys.stderr,
+            )
+            time.sleep(wait_seconds)
+
+    raise AssertionError("unreachable")
+
+
+def normalize_isbn13(value: Any) -> str | None:
+    isbn13 = "".join(character for character in str(value or "") if character.isdigit())
+    return isbn13 if len(isbn13) == 13 else None
+
+
+def collect_candidates(
+    cids: list[int],
+    ttb_key: str,
+    max_pages: int,
+    sleep_seconds: float,
+    timeout: float,
+) -> list[BookCandidate]:
+    # Keep the first occurrence so source_cid and display_order are deterministic
+    # according to CSV CID order, page order, and Aladin result order.
+    candidates_by_isbn: dict[str, BookCandidate] = {}
+    skipped = 0
+    request_count = 0
+
+    for cid_index, cid in enumerate(cids, start=1):
+        print(f"[{cid_index}/{len(cids)}] Fetching cid={cid}")
+        for page in range(1, max_pages + 1):
+            if request_count > 0:
+                time.sleep(sleep_seconds)
+            items = fetch_page(ttb_key, cid, page, timeout)
+            request_count += 1
+            print(f"  page={page}: {len(items)} item(s)")
+            if not items:
+                break
+
+            for item in items:
+                isbn13 = normalize_isbn13(item.get("isbn13"))
+                try:
+                    item_id = int(item.get("itemId"))
+                except (TypeError, ValueError):
+                    item_id = 0
+
+                if not isbn13 or item_id <= 0:
+                    skipped += 1
+                    continue
+                if isbn13 in candidates_by_isbn:
+                    continue
+
+                display_order = len(candidates_by_isbn) + 1
+                candidates_by_isbn[isbn13] = BookCandidate(
+                    isbn13=isbn13,
+                    title=str(item.get("title") or "").strip(),
+                    author=str(item.get("author") or "").strip(),
+                    item_id=item_id,
+                    source_cid=cid,
+                    display_order=display_order,
+                )
+
+    print(
+        f"Collected {len(candidates_by_isbn)} unique book(s); "
+        f"skipped {skipped} item(s) without a valid isbn13/itemId."
+    )
+    return list(candidates_by_isbn.values())
+
+
+def mysql_string(value: str) -> str:
+    """Return a MySQL string literal safe under the default SQL mode."""
+    escaped = (
+        value.replace("\\", "\\\\")
+        .replace("\0", "\\0")
+        .replace("\n", "\\n")
+        .replace("\r", "\\r")
+        .replace("\x1a", "\\Z")
+        .replace("'", "''")
+    )
+    return f"'{escaped}'"
+
+
+def render_sql(candidates: list[BookCandidate], csv_path: Path) -> str:
+    lines = [
+        "-- Generated by scripts/generate_classic_book_candidates_seed.py",
+        f"-- Source CID file: {csv_path.as_posix()}",
+        f"-- Unique ISBN13 candidates: {len(candidates)}",
+        "-- Duplicate policy: keep the first occurrence in CSV/page/result order.",
+        "",
+    ]
+
+    if candidates:
+        lines.extend(
+            [
+                "INSERT INTO home_section_book_candidates",
+                "(",
+                "    section_type,",
+                "    isbn13,",
+                "    title,",
+                "    author,",
+                "    aladin_item_id,",
+                "    source_cid,",
+                "    source_type,",
+                "    display_order,",
+                "    active,",
+                "    created_at,",
+                "    updated_at",
+                ")",
+                "VALUES",
+            ]
+        )
+
+        value_rows = []
+        for candidate in candidates:
+            value_rows.append(
+                "    ("
+                f"{mysql_string(SECTION_TYPE)}, "
+                f"{mysql_string(candidate.isbn13)}, "
+                f"{mysql_string(candidate.title)}, "
+                f"{mysql_string(candidate.author)}, "
+                f"{candidate.item_id}, "
+                f"{candidate.source_cid}, "
+                f"{mysql_string(SOURCE_TYPE)}, "
+                f"{candidate.display_order}, "
+                "TRUE, NOW(), NOW())"
+            )
+        lines.append(",\n".join(value_rows))
+        lines.extend(
+            [
+                "ON DUPLICATE KEY UPDATE",
+                "    title = VALUES(title),",
+                "    author = VALUES(author),",
+                "    aladin_item_id = VALUES(aladin_item_id),",
+                "    source_cid = VALUES(source_cid),",
+                "    source_type = VALUES(source_type),",
+                "    display_order = VALUES(display_order),",
+                "    active = VALUES(active),",
+                "    updated_at = NOW();",
+                "",
+            ]
+        )
+    else:
+        lines.extend(["-- No valid candidates were returned; no INSERT generated.", ""])
+
+    lines.extend(
+        [
+            "-- Verification queries",
+            "SELECT COUNT(*)",
+            "FROM home_section_book_candidates",
+            f"WHERE section_type = {mysql_string(SECTION_TYPE)}",
+            "  AND active = TRUE;",
+            "",
+            (
+                "SELECT id, section_type, isbn13, title, author, source_cid, "
+                "display_order, active"
+            ),
+            "FROM home_section_book_candidates",
+            f"WHERE section_type = {mysql_string(SECTION_TYPE)}",
+            "ORDER BY display_order ASC",
+            "LIMIT 50;",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def main() -> int:
+    args = parse_args()
+    if args.max_pages < 1 or args.max_pages > 20:
+        raise ValueError("--max-pages must be between 1 and 20")
+    if args.sleep < 0:
+        raise ValueError("--sleep must be zero or greater")
+    if args.timeout <= 0:
+        raise ValueError("--timeout must be greater than zero")
+
+    ttb_key = os.environ.get("ALADIN_TTB_KEY", "").strip()
+    if not ttb_key:
+        print(
+            "ALADIN_TTB_KEY is required. "
+            "Set it before running this script.",
+            file=sys.stderr,
+        )
+        return 2
+
+    csv_path = args.csv.resolve()
+    output_path = args.output.resolve()
+    cids = read_active_classic_cids(csv_path)
+    print(f"Loaded {len(cids)} active classic CID(s) from {csv_path}")
+
+    candidates = collect_candidates(
+        cids=cids,
+        ttb_key=ttb_key,
+        max_pages=args.max_pages,
+        sleep_seconds=args.sleep,
+        timeout=args.timeout,
+    )
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(render_sql(candidates, csv_path), encoding="utf-8")
+    print(f"Wrote SQL seed file: {output_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (FileNotFoundError, ValueError, RuntimeError) as error:
+        print(f"Error: {error}", file=sys.stderr)
+        raise SystemExit(1)

--- a/scripts/generate_classic_book_candidates_seed.py
+++ b/scripts/generate_classic_book_candidates_seed.py
@@ -33,6 +33,7 @@ DEFAULT_OUTPUT_PATH = (
     PROJECT_ROOT / "scripts/output/classic_book_candidates_seed.sql"
 )
 ALADIN_ITEM_LIST_URL = "https://www.aladin.co.kr/ttb/api/ItemList.aspx"
+# Keep these values in sync with HomeCandidateSectionType/HomeCandidateSourceType.
 SECTION_TYPE = "CLASSIC_BOOK_GROUP"
 SOURCE_TYPE = "ALADIN_CATEGORY_SEED"
 

--- a/src/main/java/com/example/bookiibookii/domain/aladin/entity/BestsellerIsbn.java
+++ b/src/main/java/com/example/bookiibookii/domain/aladin/entity/BestsellerIsbn.java
@@ -4,7 +4,12 @@ import jakarta.persistence.*;
 import lombok.*;
 
 @Entity
-@Table(name = "bestseller_isbn")
+@Table(
+        name = "bestseller_isbn",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_bestseller_isbn_isbn13", columnNames = "isbn13")
+        }
+)
 @Getter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -18,6 +23,15 @@ public class BestsellerIsbn {
     @Column(nullable = false, length = 13)
     private String isbn13;
 
-    @Column(nullable = false)
+    @Column(name = "ranking", nullable = false)
     private Integer rank;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false)
+    private String author;
+
+    @Column(name = "book_image", nullable = false)
+    private String bookImage;
 }

--- a/src/main/java/com/example/bookiibookii/domain/aladin/scheduler/BestsellerScheduler.java
+++ b/src/main/java/com/example/bookiibookii/domain/aladin/scheduler/BestsellerScheduler.java
@@ -10,7 +10,9 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
 @Slf4j
 @Component
@@ -35,13 +37,24 @@ public class BestsellerScheduler {
         }
 
         List<BestsellerIsbn> newList = new ArrayList<>();
+        Set<String> seenIsbn13 = new LinkedHashSet<>();
         List<AladinClient.AladinBookItem> items = response.item();
         for (int i = 0; i < items.size(); i++) {
-            String isbn13 = items.get(i).isbn13();
-            if (isbn13 == null || isbn13.isBlank()) continue;
+            AladinClient.AladinBookItem item = items.get(i);
+            String isbn13 = normalizeIsbn13(item.isbn13());
+            if (isbn13 == null || !seenIsbn13.add(isbn13)) {
+                continue;
+            }
+            if (isBlank(item.title()) || isBlank(item.author()) || isBlank(item.cover())) {
+                log.warn("[Scheduler] 베스트셀러 표시 정보 누락으로 제외 isbn13={}", isbn13);
+                continue;
+            }
             newList.add(BestsellerIsbn.builder()
                     .isbn13(isbn13)
                     .rank(i + 1)
+                    .title(item.title())
+                    .author(item.author())
+                    .bookImage(item.cover())
                     .build());
         }
 
@@ -49,5 +62,17 @@ public class BestsellerScheduler {
         bestsellerIsbnRepository.saveAll(newList);
 
         log.info("[Scheduler] 베스트셀러 갱신 완료 ({}건)", newList.size());
+    }
+
+    private String normalizeIsbn13(String isbn13) {
+        if (isbn13 == null) {
+            return null;
+        }
+        String normalized = isbn13.replaceAll("\\D", "");
+        return normalized.length() == 13 ? normalized : null;
+    }
+
+    private boolean isBlank(String value) {
+        return value == null || value.isBlank();
     }
 }

--- a/src/main/java/com/example/bookiibookii/domain/aladin/scheduler/BestsellerScheduler.java
+++ b/src/main/java/com/example/bookiibookii/domain/aladin/scheduler/BestsellerScheduler.java
@@ -42,11 +42,16 @@ public class BestsellerScheduler {
         for (int i = 0; i < items.size(); i++) {
             AladinClient.AladinBookItem item = items.get(i);
             String isbn13 = normalizeIsbn13(item.isbn13());
-            if (isbn13 == null || !seenIsbn13.add(isbn13)) {
+            if (isbn13 == null) {
                 continue;
             }
+
             if (isBlank(item.title()) || isBlank(item.author()) || isBlank(item.cover())) {
                 log.warn("[Scheduler] 베스트셀러 표시 정보 누락으로 제외 isbn13={}", isbn13);
+                continue;
+            }
+
+            if (!seenIsbn13.add(isbn13)) {
                 continue;
             }
             newList.add(BestsellerIsbn.builder()

--- a/src/main/java/com/example/bookiibookii/domain/group/controller/GroupControllerDocs.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/controller/GroupControllerDocs.java
@@ -150,10 +150,11 @@ public interface GroupControllerDocs {
 
     @Operation(summary = "그룹 홈 화면 조회 API",
             description = """
-                    그룹 홈 화면의 섹션별 추천 그룹을 한 번에 조회합니다.
-                    - newGroups: 최근 생성된 모집 중 그룹 (최대 5개)
-                    - categorySection: 새로고침마다 랜덤 카테고리 1개를 골라 해당 카테고리 그룹 추천 (최대 9개). 추천 가능한 카테고리가 없으면 category=null
-                    - regionSection: 사용자 교환 장소(구/군) 기반 직접교환 그룹 (최대 15개). 교환 장소 미설정 시 region=null
+                    추천 탭의 홈 섹션을 고정 우선순위로 조회합니다.
+                    각 섹션은 sectionType, title, subtitle, layoutType, items를 포함합니다.
+                    데이터가 없는 그룹 카드 섹션은 sections 목록에서 제외됩니다.
+                    인기 도서와 베스트셀러 책 섹션은 데이터가 없어도 빈 items로 유지됩니다.
+                    홈 요청 중 외부 도서 API는 호출하지 않습니다.
                     """)
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "성공")

--- a/src/main/java/com/example/bookiibookii/domain/group/dto/res/GroupResponseDTO.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/dto/res/GroupResponseDTO.java
@@ -2,6 +2,8 @@ package com.example.bookiibookii.domain.group.dto.res;
 
 import com.example.bookiibookii.domain.group.dto.RuleDTO;
 import com.example.bookiibookii.domain.group.enums.GroupStatus;
+import com.example.bookiibookii.domain.group.enums.HomeLayoutType;
+import com.example.bookiibookii.domain.group.enums.HomeSectionType;
 import com.example.bookiibookii.domain.group.enums.HostedGroupDisplayStatus;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
@@ -192,31 +194,27 @@ public class GroupResponseDTO {
             Integer readingPeriod
     ) {}
 
-    /** 섹션2 — 카테고리 추천 그룹. category가 null이면 추천 가능한 카테고리 없음 */
     @Builder
-    public record CategorySectionDTO(
-            String category,
-            List<HomeGroupCardDTO> groups
+    public record HomeBookThumbnailDTO(
+            String isbn13,
+            String title,
+            String author,
+            String bookImage,
+            String searchKeyword,
+            Integer rank
     ) {}
 
-    /** 섹션5 — 위치 기반 직접교환 그룹. region이 null이면 사용자 교환 장소 미설정 */
     @Builder
-    public record RegionSectionDTO(
-            String region,
-            List<HomeGroupCardDTO> groups
-    ) {}
-
-    /** 섹션3 — 베스트셀러 기반 그룹 추천 */
-    @Builder
-    public record BestsellerSectionDTO(
-            List<HomeGroupCardDTO> groups
+    public record HomeSectionDTO(
+            HomeSectionType sectionType,
+            String title,
+            String subtitle,
+            HomeLayoutType layoutType,
+            List<?> items
     ) {}
 
     @Builder
     public record HomeResponseDTO(
-            List<HomeGroupCardDTO> newGroups,
-            CategorySectionDTO categorySection,
-            BestsellerSectionDTO bestsellerSection,
-            RegionSectionDTO regionSection
+            List<HomeSectionDTO> sections
     ) {}
 }

--- a/src/main/java/com/example/bookiibookii/domain/group/entity/HomeSectionBookCandidate.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/entity/HomeSectionBookCandidate.java
@@ -1,0 +1,52 @@
+package com.example.bookiibookii.domain.group.entity;
+
+import com.example.bookiibookii.global.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "home_section_book_candidates")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class HomeSectionBookCandidate extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "section_type", nullable = false, length = 50)
+    private String sectionType;
+
+    @Column(name = "isbn13", nullable = false, length = 13)
+    private String isbn13;
+
+    @Column(name = "title", nullable = false)
+    private String title;
+
+    @Column(name = "author")
+    private String author;
+
+    @Column(name = "aladin_item_id")
+    private Long aladinItemId;
+
+    @Column(name = "source_cid")
+    private Long sourceCid;
+
+    @Column(name = "source_type", nullable = false, length = 50)
+    private String sourceType;
+
+    @Column(name = "display_order", nullable = false)
+    private Integer displayOrder;
+
+    @Column(name = "active", nullable = false)
+    private boolean active;
+}

--- a/src/main/java/com/example/bookiibookii/domain/group/entity/HomeSectionBookCandidate.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/entity/HomeSectionBookCandidate.java
@@ -1,8 +1,12 @@
 package com.example.bookiibookii.domain.group.entity;
 
+import com.example.bookiibookii.domain.group.enums.HomeCandidateSectionType;
+import com.example.bookiibookii.domain.group.enums.HomeCandidateSourceType;
 import com.example.bookiibookii.global.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -23,8 +27,9 @@ public class HomeSectionBookCandidate extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "section_type", nullable = false, length = 50)
-    private String sectionType;
+    private HomeCandidateSectionType sectionType;
 
     @Column(name = "isbn13", nullable = false, length = 13)
     private String isbn13;
@@ -41,8 +46,9 @@ public class HomeSectionBookCandidate extends BaseEntity {
     @Column(name = "source_cid")
     private Long sourceCid;
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "source_type", nullable = false, length = 50)
-    private String sourceType;
+    private HomeCandidateSourceType sourceType;
 
     @Column(name = "display_order", nullable = false)
     private Integer displayOrder;

--- a/src/main/java/com/example/bookiibookii/domain/group/enums/HomeCandidateSectionType.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/enums/HomeCandidateSectionType.java
@@ -1,0 +1,5 @@
+package com.example.bookiibookii.domain.group.enums;
+
+public enum HomeCandidateSectionType {
+    CLASSIC_BOOK_GROUP
+}

--- a/src/main/java/com/example/bookiibookii/domain/group/enums/HomeCandidateSourceType.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/enums/HomeCandidateSourceType.java
@@ -1,0 +1,5 @@
+package com.example.bookiibookii.domain.group.enums;
+
+public enum HomeCandidateSourceType {
+    ALADIN_CATEGORY_SEED
+}

--- a/src/main/java/com/example/bookiibookii/domain/group/enums/HomeGenre.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/enums/HomeGenre.java
@@ -1,0 +1,41 @@
+package com.example.bookiibookii.domain.group.enums;
+
+import com.example.bookiibookii.domain.book.enums.CustomCategory;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+@Getter
+@RequiredArgsConstructor
+public enum HomeGenre {
+    KOREAN_NOVEL("한국소설", List.of(CustomCategory.KOREAN_NOVEL)),
+    WORLD_NOVEL("세계소설", List.of(CustomCategory.WORLD_NOVEL)),
+    GENRE_NOVEL("장르소설", List.of(CustomCategory.GENRE_NOVEL)),
+    ROMANCE("로맨스", List.of(CustomCategory.ROMANCE)),
+    HISTORICAL_NOVEL("역사소설", List.of(CustomCategory.HISTORICAL_NOVEL)),
+    POETRY_ESSAY("시·에세이", List.of(CustomCategory.POETRY_ESSAY)),
+    PLAY_LITERATURE("희곡·문학", List.of(CustomCategory.PLAY_LITERATURE)),
+    ECONOMY_BUSINESS("경제·경영", List.of(CustomCategory.ECONOMY_BUSINESS)),
+    SCIENCE_IT("과학·IT", List.of(CustomCategory.SCIENCE_IT)),
+    HOME_HOBBY("가정·취미", List.of(CustomCategory.HOME_HOBBY)),
+    ART_CULTURE("예술·문화", List.of(CustomCategory.ART_CULTURE)),
+    HUMANITIES_HISTORY("인문·역사", List.of(CustomCategory.HUMANITIES_HISTORY)),
+    SELF_DEVELOPMENT("자기계발", List.of(CustomCategory.SELF_DEVELOPMENT)),
+    POLITICS_SOCIETY("정치·사회", List.of(CustomCategory.POLITICS_SOCIETY)),
+    ETC("기타", List.of(
+            CustomCategory.LITERATURE_ETC,
+            CustomCategory.NON_LITERATURE_ETC
+    ));
+
+    private final String label;
+    private final List<CustomCategory> categories;
+
+    public static Optional<HomeGenre> from(CustomCategory category) {
+        return Arrays.stream(values())
+                .filter(genre -> genre.categories.contains(category))
+                .findFirst();
+    }
+}

--- a/src/main/java/com/example/bookiibookii/domain/group/enums/HomeLayoutType.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/enums/HomeLayoutType.java
@@ -1,0 +1,7 @@
+package com.example.bookiibookii.domain.group.enums;
+
+public enum HomeLayoutType {
+    GROUP_CARD_CAROUSEL,
+    BOOK_THUMBNAIL_CAROUSEL,
+    BOOK_THUMBNAIL_GRID
+}

--- a/src/main/java/com/example/bookiibookii/domain/group/enums/HomeSectionType.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/enums/HomeSectionType.java
@@ -1,0 +1,11 @@
+package com.example.bookiibookii.domain.group.enums;
+
+public enum HomeSectionType {
+    NEW_GROUPS,
+    POPULAR_BOOKS_TOP5,
+    RANDOM_GENRE_GROUPS,
+    BESTSELLER_BOOKS,
+    CLASSIC_GROUPS,
+    PACKAGE_GROUPS,
+    NEARBY_DIRECT_GROUPS
+}

--- a/src/main/java/com/example/bookiibookii/domain/group/repository/GroupQueryRepository.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/repository/GroupQueryRepository.java
@@ -9,21 +9,28 @@ import com.example.bookiibookii.domain.group.enums.GroupStatus;
 import com.example.bookiibookii.domain.group.enums.TradeType;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.DateTimeExpression;
+import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.*;
 import org.springframework.stereotype.Repository;
 
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
 
+import static com.example.bookiibookii.domain.aladin.entity.QBestsellerIsbn.bestsellerIsbn;
 import static com.example.bookiibookii.domain.book.entity.QBook.book;
 import static com.example.bookiibookii.domain.group.entity.QGroupPlace.groupPlace;
 import static com.example.bookiibookii.domain.group.entity.QGroups.groups;
+import static com.example.bookiibookii.domain.group.entity.QHomeSectionBookCandidate.homeSectionBookCandidate;
 import static com.example.bookiibookii.domain.user.entity.QUser.user;
 
 @Repository
@@ -31,6 +38,13 @@ import static com.example.bookiibookii.domain.user.entity.QUser.user;
 public class GroupQueryRepository {
 
     private final JPAQueryFactory queryFactory;
+
+    public record HomeBookProjection(
+            String isbn13,
+            String title,
+            String author,
+            String image
+    ) {}
 
     public Slice<Groups> findGroupsByFilters(GroupRequestDTO.FilterDTO filter, Pageable pageable) {
 
@@ -163,81 +177,190 @@ public class GroupQueryRepository {
 
     // ===== 그룹 홈 화면 (GET /api/groups/home) =====
 
-    /** 섹션1 — 최근 생성된 모집 중 그룹 (최신순, 본인 호스트 제외) */
-    public List<Groups> findRecentGroups(Long userId, int limit) {
-        return queryFactory
-                .selectFrom(groups)
-                .join(groups.book, book).fetchJoin()
-                .join(groups.host, user).fetchJoin()
+    public List<Groups> findRecentGroups(
+            Long userId,
+            LocalDateTime createdAfter,
+            int limit
+    ) {
+        return homeGroupQuery(userId)
                 .where(
                         groups.groupStatus.eq(GroupStatus.RECRUITING),
-                        groups.host.id.ne(userId)
+                        groups.createdAt.goe(createdAfter)
                 )
                 .orderBy(groups.createdAt.desc(), groups.id.desc())
                 .limit(limit)
                 .fetch();
     }
 
-    /** 섹션2 — 모집 중 그룹이 1개 이상 존재하는 카테고리 목록 (본인 호스트 제외, 랜덤 추천 후보군) */
-    public List<CustomCategory> findCategoriesWithRecruitingGroups(Long userId) {
+    public List<HomeBookProjection> findPopularBooks(int limit) {
+        NumberExpression<Long> groupCount = groups.id.count();
+        DateTimeExpression<LocalDateTime> latestGroupCreatedAt = groups.createdAt.max();
+
+        return queryFactory
+                .select(Projections.constructor(
+                        HomeBookProjection.class,
+                        book.isbn13,
+                        book.title,
+                        book.author,
+                        book.image
+                ))
+                .from(groups)
+                .join(groups.book, book)
+                .where(groups.groupStatus.ne(GroupStatus.DELETED))
+                .groupBy(book.id, book.isbn13, book.title, book.author, book.image)
+                .orderBy(
+                        groupCount.desc(),
+                        latestGroupCreatedAt.desc(),
+                        book.id.desc()
+                )
+                .limit(limit)
+                .fetch();
+    }
+
+    public List<HomeBookProjection> findBestsellerBooks(int limit) {
+        return queryFactory
+                .select(Projections.constructor(
+                        HomeBookProjection.class,
+                        book.isbn13,
+                        book.title,
+                        book.author,
+                        book.image
+                ))
+                .from(bestsellerIsbn)
+                .join(book).on(book.isbn13.eq(bestsellerIsbn.isbn13))
+                .orderBy(bestsellerIsbn.rank.asc(), bestsellerIsbn.id.asc())
+                .limit(limit)
+                .fetch();
+    }
+
+    public List<CustomCategory> findCategoriesWithRecruitingGroups() {
         return queryFactory
                 .select(book.category).distinct()
                 .from(groups)
                 .join(groups.book, book)
                 .where(
                         groups.groupStatus.eq(GroupStatus.RECRUITING),
-                        groups.host.id.ne(userId)
+                        book.category.notIn(
+                                CustomCategory.ALL,
+                                CustomCategory.LITERATURE_ALL,
+                                CustomCategory.NON_LITERATURE_ALL
+                        )
                 )
+                .orderBy(book.category.asc())
                 .fetch();
     }
 
-    /** 섹션2 — 특정 카테고리의 모집 중 그룹을 랜덤으로 조회 (본인 호스트 제외) */
-    public List<Groups> findRandomGroupsByCategory(Long userId, CustomCategory category, int limit) {
-        return queryFactory
-                .selectFrom(groups)
-                .join(groups.book, book).fetchJoin()
-                .join(groups.host, user).fetchJoin()
+    public List<Groups> findGroupsByCategories(
+            Long userId,
+            List<CustomCategory> categories,
+            int limit
+    ) {
+        if (categories == null || categories.isEmpty()) {
+            return List.of();
+        }
+        return homeGroupQuery(userId)
                 .where(
                         groups.groupStatus.eq(GroupStatus.RECRUITING),
-                        groups.host.id.ne(userId),
-                        book.category.eq(category)
+                        book.category.in(categories)
                 )
-                .orderBy(Expressions.numberTemplate(Double.class, "function('rand')").asc())
+                .orderBy(groups.createdAt.desc(), groups.id.desc())
                 .limit(limit)
                 .fetch();
     }
 
-    /** 섹션5 — 사용자 지역(구/군)에서 열린 직접교환 모집 중 그룹 (최신순, 본인 호스트 제외) */
-    public List<Groups> findRegionGroups(Long userId, String region, int limit) {
-        return queryFactory
-                .selectFrom(groups)
-                .join(groups.book, book).fetchJoin()
-                .join(groups.host, user).fetchJoin()
+    public List<Groups> findClassicGroups(
+            Long userId,
+            String candidateSectionType,
+            int limit
+    ) {
+        return homeGroupQuery(userId)
+                .where(
+                        groups.groupStatus.eq(GroupStatus.RECRUITING),
+                        book.isbn13.in(
+                                JPAExpressions
+                                        .select(homeSectionBookCandidate.isbn13)
+                                        .from(homeSectionBookCandidate)
+                                        .where(
+                                                homeSectionBookCandidate.sectionType
+                                                        .eq(candidateSectionType),
+                                                homeSectionBookCandidate.active.isTrue()
+                                        )
+                        )
+                )
+                .orderBy(groups.createdAt.desc(), groups.id.desc())
+                .limit(limit)
+                .fetch();
+    }
+
+    public List<Groups> findGroupsByTradeType(
+            Long userId,
+            TradeType tradeType,
+            int limit
+    ) {
+        return homeGroupQuery(userId)
+                .where(
+                        groups.groupStatus.eq(GroupStatus.RECRUITING),
+                        groups.tradeType.eq(tradeType)
+                )
+                .orderBy(groups.createdAt.desc(), groups.id.desc())
+                .limit(limit)
+                .fetch();
+    }
+
+    public boolean existsDirectGroupsAtCoordinate(
+            Long userId,
+            BigDecimal x,
+            BigDecimal y
+    ) {
+        if (x == null || y == null) {
+            return false;
+        }
+        Integer found = queryFactory
+                .selectOne()
+                .from(groups)
                 .join(groups.groupPlace, groupPlace)
                 .where(
                         groups.groupStatus.eq(GroupStatus.RECRUITING),
                         groups.host.id.ne(userId),
                         groups.tradeType.eq(TradeType.DIRECT),
-                        groupPlace.address.contains(region)
+                        groupPlace.x.eq(x),
+                        groupPlace.y.eq(y)
+                )
+                .fetchFirst();
+        return found != null;
+    }
+
+    public List<Groups> findDirectGroupsAtCoordinate(
+            Long userId,
+            BigDecimal x,
+            BigDecimal y,
+            int limit
+    ) {
+        if (x == null || y == null) {
+            return List.of();
+        }
+        return homeGroupQuery(userId)
+                .join(groups.groupPlace, groupPlace).fetchJoin()
+                .where(
+                        groups.groupStatus.eq(GroupStatus.RECRUITING),
+                        groups.tradeType.eq(TradeType.DIRECT),
+                        groupPlace.x.eq(x),
+                        groupPlace.y.eq(y)
                 )
                 .orderBy(groups.createdAt.desc(), groups.id.desc())
                 .limit(limit)
                 .fetch();
     }
 
-    /** 섹션3 — 베스트셀러 isbn13 목록에 해당하는 모집 중 그룹 (최신순, 본인 호스트 제외) */
-    public List<Groups> findBestsellerGroups(Long userId, List<String> isbn13List) {
-        if (isbn13List == null || isbn13List.isEmpty()) return List.of();
+    private com.querydsl.jpa.impl.JPAQuery<Groups> homeGroupQuery(Long userId) {
         return queryFactory
                 .selectFrom(groups)
                 .join(groups.book, book).fetchJoin()
                 .join(groups.host, user).fetchJoin()
+                .leftJoin(user.userImage).fetchJoin()
                 .where(
-                        groups.groupStatus.eq(GroupStatus.RECRUITING),
-                        groups.host.id.ne(userId),
-                        book.isbn13.in(isbn13List)
+                        groups.host.id.ne(userId)
                 )
-                .orderBy(groups.createdAt.desc(), groups.id.desc())
-                .fetch();
+                .distinct();
     }
 }

--- a/src/main/java/com/example/bookiibookii/domain/group/repository/GroupQueryRepository.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/repository/GroupQueryRepository.java
@@ -1,11 +1,14 @@
 package com.example.bookiibookii.domain.group.repository;
 
+import com.example.bookiibookii.domain.book.entity.QBook;
 import com.example.bookiibookii.domain.book.enums.CategoryGroup;
 import com.example.bookiibookii.domain.book.enums.CustomCategory;
 import com.example.bookiibookii.domain.group.dto.req.GroupRequestDTO;
 import com.example.bookiibookii.domain.group.entity.Groups;
+import com.example.bookiibookii.domain.group.entity.QGroups;
 import com.example.bookiibookii.domain.group.enums.GroupSortType;
 import com.example.bookiibookii.domain.group.enums.GroupStatus;
+import com.example.bookiibookii.domain.group.enums.HomeCandidateSectionType;
 import com.example.bookiibookii.domain.group.enums.TradeType;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
@@ -26,8 +29,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
 
-import static com.example.bookiibookii.domain.aladin.entity.QBestsellerIsbn.bestsellerIsbn;
 import static com.example.bookiibookii.domain.book.entity.QBook.book;
+import static com.example.bookiibookii.domain.aladin.entity.QBestsellerIsbn.bestsellerIsbn;
 import static com.example.bookiibookii.domain.group.entity.QGroupPlace.groupPlace;
 import static com.example.bookiibookii.domain.group.entity.QGroups.groups;
 import static com.example.bookiibookii.domain.group.entity.QHomeSectionBookCandidate.homeSectionBookCandidate;
@@ -44,6 +47,14 @@ public class GroupQueryRepository {
             String title,
             String author,
             String image
+    ) {}
+
+    public record HomeBestsellerBookProjection(
+            String isbn13,
+            String title,
+            String author,
+            String image,
+            Integer ranking
     ) {}
 
     public Slice<Groups> findGroupsByFilters(GroupRequestDTO.FilterDTO filter, Pageable pageable) {
@@ -192,7 +203,11 @@ public class GroupQueryRepository {
                 .fetch();
     }
 
-    public List<HomeBookProjection> findPopularBooks(int limit) {
+    public List<HomeBookProjection> findPopularBooks(Long userId, int limit) {
+        BooleanExpression visibleRecruitingCandidate =
+                hasVisibleRecruitingGroups(userId)
+                        ? isbn13WithVisibleRecruitingGroups(userId)
+                        : null;
         NumberExpression<Long> groupCount = groups.id.count();
         DateTimeExpression<LocalDateTime> latestGroupCreatedAt = groups.createdAt.max();
 
@@ -206,7 +221,10 @@ public class GroupQueryRepository {
                 ))
                 .from(groups)
                 .join(groups.book, book)
-                .where(groups.groupStatus.ne(GroupStatus.DELETED))
+                .where(
+                        groups.groupStatus.ne(GroupStatus.DELETED),
+                        visibleRecruitingCandidate
+                )
                 .groupBy(book.id, book.isbn13, book.title, book.author, book.image)
                 .orderBy(
                         groupCount.desc(),
@@ -217,29 +235,61 @@ public class GroupQueryRepository {
                 .fetch();
     }
 
-    public List<HomeBookProjection> findBestsellerBooks(int limit) {
+    private boolean hasVisibleRecruitingGroups(Long userId) {
+        QGroups recruitingGroups = new QGroups("visibleRecruitingGroups");
+
+        Integer found = queryFactory
+                .selectOne()
+                .from(recruitingGroups)
+                .where(
+                        recruitingGroups.groupStatus.eq(GroupStatus.RECRUITING),
+                        recruitingGroups.host.id.ne(userId)
+                )
+                .fetchFirst();
+        return found != null;
+    }
+
+    private BooleanExpression isbn13WithVisibleRecruitingGroups(Long userId) {
+        QGroups candidateGroups = new QGroups("popularCandidateGroups");
+        QBook candidateBook = new QBook("popularCandidateBook");
+
+        return book.isbn13.in(
+                JPAExpressions
+                        .select(candidateBook.isbn13)
+                        .distinct()
+                        .from(candidateGroups)
+                        .join(candidateGroups.book, candidateBook)
+                        .where(
+                                candidateGroups.groupStatus.eq(GroupStatus.RECRUITING),
+                                candidateGroups.host.id.ne(userId)
+                        )
+        );
+    }
+
+    public List<HomeBestsellerBookProjection> findBestsellerBooks(int limit) {
         return queryFactory
                 .select(Projections.constructor(
-                        HomeBookProjection.class,
-                        book.isbn13,
-                        book.title,
-                        book.author,
-                        book.image
+                        HomeBestsellerBookProjection.class,
+                        bestsellerIsbn.isbn13,
+                        bestsellerIsbn.title,
+                        bestsellerIsbn.author,
+                        bestsellerIsbn.bookImage,
+                        bestsellerIsbn.rank
                 ))
                 .from(bestsellerIsbn)
-                .join(book).on(book.isbn13.eq(bestsellerIsbn.isbn13))
                 .orderBy(bestsellerIsbn.rank.asc(), bestsellerIsbn.id.asc())
                 .limit(limit)
                 .fetch();
     }
 
-    public List<CustomCategory> findCategoriesWithRecruitingGroups() {
+    public List<CustomCategory> findCategoriesWithRecruitingGroups(Long userId) {
         return queryFactory
                 .select(book.category).distinct()
                 .from(groups)
                 .join(groups.book, book)
                 .where(
                         groups.groupStatus.eq(GroupStatus.RECRUITING),
+                        groups.host.id.ne(userId),
                         book.category.notIn(
                                 CustomCategory.ALL,
                                 CustomCategory.LITERATURE_ALL,
@@ -270,7 +320,7 @@ public class GroupQueryRepository {
 
     public List<Groups> findClassicGroups(
             Long userId,
-            String candidateSectionType,
+            HomeCandidateSectionType candidateSectionType,
             int limit
     ) {
         return homeGroupQuery(userId)

--- a/src/main/java/com/example/bookiibookii/domain/group/service/GroupService.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/service/GroupService.java
@@ -16,6 +16,7 @@ import com.example.bookiibookii.domain.group.event.GroupNotificationEvent;
 import com.example.bookiibookii.domain.group.exception.GroupException;
 import com.example.bookiibookii.domain.group.exception.code.GroupErrorCode;
 import com.example.bookiibookii.domain.group.repository.*;
+import com.example.bookiibookii.domain.group.util.HomeSeedUtil;
 import com.example.bookiibookii.domain.notification.entity.Keyword;
 import com.example.bookiibookii.domain.notification.event.KeywordGroupCreatedEvent;
 import com.example.bookiibookii.domain.notification.publisher.DomainEventPublisher;
@@ -25,7 +26,6 @@ import com.example.bookiibookii.domain.user.enums.Tag;
 import com.example.bookiibookii.domain.user.exception.UserException;
 import com.example.bookiibookii.domain.user.exception.code.UserErrorCode;
 import com.example.bookiibookii.domain.user.service.BadWordService;
-import com.example.bookiibookii.domain.aladin.repository.BestsellerIsbnRepository;
 import com.example.bookiibookii.domain.user.service.UserImageS3Service;
 import com.example.bookiibookii.global.util.RedisUtil;
 import lombok.RequiredArgsConstructor;
@@ -36,12 +36,12 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
-import java.util.Objects;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 
 import static com.example.bookiibookii.domain.group.enums.GroupNotiType.GROUP_DELETED;
@@ -66,15 +66,15 @@ public class GroupService {
     private final UserExchangeRepository userExchangeRepository;
     private final UserDeliveryRepository userDeliveryRepository;
     private final GroupPlaceRepository groupPlaceRepository;
-    private final BestsellerIsbnRepository bestsellerIsbnRepository;
 
     private static final int PRESIGNED_GET_URL_EXPIRATION_MINUTES = 60;
     private static final Set<Tag> READING_STYLE_TAGS = Set.of(Tag.MEMO, Tag.POSTIT, Tag.PHOTO, Tag.All_ROUNDER);
 
     // 그룹 홈 화면 섹션별 노출 개수
-    private static final int HOME_NEW_GROUP_LIMIT = 5;            // 섹션1: 신규 그룹
-    private static final int HOME_CATEGORY_GROUP_LIMIT = 9;       // 섹션2: 카테고리 추천 (3개씩 3페이지)
-    private static final int HOME_REGION_GROUP_LIMIT = 15;        // 섹션5: 위치 기반 (3개씩 5페이지)
+    private static final int HOME_GROUP_LIMIT = 5;
+    private static final int HOME_POPULAR_BOOK_LIMIT = 5;
+    private static final int HOME_BESTSELLER_BOOK_LIMIT = 3;
+    private static final String CLASSIC_CANDIDATE_SECTION_TYPE = "CLASSIC_BOOK_GROUP";
 
     //그룹생성 service
     public GroupResponseDTO.CreateResultDTO createGroup(User host, GroupRequestDTO.CreateDTO request){
@@ -723,111 +723,261 @@ public class GroupService {
         }
 
         Long userId = user.getId();
+        List<GroupResponseDTO.HomeSectionDTO> sections = new ArrayList<>(7);
 
-        // 섹션1: 최근 생성된 그룹 (본인 호스트 제외)
-        List<GroupResponseDTO.HomeGroupCardDTO> newGroups = groupQueryRepository.findRecentGroups(userId, HOME_NEW_GROUP_LIMIT)
-                .stream().map(this::toHomeCard).toList();
+        addIfPresent(sections, buildNewGroupsSection(userId));
+        sections.add(buildPopularBooksSection());
+        addIfPresent(sections, buildGenreSection(userId));
+        sections.add(buildBestsellerBooksSection());
+        addIfPresent(sections, buildClassicGroupsSection(userId));
+        addIfPresent(sections, buildPackageGroupsSection(userId));
+        addIfPresent(sections, buildNearbyDirectGroupsSection(userId));
 
-        // 섹션2: 카테고리 추천 그룹 (본인 호스트 제외)
-        GroupResponseDTO.CategorySectionDTO categorySection = buildCategorySection(userId);
-
-        // 섹션3: 베스트셀러 기반 그룹 추천
-        GroupResponseDTO.BestsellerSectionDTO bestsellerSection = buildBestsellerSection(userId);
-
-        // 섹션5: 위치 기반 그룹 (본인 호스트 제외)
-        GroupResponseDTO.RegionSectionDTO regionSection = buildRegionSection(userId);
-
-        return GroupResponseDTO.HomeResponseDTO.builder()
-                .newGroups(newGroups)
-                .categorySection(categorySection)
-                .bestsellerSection(bestsellerSection)
-                .regionSection(regionSection)
-                .build();
+        return GroupResponseDTO.HomeResponseDTO.builder().sections(sections).build();
     }
 
-    // 섹션2: 그룹이 존재하는 카테고리 중 랜덤 1개를 골라 해당 카테고리 그룹을 추천
-    private GroupResponseDTO.CategorySectionDTO buildCategorySection(Long userId) {
-        List<CustomCategory> candidates = groupQueryRepository.findCategoriesWithRecruitingGroups(userId);
-        if (candidates.isEmpty()) {
-            return GroupResponseDTO.CategorySectionDTO.builder()
-                    .category(null)
-                    .groups(List.of())
-                    .build();
-        }
-
-        CustomCategory picked = candidates.get(ThreadLocalRandom.current().nextInt(candidates.size()));
-        List<GroupResponseDTO.HomeGroupCardDTO> groups =
-                groupQueryRepository.findRandomGroupsByCategory(userId, picked, HOME_CATEGORY_GROUP_LIMIT)
-                        .stream().map(this::toHomeCard).toList();
-
-        return GroupResponseDTO.CategorySectionDTO.builder()
-                .category(picked.getLabel())
-                .groups(groups)
-                .build();
+    private GroupResponseDTO.HomeSectionDTO buildNewGroupsSection(Long userId) {
+        List<GroupResponseDTO.HomeGroupCardDTO> items = toHomeCards(
+                groupQueryRepository.findRecentGroups(
+                        userId,
+                        HomeSeedUtil.twentyFourHoursAgoKst(),
+                        HOME_GROUP_LIMIT
+                )
+        );
+        return groupSection(
+                HomeSectionType.NEW_GROUPS,
+                "신규 그룹을 확인해보세요",
+                "오늘 만들어진 따끈따끈한 그룹들만 모았어요",
+                items
+        );
     }
 
-    // 섹션3: 베스트셀러 순위 순서대로, 책 1권당 그룹 1개씩 노출
-    private GroupResponseDTO.BestsellerSectionDTO buildBestsellerSection(Long userId) {
-        List<String> isbn13List = bestsellerIsbnRepository.findAllIsbn13OrderByRank();
-        if (isbn13List.isEmpty()) {
-            return GroupResponseDTO.BestsellerSectionDTO.builder().groups(List.of()).build();
-        }
+    private GroupResponseDTO.HomeSectionDTO buildPopularBooksSection() {
+        List<GroupResponseDTO.HomeBookThumbnailDTO> items = toBookThumbnails(
+                groupQueryRepository.findPopularBooks(HOME_POPULAR_BOOK_LIMIT)
+        );
+        return bookSection(
+                HomeSectionType.POPULAR_BOOKS_TOP5,
+                "인기 도서 TOP 5",
+                "지금 바로 부키부키에서 핫한 도서를 확인해보세요",
+                HomeLayoutType.BOOK_THUMBNAIL_CAROUSEL,
+                items
+        );
+    }
 
-        // isbn13별로 그룹 묶은 뒤 각 책에서 랜덤 1개 선택 (새로고침마다 다른 그룹 노출)
-        Map<String, List<Groups>> grouped = groupQueryRepository.findBestsellerGroups(userId, isbn13List)
+    private GroupResponseDTO.HomeSectionDTO buildGenreSection(Long userId) {
+        List<HomeGenre> candidates = groupQueryRepository
+                .findCategoriesWithRecruitingGroups()
                 .stream()
-                .collect(Collectors.groupingBy(g -> g.getBook().getIsbn13()));
-
-        Map<String, Groups> groupByIsbn = grouped.entrySet().stream()
-                .collect(Collectors.toMap(
-                        Map.Entry::getKey,
-                        e -> e.getValue().get(ThreadLocalRandom.current().nextInt(e.getValue().size()))
-                ));
-
-        // 베스트셀러 순위 순서 유지하며 카드 조립
-        List<GroupResponseDTO.HomeGroupCardDTO> cards = isbn13List.stream()
-                .map(groupByIsbn::get)
-                .filter(Objects::nonNull)
-                .map(this::toHomeCard)
+                .map(HomeGenre::from)
+                .flatMap(java.util.Optional::stream)
+                .distinct()
+                .sorted(Comparator.comparing(Enum::name))
                 .toList();
-
-        return GroupResponseDTO.BestsellerSectionDTO.builder().groups(cards).build();
-    }
-
-    // 섹션5: 사용자 교환 장소(구/군)에서 열린 직접교환 그룹을 추천
-    private GroupResponseDTO.RegionSectionDTO buildRegionSection(Long userId) {
-        List<UserExchange> exchanges = userExchangeRepository.findByUserIdWithLocation(userId);
-        String district = exchanges.isEmpty() ? null
-                : extractDistrict(exchanges.get(0).getLocation().getAddress());
-
-        if (district == null) {
-            return GroupResponseDTO.RegionSectionDTO.builder()
-                    .region(null)
-                    .groups(List.of())
-                    .build();
-        }
-
-        List<GroupResponseDTO.HomeGroupCardDTO> groups =
-                groupQueryRepository.findRegionGroups(userId, district, HOME_REGION_GROUP_LIMIT)
-                        .stream().map(this::toHomeCard).toList();
-
-        return GroupResponseDTO.RegionSectionDTO.builder()
-                .region(district)
-                .groups(groups)
-                .build();
-    }
-
-    // 주소 문자열에서 구/군 토큰 추출 (예: "서울특별시 동작구 흑석로 84" -> "동작구")
-    private String extractDistrict(String address) {
-        if (address == null || address.isBlank()) {
+        if (candidates.isEmpty()) {
             return null;
         }
-        for (String token : address.trim().split("\\s+")) {
-            if (token.endsWith("구") || token.endsWith("군")) {
-                return token;
-            }
+
+        HomeGenre picked = deterministicPick(
+                candidates,
+                HomeSeedUtil.currentSeedKey()
+        );
+        List<GroupResponseDTO.HomeGroupCardDTO> items = toHomeCards(
+                groupQueryRepository.findGroupsByCategories(
+                        userId,
+                        picked.getCategories(),
+                        HOME_GROUP_LIMIT
+                )
+        );
+        return groupSection(
+                HomeSectionType.RANDOM_GENRE_GROUPS,
+                picked.getLabel() + " 도서와 함께해볼까요?",
+                "평소 자주 읽지 않았던 장르여도 도전해보세요",
+                items
+        );
+    }
+
+    private GroupResponseDTO.HomeSectionDTO buildBestsellerBooksSection() {
+        List<GroupResponseDTO.HomeBookThumbnailDTO> items = toBookThumbnails(
+                groupQueryRepository.findBestsellerBooks(HOME_BESTSELLER_BOOK_LIMIT)
+        );
+        return bookSection(
+                HomeSectionType.BESTSELLER_BOOKS,
+                "나 빼고 다 읽은 책 여기 있어요",
+                "이번 기회에 베스트셀러 읽어볼까요?",
+                HomeLayoutType.BOOK_THUMBNAIL_GRID,
+                items
+        );
+    }
+
+    private GroupResponseDTO.HomeSectionDTO buildClassicGroupsSection(Long userId) {
+        List<GroupResponseDTO.HomeGroupCardDTO> items = toHomeCards(
+                groupQueryRepository.findClassicGroups(
+                        userId,
+                        CLASSIC_CANDIDATE_SECTION_TYPE,
+                        HOME_GROUP_LIMIT
+                )
+        );
+        return groupSection(
+                HomeSectionType.CLASSIC_GROUPS,
+                "고전, 한 번쯤은 읽어야죠",
+                "파트너와 함께라면 더 재미있을 거예요",
+                items
+        );
+    }
+
+    private GroupResponseDTO.HomeSectionDTO buildPackageGroupsSection(Long userId) {
+        List<GroupResponseDTO.HomeGroupCardDTO> items = toHomeCards(
+                groupQueryRepository.findGroupsByTradeType(
+                        userId,
+                        TradeType.DELIVERY,
+                        HOME_GROUP_LIMIT
+                )
+        );
+        return groupSection(
+                HomeSectionType.PACKAGE_GROUPS,
+                "택배로 책을 안전하게 교환해요",
+                "전국 어디에 있어도 책을 교환할 수 있어요",
+                items
+        );
+    }
+
+    private GroupResponseDTO.HomeSectionDTO buildNearbyDirectGroupsSection(Long userId) {
+        List<UserExchange> exchanges = userExchangeRepository
+                .findByUserIdWithLocation(userId)
+                .stream()
+                .filter(exchange -> exchange.getLocation().getX() != null)
+                .filter(exchange -> exchange.getLocation().getY() != null)
+                .filter(distinctByCoordinate())
+                .limit(2)
+                .toList();
+        if (exchanges.isEmpty()) {
+            return null;
         }
-        return null;
+
+        List<UserExchange> candidates = exchanges.stream()
+                .filter(exchange -> groupQueryRepository.existsDirectGroupsAtCoordinate(
+                        userId,
+                        exchange.getLocation().getX(),
+                        exchange.getLocation().getY()
+                ))
+                .toList();
+        if (candidates.isEmpty()) {
+            return null;
+        }
+
+        UserExchange picked = deterministicPick(
+                candidates,
+                HomeSeedUtil.userSeedKey(userId, HomeSeedUtil.currentSeedKey())
+        );
+        List<GroupResponseDTO.HomeGroupCardDTO> items = toHomeCards(
+                groupQueryRepository.findDirectGroupsAtCoordinate(
+                        userId,
+                        picked.getLocation().getX(),
+                        picked.getLocation().getY(),
+                        HOME_GROUP_LIMIT
+                )
+        );
+        return groupSection(
+                HomeSectionType.NEARBY_DIRECT_GROUPS,
+                "근처에서 직접 만나 교환해요",
+                "",
+                items
+        );
+    }
+
+    private <T> T deterministicPick(List<T> candidates, String seedKey) {
+        return candidates.get(HomeSeedUtil.pickIndex(seedKey, candidates.size()));
+    }
+
+    private java.util.function.Predicate<UserExchange> distinctByCoordinate() {
+        Set<String> seen = new java.util.HashSet<>();
+        return exchange -> seen.add(
+                coordinateKey(
+                        exchange.getLocation().getX(),
+                        exchange.getLocation().getY()
+                )
+        );
+    }
+
+    private String coordinateKey(BigDecimal x, BigDecimal y) {
+        return x.stripTrailingZeros().toPlainString()
+                + ":"
+                + y.stripTrailingZeros().toPlainString();
+    }
+
+    private List<GroupResponseDTO.HomeGroupCardDTO> toHomeCards(
+            List<Groups> groups
+    ) {
+        if (groups == null || groups.isEmpty()) {
+            return List.of();
+        }
+        return groups.stream().map(this::toHomeCard).toList();
+    }
+
+    private List<GroupResponseDTO.HomeBookThumbnailDTO> toBookThumbnails(
+            List<GroupQueryRepository.HomeBookProjection> books
+    ) {
+        if (books == null || books.isEmpty()) {
+            return List.of();
+        }
+        List<GroupResponseDTO.HomeBookThumbnailDTO> items =
+                new ArrayList<>(books.size());
+        for (int i = 0; i < books.size(); i++) {
+            GroupQueryRepository.HomeBookProjection book = books.get(i);
+            items.add(GroupResponseDTO.HomeBookThumbnailDTO.builder()
+                    .isbn13(book.isbn13())
+                    .title(book.title())
+                    .author(book.author())
+                    .bookImage(book.image())
+                    .searchKeyword(book.title())
+                    .rank(i + 1)
+                    .build());
+        }
+        return items;
+    }
+
+    private GroupResponseDTO.HomeSectionDTO groupSection(
+            HomeSectionType sectionType,
+            String title,
+            String subtitle,
+            List<GroupResponseDTO.HomeGroupCardDTO> items
+    ) {
+        if (items == null || items.isEmpty()) {
+            return null;
+        }
+        return GroupResponseDTO.HomeSectionDTO.builder()
+                .sectionType(sectionType)
+                .title(title)
+                .subtitle(subtitle)
+                .layoutType(HomeLayoutType.GROUP_CARD_CAROUSEL)
+                .items(items)
+                .build();
+    }
+
+    private GroupResponseDTO.HomeSectionDTO bookSection(
+            HomeSectionType sectionType,
+            String title,
+            String subtitle,
+            HomeLayoutType layoutType,
+            List<GroupResponseDTO.HomeBookThumbnailDTO> items
+    ) {
+        return GroupResponseDTO.HomeSectionDTO.builder()
+                .sectionType(sectionType)
+                .title(title)
+                .subtitle(subtitle)
+                .layoutType(layoutType)
+                .items(items == null ? List.of() : items)
+                .build();
+    }
+
+    private void addIfPresent(
+            List<GroupResponseDTO.HomeSectionDTO> sections,
+            GroupResponseDTO.HomeSectionDTO section
+    ) {
+        if (section != null) {
+            sections.add(section);
+        }
     }
 
     private GroupResponseDTO.HomeGroupCardDTO toHomeCard(Groups group) {

--- a/src/main/java/com/example/bookiibookii/domain/group/service/GroupService.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/service/GroupService.java
@@ -74,7 +74,6 @@ public class GroupService {
     private static final int HOME_GROUP_LIMIT = 5;
     private static final int HOME_POPULAR_BOOK_LIMIT = 5;
     private static final int HOME_BESTSELLER_BOOK_LIMIT = 3;
-    private static final String CLASSIC_CANDIDATE_SECTION_TYPE = "CLASSIC_BOOK_GROUP";
 
     //그룹생성 service
     public GroupResponseDTO.CreateResultDTO createGroup(User host, GroupRequestDTO.CreateDTO request){
@@ -726,7 +725,7 @@ public class GroupService {
         List<GroupResponseDTO.HomeSectionDTO> sections = new ArrayList<>(7);
 
         addIfPresent(sections, buildNewGroupsSection(userId));
-        sections.add(buildPopularBooksSection());
+        sections.add(buildPopularBooksSection(userId));
         addIfPresent(sections, buildGenreSection(userId));
         sections.add(buildBestsellerBooksSection());
         addIfPresent(sections, buildClassicGroupsSection(userId));
@@ -752,9 +751,9 @@ public class GroupService {
         );
     }
 
-    private GroupResponseDTO.HomeSectionDTO buildPopularBooksSection() {
+    private GroupResponseDTO.HomeSectionDTO buildPopularBooksSection(Long userId) {
         List<GroupResponseDTO.HomeBookThumbnailDTO> items = toBookThumbnails(
-                groupQueryRepository.findPopularBooks(HOME_POPULAR_BOOK_LIMIT)
+                groupQueryRepository.findPopularBooks(userId, HOME_POPULAR_BOOK_LIMIT)
         );
         return bookSection(
                 HomeSectionType.POPULAR_BOOKS_TOP5,
@@ -767,7 +766,7 @@ public class GroupService {
 
     private GroupResponseDTO.HomeSectionDTO buildGenreSection(Long userId) {
         List<HomeGenre> candidates = groupQueryRepository
-                .findCategoriesWithRecruitingGroups()
+                .findCategoriesWithRecruitingGroups(userId)
                 .stream()
                 .map(HomeGenre::from)
                 .flatMap(java.util.Optional::stream)
@@ -798,7 +797,7 @@ public class GroupService {
     }
 
     private GroupResponseDTO.HomeSectionDTO buildBestsellerBooksSection() {
-        List<GroupResponseDTO.HomeBookThumbnailDTO> items = toBookThumbnails(
+        List<GroupResponseDTO.HomeBookThumbnailDTO> items = toBestsellerBookThumbnails(
                 groupQueryRepository.findBestsellerBooks(HOME_BESTSELLER_BOOK_LIMIT)
         );
         return bookSection(
@@ -814,7 +813,7 @@ public class GroupService {
         List<GroupResponseDTO.HomeGroupCardDTO> items = toHomeCards(
                 groupQueryRepository.findClassicGroups(
                         userId,
-                        CLASSIC_CANDIDATE_SECTION_TYPE,
+                        HomeCandidateSectionType.CLASSIC_BOOK_GROUP,
                         HOME_GROUP_LIMIT
                 )
         );
@@ -849,25 +848,19 @@ public class GroupService {
                 .filter(exchange -> exchange.getLocation().getX() != null)
                 .filter(exchange -> exchange.getLocation().getY() != null)
                 .filter(distinctByCoordinate())
+                .filter(exchange -> groupQueryRepository.existsDirectGroupsAtCoordinate(
+                        userId,
+                        exchange.getLocation().getX(),
+                        exchange.getLocation().getY()
+                ))
                 .limit(2)
                 .toList();
         if (exchanges.isEmpty()) {
             return null;
         }
 
-        List<UserExchange> candidates = exchanges.stream()
-                .filter(exchange -> groupQueryRepository.existsDirectGroupsAtCoordinate(
-                        userId,
-                        exchange.getLocation().getX(),
-                        exchange.getLocation().getY()
-                ))
-                .toList();
-        if (candidates.isEmpty()) {
-            return null;
-        }
-
         UserExchange picked = deterministicPick(
-                candidates,
+                exchanges,
                 HomeSeedUtil.userSeedKey(userId, HomeSeedUtil.currentSeedKey())
         );
         List<GroupResponseDTO.HomeGroupCardDTO> items = toHomeCards(
@@ -935,6 +928,26 @@ public class GroupService {
                     .build());
         }
         return items;
+    }
+
+    private List<GroupResponseDTO.HomeBookThumbnailDTO> toBestsellerBookThumbnails(
+            List<GroupQueryRepository.HomeBestsellerBookProjection> books
+    ) {
+        if (books == null || books.isEmpty()) {
+            return List.of();
+        }
+        return books.stream()
+                .filter(book -> !isBlank(book.isbn13()))
+                .filter(book -> !isBlank(book.title()))
+                .map(book -> GroupResponseDTO.HomeBookThumbnailDTO.builder()
+                        .isbn13(book.isbn13())
+                        .title(book.title())
+                        .author(book.author())
+                        .bookImage(book.image())
+                        .searchKeyword(book.title())
+                        .rank(book.ranking())
+                        .build())
+                .toList();
     }
 
     private GroupResponseDTO.HomeSectionDTO groupSection(

--- a/src/main/java/com/example/bookiibookii/domain/group/util/HomeSeedUtil.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/util/HomeSeedUtil.java
@@ -1,0 +1,42 @@
+package com.example.bookiibookii.domain.group.util;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+
+public final class HomeSeedUtil {
+
+    public static final ZoneId KST = ZoneId.of("Asia/Seoul");
+    private static final DateTimeFormatter SEED_DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
+
+    private HomeSeedUtil() {
+    }
+
+    public static String currentSeedKey() {
+        return seedKey(LocalDateTime.now(KST));
+    }
+
+    public static String seedKey(LocalDateTime kstDateTime) {
+        int sixHourSlot = kstDateTime.getHour() / 6;
+        return kstDateTime.format(SEED_DATE_FORMATTER) + "_" + sixHourSlot;
+    }
+
+    public static long seed(String seedKey) {
+        return seedKey.hashCode();
+    }
+
+    public static int pickIndex(String seedKey, int candidateCount) {
+        if (candidateCount <= 0) {
+            throw new IllegalArgumentException("candidateCount must be positive");
+        }
+        return Math.floorMod(seed(seedKey), candidateCount);
+    }
+
+    public static String userSeedKey(Long userId, String sixHourSeedKey) {
+        return userId + "_" + sixHourSeedKey;
+    }
+
+    public static LocalDateTime twentyFourHoursAgoKst() {
+        return LocalDateTime.now(KST).minusHours(24);
+    }
+}

--- a/src/main/java/com/example/bookiibookii/domain/tracker/resolver/TrackerDisplayStatusResolver.java
+++ b/src/main/java/com/example/bookiibookii/domain/tracker/resolver/TrackerDisplayStatusResolver.java
@@ -98,7 +98,7 @@ public class TrackerDisplayStatusResolver {
                         TrackerDisplayStatus.RETURN_TRACKING_REQUIRED;
 
                 case TRACKING_REGISTERED ->
-                        TrackerDisplayStatus.SHIPPING;
+                        TrackerDisplayStatus.RETURNING;
 
                 case RECEIVED_CONFIRMED, NOT_STARTED ->
                         TrackerDisplayStatus.EXCHANGE_REVIEW_WRITING;

--- a/src/main/resources/aladin_classic_cids.csv
+++ b/src/main/resources/aladin_classic_cids.csv
@@ -1,0 +1,26 @@
+section_type,cid,category_name,mall,category_path,depth,active
+CLASSIC_BOOK_GROUP,2105,고전,국내도서,고전,1,true
+CLASSIC_BOOK_GROUP,2330,경제학고전,국내도서,고전 > 경제학고전,2,true
+CLASSIC_BOOK_GROUP,4527,고사성어/속담,국내도서,고전 > 고사성어/속담,2,true
+CLASSIC_BOOK_GROUP,2094,고전에서배운다,국내도서,고전 > 고전에서배운다,2,true
+CLASSIC_BOOK_GROUP,2344,과학고전,국내도서,고전 > 과학고전,2,true
+CLASSIC_BOOK_GROUP,2310,군사고전,국내도서,고전 > 군사고전,2,true
+CLASSIC_BOOK_GROUP,2095,다시쓴고전,국내도서,고전 > 다시쓴고전,2,true
+CLASSIC_BOOK_GROUP,2123,동양고전문학,국내도서,고전 > 동양고전문학,2,true
+CLASSIC_BOOK_GROUP,4378,기타 동양고전,국내도서,고전 > 동양고전문학 > 기타 동양고전,3,true
+CLASSIC_BOOK_GROUP,4655,중국고전-산문,국내도서,고전 > 동양고전문학 > 중국고전-산문,3,true
+CLASSIC_BOOK_GROUP,12390,중국고전-시가,국내도서,고전 > 동양고전문학 > 중국고전-시가,3,true
+CLASSIC_BOOK_GROUP,2124,동양고전사상,국내도서,고전 > 동양고전사상,2,true
+CLASSIC_BOOK_GROUP,4438,기타 동양고전사상,국내도서,고전 > 동양고전사상 > 기타 동양고전사상,3,true
+CLASSIC_BOOK_GROUP,4437,도가사상,국내도서,고전 > 동양고전사상 > 도가사상,3,true
+CLASSIC_BOOK_GROUP,4436,유가사상,국내도서,고전 > 동양고전사상 > 유가사상,3,true
+CLASSIC_BOOK_GROUP,2125,서양고전문학,국내도서,고전 > 서양고전문학,2,true
+CLASSIC_BOOK_GROUP,2149,서양고대문학,국내도서,고전 > 서양고전문학 > 서양고대문학,3,true
+CLASSIC_BOOK_GROUP,2314,서양근대문학,국내도서,고전 > 서양고전문학 > 서양근대문학,3,true
+CLASSIC_BOOK_GROUP,2138,서양중세문학,국내도서,고전 > 서양고전문학 > 서양중세문학,3,true
+CLASSIC_BOOK_GROUP,222,서양현대고전,국내도서,고전 > 서양고전문학 > 서양현대고전,3,true
+CLASSIC_BOOK_GROUP,2126,서양고전사상,국내도서,고전 > 서양고전사상,2,true
+CLASSIC_BOOK_GROUP,2121,우리나라 옛글,국내도서,고전 > 우리나라 옛글,2,true
+CLASSIC_BOOK_GROUP,4440,산문,국내도서,고전 > 우리나라 옛글 > 산문,3,true
+CLASSIC_BOOK_GROUP,4441,시가,국내도서,고전 > 우리나라 옛글 > 시가,3,true
+CLASSIC_BOOK_GROUP,7459,위대한 작가들,국내도서,고전 > 위대한 작가들,2,true


### PR DESCRIPTION
## 개요
<!---- 자신이 완료한 이슈를 닫아주세요 -->
- closed #527 
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
홈 추천 안의 7가지 섹션을 구현했습니다. 

- 홈 응답을 `HomeResponseDTO.sections` 순서형 목록 구조로 변경했습니다.
- 각 섹션에 `sectionType`, `title`, `subtitle`, `layoutType`, `items`를 내려주도록 수정했습니다.
- KST 기준 날짜와 `hour / 6` 값을 사용해 6시간 단위 seed를 생성했습니다.
- 직접교환 섹션은 `userId + seed`를 사용해 유저별로 독립적인 랜덤 결과를 제공합니다.

<!---- Resolves: #(Isuue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

📣 **To Reviewers**
---
<!-- 전달사항 -->

- Reviewers : 팀 선택
- Labels : 작업 유형, 자기 자신


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 홈 화면 섹션을 단일화해 신규 그룹, 인기 도서, 장르 추천, 베스트셀러, 고전 그룹, 근처 직거래 등을 일관된 섹션 리스트로 제공합니다.
  * 책 썸네일용 캐러셀·그리드 레이아웃을 추가했습니다.
* **설명서**
  * 홈 섹션 조회 API 문서를 섹션 구성·데이터 처리·외부 API 호출 조건에 맞게 업데이트했습니다.
* **동작 변경**
  * 장르·근처 섹션은 시드 기반 결정 로직으로 일관된 후보 선택을 수행합니다.
  * 베스트셀러 갱신 시 ISBN/메타 검증과 중복 제거를 강화해 유효한 항목만 저장합니다.
  * 반품 배송 표시 상태가 일부 경우 RETURNING으로 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->