### PR TITLE
[Fix]#539 트래커 D-day 계산 기준 정리

### DIFF
--- a/src/main/java/com/example/bookiibookii/domain/group/repository/GroupsRepository.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/repository/GroupsRepository.java
@@ -106,7 +106,7 @@ public interface GroupsRepository extends JpaRepository<Groups, Long> {
 
     // 독서 종료일로부터 3일이 지났는데 아직 종료되지 않은(MATCHED) 그룹 조회
     @Query(value = "SELECT * FROM `groups` g WHERE g.group_status = 'MATCHED' " +
-            "AND DATE_ADD(g.start_date, INTERVAL g.reading_period DAY) <= :deadline",
+            "AND DATE_ADD(g.start_date, INTERVAL (g.reading_period - 1) DAY) <= :deadline",
             nativeQuery = true)
     List<Groups> findGroupsPastReviewDeadline(@Param("deadline") LocalDate deadline);
 }

--- a/src/main/java/com/example/bookiibookii/domain/group/util/ReadingPeriodDateCalculator.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/util/ReadingPeriodDateCalculator.java
@@ -32,7 +32,15 @@ public final class ReadingPeriodDateCalculator {
     }
 
     public static int inclusivePeriod(LocalDate startDate, LocalDate endDate) {
-        return (int) ChronoUnit.DAYS.between(startDate, endDate) + 1;
+        if (startDate == null || endDate == null) {
+            throw new IllegalArgumentException("startDate and endDate must not be null");
+        }
+
+        if (endDate.isBefore(startDate)) {
+            throw new IllegalArgumentException("endDate must not be before startDate");
+        }
+
+        return Math.toIntExact(ChronoUnit.DAYS.between(startDate, endDate) + 1);
     }
 
     public static Integer remainingDaysUntil(LocalDate dueDate, LocalDate today) {

--- a/src/main/java/com/example/bookiibookii/domain/group/util/ReadingPeriodDateCalculator.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/util/ReadingPeriodDateCalculator.java
@@ -1,0 +1,44 @@
+package com.example.bookiibookii.domain.group.util;
+
+import com.example.bookiibookii.domain.group.entity.Groups;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
+
+public final class ReadingPeriodDateCalculator {
+
+    public static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+    private ReadingPeriodDateCalculator() {
+    }
+
+    public static LocalDate todayKst() {
+        return LocalDate.now(KST);
+    }
+
+    public static LocalDate endDate(Groups group) {
+        if (group == null) {
+            return null;
+        }
+        return endDate(group.getStartDate(), group.getReadingPeriod());
+    }
+
+    public static LocalDate endDate(LocalDate startDate, Integer readingPeriod) {
+        if (startDate == null || readingPeriod == null) {
+            return null;
+        }
+        return startDate.plusDays(readingPeriod - 1L);
+    }
+
+    public static int inclusivePeriod(LocalDate startDate, LocalDate endDate) {
+        return (int) ChronoUnit.DAYS.between(startDate, endDate) + 1;
+    }
+
+    public static Integer remainingDaysUntil(LocalDate dueDate, LocalDate today) {
+        if (dueDate == null || today == null) {
+            return null;
+        }
+        return Math.max((int) ChronoUnit.DAYS.between(today, dueDate), 0);
+    }
+}

--- a/src/main/java/com/example/bookiibookii/domain/memberbook/service/MemberBookLibraryService.java
+++ b/src/main/java/com/example/bookiibookii/domain/memberbook/service/MemberBookLibraryService.java
@@ -1,5 +1,6 @@
 package com.example.bookiibookii.domain.memberbook.service;
 
+import com.example.bookiibookii.domain.group.util.ReadingPeriodDateCalculator;
 import com.example.bookiibookii.domain.memberbook.dto.res.LibraryMemberBookResponseDTO;
 import com.example.bookiibookii.domain.memberbook.entity.MemberBook;
 import com.example.bookiibookii.domain.memberbook.exception.MemberBookException;
@@ -114,10 +115,7 @@ public class MemberBookLibraryService {
             }
         }
 
-        LocalDate finalEndDate = null;
-        if (group.getStartDate() != null && group.getReadingPeriod() != null) {
-            finalEndDate = group.getStartDate().plusDays(group.getReadingPeriod());
-        }
+        LocalDate finalEndDate = ReadingPeriodDateCalculator.endDate(group);
 
         Double rating = bookReview != null ? bookReview.getStar() : null;
         String comment = bookReview != null ? bookReview.getComment() : null;

--- a/src/main/java/com/example/bookiibookii/domain/tracker/resolver/TrackerDueDateResolver.java
+++ b/src/main/java/com/example/bookiibookii/domain/tracker/resolver/TrackerDueDateResolver.java
@@ -1,14 +1,25 @@
 package com.example.bookiibookii.domain.tracker.resolver;
 
 import com.example.bookiibookii.domain.group.entity.Groups;
+import com.example.bookiibookii.domain.group.util.ReadingPeriodDateCalculator;
 import com.example.bookiibookii.domain.tracker.enums.TrackerDisplayStatus;
 import org.springframework.stereotype.Component;
 
+import java.time.Clock;
 import java.time.LocalDate;
-import java.time.temporal.ChronoUnit;
 
 @Component
 public class TrackerDueDateResolver {
+
+    private final Clock clock;
+
+    public TrackerDueDateResolver() {
+        this(Clock.system(ReadingPeriodDateCalculator.KST));
+    }
+
+    public TrackerDueDateResolver(Clock clock) {
+        this.clock = clock;
+    }
 
     public Integer calculate(
             TrackerDisplayStatus displayStatus,
@@ -19,16 +30,11 @@ public class TrackerDueDateResolver {
             return null;
         }
 
-        LocalDate dueDate = group.getStartDate() == null || group.getReadingPeriod() == null
-                ? null
-                : group.getStartDate().plusDays(group.getReadingPeriod());
-
+        LocalDate dueDate = ReadingPeriodDateCalculator.endDate(group);
         if (dueDate == null) {
             return null;
         }
 
-        long days = ChronoUnit.DAYS.between(LocalDate.now(), dueDate);
-
-        return Math.max((int) days, 0);
+        return ReadingPeriodDateCalculator.remainingDaysUntil(dueDate, LocalDate.now(clock));
     }
 }

--- a/src/main/java/com/example/bookiibookii/domain/tracker/service/TrackerService.java
+++ b/src/main/java/com/example/bookiibookii/domain/tracker/service/TrackerService.java
@@ -8,6 +8,7 @@ import com.example.bookiibookii.domain.group.exception.GroupException;
 import com.example.bookiibookii.domain.group.exception.code.GroupErrorCode;
 import com.example.bookiibookii.domain.group.repository.GroupsRepository;
 import com.example.bookiibookii.domain.group.repository.MatchedMemberRepository;
+import com.example.bookiibookii.domain.group.util.ReadingPeriodDateCalculator;
 import com.example.bookiibookii.domain.review.repository.BookReviewRepository;
 import com.example.bookiibookii.domain.tracker.converter.TrackerConverter;
 import com.example.bookiibookii.domain.tracker.dto.req.ExtendReadingPeriodReqDTO;
@@ -25,8 +26,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDate;
-import java.time.temporal.ChronoUnit;
 import java.util.List;
 
 @Slf4j
@@ -176,10 +175,13 @@ public class TrackerService {
         Groups group = groupsRepository.findById(groupId)
                 .orElseThrow(() -> new GroupException(GroupErrorCode.GROUP_NOT_FOUND));
 
-        long newPeriod = ChronoUnit.DAYS.between(group.getStartDate(), request.newEndDate()) + 1;
-        group.setReadingPeriod((int) newPeriod);
+        int newPeriod = ReadingPeriodDateCalculator.inclusivePeriod(group.getStartDate(), request.newEndDate());
+        group.setReadingPeriod(newPeriod);
 
-        int dDay = (int) ChronoUnit.DAYS.between(LocalDate.now(), request.newEndDate()) + 1;
+        int dDay = ReadingPeriodDateCalculator.remainingDaysUntil(
+                request.newEndDate(),
+                ReadingPeriodDateCalculator.todayKst()
+        );
         return new ExtendReadingPeriodResDTO(request.newEndDate(), dDay);
     }
 
@@ -209,12 +211,7 @@ public class TrackerService {
                 && readingStatus != ReadingStatus.PARTNER_BOOK_READING) {
             return null;
         }
-        if (group.getStartDate() == null || group.getReadingPeriod() == null) {
-            return null;
-        }
-
-        LocalDate dueDate = group.getStartDate().plusDays(group.getReadingPeriod());
-        return Math.max((int) ChronoUnit.DAYS.between(LocalDate.now(), dueDate), 0);
+        return trackerDueDateResolver.calculate(TrackerDisplayStatus.READING, group);
     }
 
     private TrackerListResDTO.Summary buildListSummary(List<TrackerListItemResDTO> items) {


### PR DESCRIPTION
## 개요
<!---- 자신이 완료한 이슈를 닫아주세요 -->
- closed #539 
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 트래커 D-day가 하루씩 밀려 표시되는 문제를 수정했습니다.
- readingPeriod 기준을 시작일/종료일 포함으로 통일했습니다.
  예: 7일 독서 기간, 2026-06-08 시작 → 2026-06-14 종료
- D-day 계산을 Asia/Seoul 기준 오늘 ~ 기준일 차이로 통일했습니다.

<!---- Resolves: #(Isuue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

📣 **To Reviewers**
---
<!-- 전달사항 -->

- Reviewers : 팀 선택
- Labels : 작업 유형, 자기 자신


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 독서 기간 마감일 계산이 개선되었습니다. 기존보다 더욱 정확한 기한 정보를 제공하여 사용자의 독서 일정 관리 및 마감일 추적이 보다 편리하고 신뢰할 수 있도록 개선되었습니다.
  * 남은 일수 계산이 정확하게 개선되었습니다. 음수 값 처리가 추가되어 더욱 신뢰할 수 있는 남은 기간 정보를 제공합니다.

* **Refactor**
  * 기간 및 기한 관련 계산 로직이 통합되었습니다. 시스템의 일관성과 유지보수성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->