### PR TITLE
[Feat]#546 홈 그룹 카드 필드 추가 및 베스트셀러 자동 갱신 개선

### DIFF
--- a/src/main/java/com/example/bookiibookii/domain/aladin/controller/DevBestsellerController.java
+++ b/src/main/java/com/example/bookiibookii/domain/aladin/controller/DevBestsellerController.java
@@ -1,0 +1,31 @@
+package com.example.bookiibookii.domain.aladin.controller;
+
+import com.example.bookiibookii.domain.aladin.scheduler.BestsellerScheduler;
+import com.example.bookiibookii.global.apiPayload.ApiResponse;
+import com.example.bookiibookii.global.apiPayload.code.GeneralSuccessCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+// todo : 테스트용이므로 나중에 삭제 필요
+@RestController
+@Profile({"local", "dev"})
+@RequestMapping("/api/dev/admin/bestsellers")
+@RequiredArgsConstructor
+public class DevBestsellerController {
+
+    private final BestsellerScheduler bestsellerScheduler;
+
+    @PostMapping("/refresh")
+    public ApiResponse<RefreshResult> refresh() {
+        return ApiResponse.onSuccess(
+                GeneralSuccessCode.REQUEST_OK,
+                new RefreshResult(bestsellerScheduler.refreshBestsellers())
+        );
+    }
+
+    public record RefreshResult(int savedCount) {
+    }
+}

--- a/src/main/java/com/example/bookiibookii/domain/aladin/scheduler/BestsellerScheduler.java
+++ b/src/main/java/com/example/bookiibookii/domain/aladin/scheduler/BestsellerScheduler.java
@@ -24,16 +24,23 @@ public class BestsellerScheduler {
     private final AladinClient aladinClient;
     private final BestsellerIsbnRepository bestsellerIsbnRepository;
 
-    @Scheduled(cron = "0 0 0 * * MON", zone = "Asia/Seoul")
+    // 매일 00:00 KST 실행. 환경별로 scheduler.bestseller.cron 설정으로 변경할 수 있다.
+    @Scheduled(cron = "${scheduler.bestseller.cron:0 0 0 * * *}", zone = "Asia/Seoul")
     @Transactional
-    public void refreshBestsellers() {
+    public int refreshBestsellers() {
         log.info("[Scheduler] 베스트셀러 갱신 시작");
 
-        AladinClient.AladinItemSearchResponse response = aladinClient.fetchBestsellers(BESTSELLER_LIMIT);
+        AladinClient.AladinItemSearchResponse response;
+        try {
+            response = aladinClient.fetchBestsellers(BESTSELLER_LIMIT);
+        } catch (RuntimeException e) {
+            log.error("[Scheduler] 알라딘 베스트셀러 조회 실패 - 기존 데이터 유지", e);
+            throw e;
+        }
 
         if (response == null || response.item() == null || response.item().isEmpty()) {
             log.warn("[Scheduler] 베스트셀러 응답 없음 — 기존 데이터 유지");
-            return;
+            return 0;
         }
 
         List<BestsellerIsbn> newList = new ArrayList<>();
@@ -41,6 +48,9 @@ public class BestsellerScheduler {
         List<AladinClient.AladinBookItem> items = response.item();
         for (int i = 0; i < items.size(); i++) {
             AladinClient.AladinBookItem item = items.get(i);
+            if (item == null) {
+                continue;
+            }
             String isbn13 = normalizeIsbn13(item.isbn13());
             if (isbn13 == null) {
                 continue;
@@ -63,10 +73,16 @@ public class BestsellerScheduler {
                     .build());
         }
 
-        bestsellerIsbnRepository.deleteAll();
-        bestsellerIsbnRepository.saveAll(newList);
+        if (newList.isEmpty()) {
+            log.warn("[Scheduler] 저장 가능한 베스트셀러가 없어 기존 데이터 유지");
+            return 0;
+        }
+
+        bestsellerIsbnRepository.deleteAllInBatch();
+        bestsellerIsbnRepository.saveAllAndFlush(newList);
 
         log.info("[Scheduler] 베스트셀러 갱신 완료 ({}건)", newList.size());
+        return newList.size();
     }
 
     private String normalizeIsbn13(String isbn13) {

--- a/src/main/java/com/example/bookiibookii/domain/group/dto/res/GroupResponseDTO.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/dto/res/GroupResponseDTO.java
@@ -2,10 +2,13 @@ package com.example.bookiibookii.domain.group.dto.res;
 
 import com.example.bookiibookii.domain.group.dto.RuleDTO;
 import com.example.bookiibookii.domain.group.enums.GroupStatus;
+import com.example.bookiibookii.domain.group.enums.GroupType;
 import com.example.bookiibookii.domain.group.enums.HomeLayoutType;
 import com.example.bookiibookii.domain.group.enums.HomeSectionType;
 import com.example.bookiibookii.domain.group.enums.HostedGroupDisplayStatus;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -191,6 +194,10 @@ public class GroupResponseDTO {
             String bookImage,
             String bookTitle,
             String author,
+            @Schema(description = "그룹 진행 방식", example = "RELAY")
+            GroupType groupType,
+            @Schema(description = "책 장르 표시명", example = "한국소설")
+            String genre,
             Integer readingPeriod
     ) {}
 
@@ -210,6 +217,9 @@ public class GroupResponseDTO {
             String title,
             String subtitle,
             HomeLayoutType layoutType,
+            @ArraySchema(schema = @Schema(
+                    oneOf = {HomeGroupCardDTO.class, HomeBookThumbnailDTO.class}
+            ))
             List<?> items
     ) {}
 

--- a/src/main/java/com/example/bookiibookii/domain/group/service/GroupService.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/service/GroupService.java
@@ -723,25 +723,30 @@ public class GroupService {
 
         Long userId = user.getId();
         List<GroupResponseDTO.HomeSectionDTO> sections = new ArrayList<>(7);
+        Map<String, String> profileImageUrlCache = new java.util.HashMap<>();
 
-        addIfPresent(sections, buildNewGroupsSection(userId));
+        addIfPresent(sections, buildNewGroupsSection(userId, profileImageUrlCache));
         sections.add(buildPopularBooksSection(userId));
-        addIfPresent(sections, buildGenreSection(userId));
+        addIfPresent(sections, buildGenreSection(userId, profileImageUrlCache));
         sections.add(buildBestsellerBooksSection());
-        addIfPresent(sections, buildClassicGroupsSection(userId));
-        addIfPresent(sections, buildPackageGroupsSection(userId));
-        addIfPresent(sections, buildNearbyDirectGroupsSection(userId));
+        addIfPresent(sections, buildClassicGroupsSection(userId, profileImageUrlCache));
+        addIfPresent(sections, buildPackageGroupsSection(userId, profileImageUrlCache));
+        addIfPresent(sections, buildNearbyDirectGroupsSection(userId, profileImageUrlCache));
 
         return GroupResponseDTO.HomeResponseDTO.builder().sections(sections).build();
     }
 
-    private GroupResponseDTO.HomeSectionDTO buildNewGroupsSection(Long userId) {
+    private GroupResponseDTO.HomeSectionDTO buildNewGroupsSection(
+            Long userId,
+            Map<String, String> profileImageUrlCache
+    ) {
         List<GroupResponseDTO.HomeGroupCardDTO> items = toHomeCards(
                 groupQueryRepository.findRecentGroups(
                         userId,
                         HomeSeedUtil.twentyFourHoursAgoKst(),
                         HOME_GROUP_LIMIT
-                )
+                ),
+                profileImageUrlCache
         );
         return groupSection(
                 HomeSectionType.NEW_GROUPS,
@@ -764,7 +769,10 @@ public class GroupService {
         );
     }
 
-    private GroupResponseDTO.HomeSectionDTO buildGenreSection(Long userId) {
+    private GroupResponseDTO.HomeSectionDTO buildGenreSection(
+            Long userId,
+            Map<String, String> profileImageUrlCache
+    ) {
         List<HomeGenre> candidates = groupQueryRepository
                 .findCategoriesWithRecruitingGroups(userId)
                 .stream()
@@ -786,7 +794,8 @@ public class GroupService {
                         userId,
                         picked.getCategories(),
                         HOME_GROUP_LIMIT
-                )
+                ),
+                profileImageUrlCache
         );
         return groupSection(
                 HomeSectionType.RANDOM_GENRE_GROUPS,
@@ -809,13 +818,17 @@ public class GroupService {
         );
     }
 
-    private GroupResponseDTO.HomeSectionDTO buildClassicGroupsSection(Long userId) {
+    private GroupResponseDTO.HomeSectionDTO buildClassicGroupsSection(
+            Long userId,
+            Map<String, String> profileImageUrlCache
+    ) {
         List<GroupResponseDTO.HomeGroupCardDTO> items = toHomeCards(
                 groupQueryRepository.findClassicGroups(
                         userId,
                         HomeCandidateSectionType.CLASSIC_BOOK_GROUP,
                         HOME_GROUP_LIMIT
-                )
+                ),
+                profileImageUrlCache
         );
         return groupSection(
                 HomeSectionType.CLASSIC_GROUPS,
@@ -825,13 +838,17 @@ public class GroupService {
         );
     }
 
-    private GroupResponseDTO.HomeSectionDTO buildPackageGroupsSection(Long userId) {
+    private GroupResponseDTO.HomeSectionDTO buildPackageGroupsSection(
+            Long userId,
+            Map<String, String> profileImageUrlCache
+    ) {
         List<GroupResponseDTO.HomeGroupCardDTO> items = toHomeCards(
                 groupQueryRepository.findGroupsByTradeType(
                         userId,
                         TradeType.DELIVERY,
                         HOME_GROUP_LIMIT
-                )
+                ),
+                profileImageUrlCache
         );
         return groupSection(
                 HomeSectionType.PACKAGE_GROUPS,
@@ -841,7 +858,10 @@ public class GroupService {
         );
     }
 
-    private GroupResponseDTO.HomeSectionDTO buildNearbyDirectGroupsSection(Long userId) {
+    private GroupResponseDTO.HomeSectionDTO buildNearbyDirectGroupsSection(
+            Long userId,
+            Map<String, String> profileImageUrlCache
+    ) {
         List<UserExchange> exchanges = userExchangeRepository
                 .findByUserIdWithLocation(userId)
                 .stream()
@@ -869,7 +889,8 @@ public class GroupService {
                         picked.getLocation().getX(),
                         picked.getLocation().getY(),
                         HOME_GROUP_LIMIT
-                )
+                ),
+                profileImageUrlCache
         );
         return groupSection(
                 HomeSectionType.NEARBY_DIRECT_GROUPS,
@@ -900,12 +921,15 @@ public class GroupService {
     }
 
     private List<GroupResponseDTO.HomeGroupCardDTO> toHomeCards(
-            List<Groups> groups
+            List<Groups> groups,
+            Map<String, String> profileImageUrlCache
     ) {
         if (groups == null || groups.isEmpty()) {
             return List.of();
         }
-        return groups.stream().map(this::toHomeCard).toList();
+        return groups.stream()
+                .map(group -> toHomeCard(group, profileImageUrlCache))
+                .toList();
     }
 
     private List<GroupResponseDTO.HomeBookThumbnailDTO> toBookThumbnails(
@@ -993,16 +1017,35 @@ public class GroupService {
         }
     }
 
-    private GroupResponseDTO.HomeGroupCardDTO toHomeCard(Groups group) {
+    private GroupResponseDTO.HomeGroupCardDTO toHomeCard(
+            Groups group,
+            Map<String, String> profileImageUrlCache
+    ) {
         return GroupResponseDTO.HomeGroupCardDTO.builder()
                 .groupId(group.getId())
                 .groupName(group.getGroupName())
                 .hostNickname(group.getHost().getNickName())
-                .hostProfileImageUrl(userProfileImageUrl(group.getHost()))
+                .hostProfileImageUrl(userProfileImageUrl(group.getHost(), profileImageUrlCache))
                 .bookImage(group.getBook().getImage())
                 .bookTitle(group.getBook().getTitle())
                 .author(group.getBook().getAuthor())
+                .groupType(group.getGroupType())
+                .genre(group.getBook().getCategory().getLabel())
                 .readingPeriod(group.getReadingPeriod())
                 .build();
+    }
+
+    private String userProfileImageUrl(User user, Map<String, String> profileImageUrlCache) {
+        if (user == null || user.getUserImage() == null || isBlank(user.getUserImage().getS3Key())) {
+            return null;
+        }
+        String s3Key = user.getUserImage().getS3Key();
+        return profileImageUrlCache.computeIfAbsent(
+                s3Key,
+                key -> userImageS3Service.generatePresignedGetUrl(
+                        key,
+                        PRESIGNED_GET_URL_EXPIRATION_MINUTES
+                )
+        );
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,3 +8,7 @@ springdoc:
   swagger-ui:
     doc-expansion: none
     tags-sorter: none
+
+scheduler:
+  bestseller:
+    cron: "0 0 0 * * *"


### PR DESCRIPTION
## 개요
<!---- 자신이 완료한 이슈를 닫아주세요 -->
- closed #546 
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
홈 GROUP_CARD_CAROUSEL 응답에 프론트 표시용 groupType, genre를 추가했습니다.

또한 hostProfileImageUrl은 기존처럼 DB에 저장된 s3Key를 기반으로 응답 조립 시 presigned URL을 생성하되,
홈 카드 목록에서 동일한 프로필 이미지가 반복될 수 있어 요청 단위 Map 캐시를 추가했습니다.
전역 캐시가 아니며, S3 정책이나 다른 도메인의 이미지 응답 방식은 변경하지 않았습니다.

베스트셀러 스케줄러는 기존 매주 월요일 00시 실행에서 매일 00시 실행으로 변경했습니다.
API 실패, 빈 응답, 유효 데이터 없음 상황에서는 기존 데이터를 삭제하지 않도록 보호 로직을 추가했고,
local/dev 프로필에서만 수동 갱신 API를 사용할 수 있도록 했습니다.

<!---- Resolves: #(Isuue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

📣 **To Reviewers**
---
<!-- 전달사항 -->

- Reviewers : 팀 선택
- Labels : 작업 유형, 자기 자신


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **성능 개선**
  * 프로필 이미지 URL 캐싱으로 반복 요청 최적화

* **API 문서화**
  * OpenAPI 스키마 메타데이터 보강으로 API 명세 명확화

* **관리 기능**
  * 베스트셀러 정보 새로고침 엔드포인트 추가
  * 스케줄러 실행 시간을 설정으로 유연하게 관리 가능

<!-- end of auto-generated comment: release notes by coderabbit.ai -->