### PR TITLE
[Fix]#538 알라딘 카테고리 매핑 수정

### DIFF
--- a/src/main/java/com/example/bookiibookii/domain/aladin/scheduler/BestsellerScheduler.java
+++ b/src/main/java/com/example/bookiibookii/domain/aladin/scheduler/BestsellerScheduler.java
@@ -3,6 +3,7 @@ package com.example.bookiibookii.domain.aladin.scheduler;
 import com.example.bookiibookii.domain.aladin.config.AladinClient;
 import com.example.bookiibookii.domain.aladin.entity.BestsellerIsbn;
 import com.example.bookiibookii.domain.aladin.repository.BestsellerIsbnRepository;
+import com.example.bookiibookii.domain.book.service.BookCategoryMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -23,6 +24,7 @@ public class BestsellerScheduler {
 
     private final AladinClient aladinClient;
     private final BestsellerIsbnRepository bestsellerIsbnRepository;
+    private final BookCategoryMapper bookCategoryMapper;
 
     // 매일 00:00 KST 실행. 환경별로 scheduler.bestseller.cron 설정으로 변경할 수 있다.
     @Scheduled(cron = "${scheduler.bestseller.cron:0 0 0 * * *}", zone = "Asia/Seoul")
@@ -53,6 +55,22 @@ public class BestsellerScheduler {
             }
             String isbn13 = normalizeIsbn13(item.isbn13());
             if (isbn13 == null) {
+                continue;
+            }
+
+            if (bookCategoryMapper.mapCategory(
+                    item.categoryId(),
+                    item.categoryName(),
+                    isbn13,
+                    item.title()
+            ).isEmpty()) {
+                log.debug(
+                        "[Scheduler] 차단 카테고리 베스트셀러 제외 categoryId={}, categoryName={}, isbn={}, title={}",
+                        item.categoryId(),
+                        item.categoryName(),
+                        isbn13,
+                        item.title()
+                );
                 continue;
             }
 

--- a/src/main/java/com/example/bookiibookii/domain/aladin/service/AladinService.java
+++ b/src/main/java/com/example/bookiibookii/domain/aladin/service/AladinService.java
@@ -29,7 +29,12 @@ public class AladinService {
         List<BookResDTO> books = raw.item() == null ? List.of()
                 : raw.item().stream()
                 .flatMap(item -> {
-                    Optional<CustomCategory> cc = bookCategoryMapper.mapCategory(item.categoryId());
+                    Optional<CustomCategory> cc = bookCategoryMapper.mapCategory(
+                            item.categoryId(),
+                            item.categoryName(),
+                            item.isbn13(),
+                            item.title()
+                    );
                     if (cc.isEmpty()) return Stream.empty(); // 차단 카테고리일 시 제거
 
                     return Stream.of(

--- a/src/main/java/com/example/bookiibookii/domain/book/service/BookCategoryMapper.java
+++ b/src/main/java/com/example/bookiibookii/domain/book/service/BookCategoryMapper.java
@@ -2,13 +2,16 @@ package com.example.bookiibookii.domain.book.service;
 
 import com.example.bookiibookii.domain.book.enums.CustomCategory;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class BookCategoryMapper {
@@ -39,16 +42,49 @@ public class BookCategoryMapper {
             50951L  // 문학 잡지
     );
 
+    private static final Set<String> BLOCKED_CATEGORY_NAMES = Set.of(
+            "수험서/자격증",
+            "대학교재/전문서적",
+            "초등학교참고서",
+            "중학교참고서",
+            "고등학교참고서",
+            "어린이",
+            "유아",
+            "전집/중고전집",
+            "잡지"
+    );
+
     private static final Map<Long, CustomCategory> CID_CATEGORY_MAP = Map.<Long, CustomCategory>ofEntries(
             // 문학
+            Map.entry(1L, CustomCategory.LITERATURE_ETC),         // 소설/시/희곡
             Map.entry(50917L, CustomCategory.KOREAN_NOVEL),      // 한국소설
+            Map.entry(89482L, CustomCategory.KOREAN_NOVEL),      // 한국 과학소설
+            Map.entry(51065L, CustomCategory.KOREAN_NOVEL),      // 한국 추리/미스터리소설
             Map.entry(50925L, CustomCategory.WORLD_NOVEL),       // 세계의 소설
+            Map.entry(50919L, CustomCategory.WORLD_NOVEL),       // 영미소설
+            Map.entry(50922L, CustomCategory.WORLD_NOVEL),       // 독일소설
+            Map.entry(52650L, CustomCategory.WORLD_NOVEL),       // 러시아소설
+            Map.entry(50918L, CustomCategory.WORLD_NOVEL),       // 일본소설
+            Map.entry(50923L, CustomCategory.WORLD_NOVEL),       // 중국소설
+            Map.entry(50921L, CustomCategory.WORLD_NOVEL),       // 프랑스소설
+            Map.entry(50920L, CustomCategory.WORLD_NOVEL),       // 스페인/중남미소설
+            Map.entry(89481L, CustomCategory.WORLD_NOVEL),       // 외국 과학소설
+            Map.entry(51067L, CustomCategory.WORLD_NOVEL),       // 기타국가 추리/미스터리소설
+            Map.entry(51062L, CustomCategory.WORLD_NOVEL),       // 영미 추리/미스터리소설
+            Map.entry(51058L, CustomCategory.WORLD_NOVEL),       // 일본 추리/미스터리소설
             Map.entry(112011L, CustomCategory.GENRE_NOVEL),      // 장르소설
             Map.entry(50935L, CustomCategory.ROMANCE),           // 로맨스소설
             Map.entry(50929L, CustomCategory.HISTORICAL_NOVEL),  // 역사소설
             Map.entry(50940L, CustomCategory.POETRY_ESSAY),      // 시
             Map.entry(55889L, CustomCategory.POETRY_ESSAY),      // 에세이
             Map.entry(50948L, CustomCategory.PLAY_LITERATURE),   // 희곡
+            Map.entry(2105L, CustomCategory.LITERATURE_ETC),     // 고전
+            Map.entry(90842L, CustomCategory.LITERATURE_ETC),    // 외국도서 소설/시/희곡
+            Map.entry(90845L, CustomCategory.POETRY_ESSAY),      // 외국도서 에세이
+            Map.entry(38396L, CustomCategory.LITERATURE_ETC),    // 전자책 소설/시/희곡
+            Map.entry(38414L, CustomCategory.LITERATURE_ETC),    // 전자책 고전
+            Map.entry(56387L, CustomCategory.POETRY_ESSAY),      // 전자책 에세이
+            Map.entry(112013L, CustomCategory.GENRE_NOVEL),      // 전자책 장르소설
 
             // 비문학
             Map.entry(170L, CustomCategory.ECONOMY_BUSINESS),    // 경제경영
@@ -72,19 +108,91 @@ public class BookCategoryMapper {
             Map.entry(51046L, CustomCategory.POLITICS_SOCIETY)   // 법과 생활
     );
 
-    public Optional<CustomCategory> mapCategory(Long aladinCategoryId) {
+    public Optional<CustomCategory> mapCategory(
+            Long aladinCategoryId,
+            String categoryName,
+            String isbn13,
+            String title
+    ) {
+        if (isBlockedCategoryName(categoryName) || isBlockedCategoryId(aladinCategoryId)) {
+            return Optional.empty();
+        }
+
+        Optional<CustomCategory> nameMapped = mapByCategoryName(categoryName);
+        if (nameMapped.isPresent()) {
+            return nameMapped;
+        }
+
+        Optional<CustomCategory> cidMapped = mapByCategoryId(aladinCategoryId);
+        if (cidMapped.isPresent()) {
+            return cidMapped;
+        }
+
+        log.debug(
+                "알라딘 카테고리 매핑 실패로 기타 분류 categoryId={}, categoryName={}, isbn={}, title={}",
+                aladinCategoryId,
+                categoryName,
+                isbn13,
+                title
+        );
+        return Optional.of(CustomCategory.NON_LITERATURE_ETC);
+    }
+
+    private Optional<CustomCategory> mapByCategoryName(String categoryName) {
+        if (categoryName == null || categoryName.isBlank()) {
+            return Optional.empty();
+        }
+
+        String[] path = Arrays.stream(categoryName.split(">"))
+                .map(String::trim)
+                .filter(segment -> !segment.isEmpty())
+                .toArray(String[]::new);
+
+        if (contains(path, "한국소설")) {
+            return Optional.of(CustomCategory.KOREAN_NOVEL);
+        }
+        if (containsAny(path, "세계의 소설", "세계소설", "외국소설")) {
+            return Optional.of(CustomCategory.WORLD_NOVEL);
+        }
+        if (contains(path, "장르소설")) {
+            return Optional.of(CustomCategory.GENRE_NOVEL);
+        }
+        if (contains(path, "로맨스")) {
+            return Optional.of(CustomCategory.ROMANCE);
+        }
+        if (contains(path, "역사소설")) {
+            return Optional.of(CustomCategory.HISTORICAL_NOVEL);
+        }
+        if (isKoreanNovelPath(path)) {
+            return Optional.of(CustomCategory.KOREAN_NOVEL);
+        }
+        if (isWorldNovelPath(path)) {
+            return Optional.of(CustomCategory.WORLD_NOVEL);
+        }
+        if (containsOutsideLiteratureRoot(path, "희곡")) {
+            return Optional.of(CustomCategory.PLAY_LITERATURE);
+        }
+        if (contains(path, "에세이") || hasExactSegment(path, "시")) {
+            return Optional.of(CustomCategory.POETRY_ESSAY);
+        }
+        if (containsAny(path, "소설", "문학")
+                || hasExactSegment(path, "고전")
+                || contains(path, "고전문학")) {
+            return Optional.of(CustomCategory.LITERATURE_ETC);
+        }
+
+        return Optional.empty();
+    }
+
+    private Optional<CustomCategory> mapByCategoryId(Long aladinCategoryId) {
         if (aladinCategoryId == null) {
-            return Optional.of(CustomCategory.NON_LITERATURE_ETC);
+            return Optional.empty();
         }
 
         Long currentCid = aladinCategoryId;
         Set<Long> visited = new HashSet<>();
 
         while (currentCid != null && visited.add(currentCid)) {
-            if (BLOCK_ROOT_CIDS.contains(currentCid)) {
-                return Optional.empty();
-            }
-
             CustomCategory mapped = CID_CATEGORY_MAP.get(currentCid);
             if (mapped != null) {
                 return Optional.of(mapped);
@@ -93,6 +201,80 @@ public class BookCategoryMapper {
             currentCid = aladinCategoryTree.getParentCid(currentCid).orElse(null);
         }
 
-        return Optional.of(CustomCategory.NON_LITERATURE_ETC);
+        return Optional.empty();
+    }
+
+    private boolean isBlockedCategoryId(Long aladinCategoryId) {
+        if (aladinCategoryId == null) {
+            return false;
+        }
+
+        Long currentCid = aladinCategoryId;
+        Set<Long> visited = new HashSet<>();
+        while (currentCid != null && visited.add(currentCid)) {
+            if (BLOCK_ROOT_CIDS.contains(currentCid)) {
+                return true;
+            }
+            currentCid = aladinCategoryTree.getParentCid(currentCid).orElse(null);
+        }
+        return false;
+    }
+
+    private boolean isBlockedCategoryName(String categoryName) {
+        if (categoryName == null || categoryName.isBlank()) {
+            return false;
+        }
+        return Arrays.stream(categoryName.split(">"))
+                .map(String::trim)
+                .anyMatch(segment -> BLOCKED_CATEGORY_NAMES.stream().anyMatch(segment::contains));
+    }
+
+    private boolean contains(String[] path, String keyword) {
+        return Arrays.stream(path).anyMatch(segment -> segment.contains(keyword));
+    }
+
+    private boolean containsAny(String[] path, String... keywords) {
+        return Arrays.stream(keywords).anyMatch(keyword -> contains(path, keyword));
+    }
+
+    private boolean hasExactSegment(String[] path, String expected) {
+        return Arrays.stream(path).anyMatch(expected::equals);
+    }
+
+    private boolean containsOutsideLiteratureRoot(String[] path, String keyword) {
+        return Arrays.stream(path)
+                .filter(segment -> !"소설/시/희곡".equals(segment))
+                .anyMatch(segment -> segment.contains(keyword));
+    }
+
+    private boolean isKoreanNovelPath(String[] path) {
+        return Arrays.stream(path)
+                .anyMatch(segment -> segment.contains("한국") && segment.contains("소설"));
+    }
+
+    private boolean isWorldNovelPath(String[] path) {
+        return Arrays.stream(path)
+                .anyMatch(segment ->
+                        segment.contains("소설")
+                                && containsAnyKeyword(
+                                segment,
+                                "세계",
+                                "외국",
+                                "기타국가",
+                                "기타 국가",
+                                "영미",
+                                "독일",
+                                "러시아",
+                                "일본",
+                                "중국",
+                                "프랑스",
+                                "스페인",
+                                "중남미"
+                        )
+                );
+    }
+
+    private boolean containsAnyKeyword(String value, String... keywords) {
+        return Arrays.stream(keywords).anyMatch(value::contains);
     }
 }

--- a/src/main/java/com/example/bookiibookii/domain/book/service/BookCategoryMapper.java
+++ b/src/main/java/com/example/bookiibookii/domain/book/service/BookCategoryMapper.java
@@ -154,14 +154,14 @@ public class BookCategoryMapper {
         if (containsAny(path, "세계의 소설", "세계소설", "외국소설")) {
             return Optional.of(CustomCategory.WORLD_NOVEL);
         }
-        if (contains(path, "장르소설")) {
-            return Optional.of(CustomCategory.GENRE_NOVEL);
-        }
         if (contains(path, "로맨스")) {
             return Optional.of(CustomCategory.ROMANCE);
         }
         if (contains(path, "역사소설")) {
             return Optional.of(CustomCategory.HISTORICAL_NOVEL);
+        }
+        if (contains(path, "장르소설")) {
+            return Optional.of(CustomCategory.GENRE_NOVEL);
         }
         if (isKoreanNovelPath(path)) {
             return Optional.of(CustomCategory.KOREAN_NOVEL);

--- a/src/main/java/com/example/bookiibookii/domain/book/service/BookService.java
+++ b/src/main/java/com/example/bookiibookii/domain/book/service/BookService.java
@@ -30,7 +30,12 @@ public class BookService {
                 .orElseGet(() -> { // 없을 시
                     // 1) 알라딘에서 단건 조회
                     AladinClient.AladinBookItem item = aladinClient.lookupBookByIsbn13(isbn13);
-                    Optional<CustomCategory> cc = bookCategoryMapper.mapCategory(item.categoryId());
+                    Optional<CustomCategory> cc = bookCategoryMapper.mapCategory(
+                            item.categoryId(),
+                            item.categoryName(),
+                            item.isbn13(),
+                            item.title()
+                    );
                     if (cc.isEmpty()) {
                         throw new BookException(BookErrorCode.BLOCKED_CATEGORY);
                     }


### PR DESCRIPTION
## 개요
<!---- 자신이 완료한 이슈를 닫아주세요 -->
- closed #538 
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 기존 CID 기반 매핑에 categoryName 경로 기반 매핑을 추가/보완했습니다.
- 문학 최상위/하위 CID가 NON_LITERATURE_ETC 또는 LITERATURE_ETC로 과도하게 fallback되던 문제를 수정했습니다.
- 기존 CustomCategory enum 기준으로 매핑 가능한 문학/비문학 경로만 보강했습니다.
- 차단 카테고리 판정이 알라딘 검색, 그룹 생성, 베스트셀러 저장 경로에 공통 적용되도록 정리했습니다.

<!---- Resolves: #(Isuue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

📣 **To Reviewers**
---
<!-- 전달사항 -->
기존 book.category 오분류 데이터는 자동 보정되지 않습니다.
2차 QA 전 DB 초기화 및 데이터 재적재 예정이므로, 별도 보정 작업은 이번 PR 범위에서 제외했습니다.

- Reviewers : 팀 선택
- Labels : 작업 유형, 자기 자신


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **기능 개선**
  * 도서 카테고리 분류 알고리즘을 개선하여 카테고리명과 ID를 종합적으로 고려한 정확한 분류를 지원합니다.
  * 유효하지 않거나 차단된 카테고리 정보를 가진 도서를 자동으로 필터링하여 데이터 품질을 개선합니다.
  * 베스트셀러 갱신 시 분류 규칙을 강화하여 신뢰성 있는 도서 정보를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->