### PR TITLE
[Feat]#551 그룹 관련 및 키워드 알림 구현

### DIFF
--- a/src/main/java/com/example/bookiibookii/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/example/bookiibookii/domain/comment/controller/CommentController.java
@@ -36,7 +36,7 @@ public class CommentController implements CommentControllerDocs{
             @PathVariable Long groupId,
             @AuthenticationPrincipal(expression = "user") User user
     ) {
-        List<CommentTreeResDTO> result = commentService.getTree(groupId, user.getId());
+        List<CommentTreeResDTO> result = commentService.getTree(groupId, user);
         return ApiResponse.onSuccess(CommentSuccessCode.COMMENT_FOUND_OK, result);
     }
 

--- a/src/main/java/com/example/bookiibookii/domain/comment/enums/CommentContext.java
+++ b/src/main/java/com/example/bookiibookii/domain/comment/enums/CommentContext.java
@@ -1,0 +1,6 @@
+package com.example.bookiibookii.domain.comment.enums;
+
+public enum CommentContext {
+    GROUP_DETAIL,
+    TRACKER
+}

--- a/src/main/java/com/example/bookiibookii/domain/comment/event/CommentEvent.java
+++ b/src/main/java/com/example/bookiibookii/domain/comment/event/CommentEvent.java
@@ -1,13 +1,15 @@
 package com.example.bookiibookii.domain.comment.event;
 
+import com.example.bookiibookii.domain.notification.enums.NotificationType;
+
+import java.util.List;
+
 public record CommentEvent(
-        // 알림 내용
+        NotificationType notificationType,
         String commenterNickname,
-        String bookTitle,
-
-        // 수신자
-        Long hostId,
-
-        // redirect
-        Long groupId
+        String groupTitle,
+        List<Long> receiverIds,
+        Long groupId,
+        Long commentId,
+        Long parentCommentId
 ) {}

--- a/src/main/java/com/example/bookiibookii/domain/comment/service/CommentAccessPolicy.java
+++ b/src/main/java/com/example/bookiibookii/domain/comment/service/CommentAccessPolicy.java
@@ -1,0 +1,51 @@
+package com.example.bookiibookii.domain.comment.service;
+
+import com.example.bookiibookii.domain.comment.enums.CommentContext;
+import com.example.bookiibookii.domain.comment.exception.CommentException;
+import com.example.bookiibookii.domain.comment.exception.code.CommentErrorCode;
+import com.example.bookiibookii.domain.group.entity.Groups;
+import com.example.bookiibookii.domain.group.enums.MemberStatus;
+import com.example.bookiibookii.domain.group.exception.GroupException;
+import com.example.bookiibookii.domain.group.exception.code.GroupErrorCode;
+import com.example.bookiibookii.domain.group.repository.MatchedMemberRepository;
+import com.example.bookiibookii.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CommentAccessPolicy {
+
+    private final MatchedMemberRepository matchedMemberRepository;
+
+    public CommentContext resolveContext(Groups group) {
+        return switch (group.getGroupStatus()) {
+            case RECRUITING -> CommentContext.GROUP_DETAIL;
+            case MATCHED, COMPLETED -> CommentContext.TRACKER;
+            case DELETED -> throw new GroupException(GroupErrorCode.GROUP_NOT_FOUND);
+        };
+    }
+
+    public void validateGroupDetailAccess(User user) {
+        if (user == null) {
+            throw new CommentException(CommentErrorCode.NO_PERMISSION);
+        }
+    }
+
+    public void validateTrackerAccess(Long groupId, User user) {
+        if (user == null || !matchedMemberRepository.existsByGroup_IdAndUser_IdAndStatus(
+                groupId,
+                user.getId(),
+                MemberStatus.JOINED
+        )) {
+            throw new CommentException(CommentErrorCode.NO_PERMISSION);
+        }
+    }
+
+    public void validateAccess(CommentContext context, Long groupId, User user) {
+        switch (context) {
+            case GROUP_DETAIL -> validateGroupDetailAccess(user);
+            case TRACKER -> validateTrackerAccess(groupId, user);
+        }
+    }
+}

--- a/src/main/java/com/example/bookiibookii/domain/comment/service/CommentNotificationService.java
+++ b/src/main/java/com/example/bookiibookii/domain/comment/service/CommentNotificationService.java
@@ -21,20 +21,38 @@ public class CommentNotificationService {
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void send(CommentEvent event) {
-        Long receiverId = event.hostId();
-        String title = "새로운 댓글이 달렸어요";
-        String message = String.format("%s님이 %s 그룹에 댓글을 남겼어요. 확인해볼까요?",
-                event.commenterNickname(), event.bookTitle());
+        if (event.receiverIds() == null || event.receiverIds().isEmpty()) return;
+
+        boolean reply = event.notificationType() == NotificationType.GROUP_COMMENT_REPLIED;
+        String title = reply ? "내 댓글에 답글이 달렸어요" : "새로운 댓글이 달렸어요";
+        String message = reply
+                ? String.format("%s님이 회원님의 댓글에 답글을 남겼어요.", event.commenterNickname())
+                : String.format("%s님이 %s 그룹에 새 댓글을 남겼어요.",
+                        event.commenterNickname(), event.groupTitle());
         String payload = notificationFactory.toJson(
                 NotificationPayload.builder()
                         .redirectType(RedirectType.GROUP_DETAIL)
                         .groupId(event.groupId())
+                        .commentId(event.commentId())
+                        .parentCommentId(event.parentCommentId())
                         .build()
         );
 
-        notificationStore.save(
-                notificationFactory.create(receiverId, NotificationCategory.SYSTEM, NotificationType.GROUP_COMMENT_CREATED,
-                        title, message, payload)
-        );
+        for (Long receiverId : event.receiverIds()) {
+            if (receiverId == null) continue;
+            String notiId = reply ? "NOTI-GRP-005" : "NOTI-GRP-004";
+            String dedupKey = String.format("%s:%d:%d", notiId, event.commentId(), receiverId);
+            notificationStore.save(
+                    notificationFactory.create(
+                            receiverId,
+                            NotificationCategory.SYSTEM,
+                            event.notificationType(),
+                            title,
+                            message,
+                            payload,
+                            dedupKey
+                    )
+            );
+        }
     }
 }

--- a/src/main/java/com/example/bookiibookii/domain/comment/service/CommentService.java
+++ b/src/main/java/com/example/bookiibookii/domain/comment/service/CommentService.java
@@ -5,19 +5,17 @@ import com.example.bookiibookii.domain.comment.dto.res.CommentCreateResDTO;
 import com.example.bookiibookii.domain.comment.dto.res.CommentTreeResDTO;
 import com.example.bookiibookii.domain.comment.dto.req.CommentCreateReqDTO;
 import com.example.bookiibookii.domain.comment.entity.Comment;
+import com.example.bookiibookii.domain.comment.enums.CommentContext;
 import com.example.bookiibookii.domain.comment.enums.WriterRole;
-import com.example.bookiibookii.domain.comment.event.CommentEvent;
 import com.example.bookiibookii.domain.comment.exception.code.CommentErrorCode;
 import com.example.bookiibookii.domain.comment.exception.CommentException;
 import com.example.bookiibookii.domain.comment.repository.CommentRepository;
 import com.example.bookiibookii.domain.group.entity.Groups;
-import com.example.bookiibookii.domain.group.enums.GroupStatus;
 import com.example.bookiibookii.domain.group.enums.RoleStatus;
 import com.example.bookiibookii.domain.group.exception.GroupException;
 import com.example.bookiibookii.domain.group.exception.code.GroupErrorCode;
 import com.example.bookiibookii.domain.group.repository.GroupsRepository;
 import com.example.bookiibookii.domain.group.repository.MatchedMemberRepository;
-import com.example.bookiibookii.domain.notification.publisher.DomainEventPublisher;
 import com.example.bookiibookii.domain.user.entity.User;
 import com.example.bookiibookii.domain.user.service.UserImageS3Service;
 import lombok.RequiredArgsConstructor;
@@ -37,7 +35,7 @@ public class CommentService {
     private final CommentRepository commentRepository;
     private final GroupsRepository groupRepository;
     private final MatchedMemberRepository matchedMemberRepository;
-    private final DomainEventPublisher eventPublisher;
+    private final CommentAccessPolicy commentAccessPolicy;
     private final UserImageS3Service userImageS3Service;
 
     private static final int PRESIGNED_GET_URL_EXPIRATION_MINUTES = 60;
@@ -46,23 +44,48 @@ public class CommentService {
     public CommentCreateResDTO create(Long groupId, User user, CommentCreateReqDTO req) {
         Groups group = groupRepository.findByIdWithBookAndHost(groupId)
                 .orElseThrow(() -> new GroupException(GroupErrorCode.GROUP_NOT_FOUND));
+        CommentContext context = commentAccessPolicy.resolveContext(group);
+        commentAccessPolicy.validateAccess(context, groupId, user);
 
-        // 댓글 작성자의 그룹 내 역할
         WriterRole writerRole = matchedMemberRepository.findRoleByGroupIdAndUserId(groupId, user.getId())
                 .map(r -> r == RoleStatus.HOST ? WriterRole.HOST : WriterRole.GUEST)
                 .orElse(WriterRole.NONE);
 
-        // 진행 중 그룹에 그룹 멤버가 아닌 유저가 댓글 달 시 에러처리
-        if (group.getGroupStatus() != GroupStatus.RECRUITING && writerRole == WriterRole.NONE) {
-            throw new CommentException(CommentErrorCode.COMMENT_WRITE_FORBIDDEN);
-        }
+        return switch (context) {
+            case GROUP_DETAIL -> createGroupDetailComment(group, user, req, writerRole);
+            case TRACKER -> createTrackerComment(group, user, req, writerRole);
+        };
+    }
 
+    private CommentCreateResDTO createGroupDetailComment(
+            Groups group,
+            User user,
+            CommentCreateReqDTO req,
+            WriterRole writerRole
+    ) {
+        Comment saved = saveComment(group, user, req);
+        // NOTI-GRP-004/005 trigger point: group-detail comment/reply created.
+        return toCreateResDTO(saved, writerRole);
+    }
+
+    private CommentCreateResDTO createTrackerComment(
+            Groups group,
+            User user,
+            CommentCreateReqDTO req,
+            WriterRole writerRole
+    ) {
+        Comment saved = saveComment(group, user, req);
+        // NOTI-TRK-003 trigger point: tracker comment/reply created.
+        return toCreateResDTO(saved, writerRole);
+    }
+
+    private Comment saveComment(Groups group, User user, CommentCreateReqDTO req) {
         Comment parent = null;
         if (req.getParentId() != null) {
             parent = commentRepository.findById(req.getParentId())
                     .orElseThrow(() -> new CommentException(CommentErrorCode.PARENT_COMMENT_NOT_FOUND));
 
-            if (!parent.getGroup().getId().equals(groupId)) {
+            if (!parent.getGroup().getId().equals(group.getId())) {
                 throw new CommentException(CommentErrorCode.PARENT_COMMENT_GROUP_MISMATCH);
             }
 
@@ -89,19 +112,16 @@ public class CommentService {
                 .secret(isSecret)
                 .secretTargetUserId(secretTargetUserId)
                 .build();
-        Comment saved = commentRepository.save(comment);
-
-        Long notifyUserId = isSecret ? secretTargetUserId : group.getHost().getId();
-        if (!user.getId().equals(notifyUserId)) {
-            eventPublisher.publish(new CommentEvent(user.getNickName(), group.getBook().getTitle(), notifyUserId, group.getId()));
-        }
-        return toCreateResDTO(saved, writerRole);
+        return commentRepository.save(comment);
     }
 
-    // 그룹 페이지 내 모든 댓글 조회(대댓글 포함)
     @Transactional(readOnly = true)
-    public List<CommentTreeResDTO> getTree(Long groupId, Long viewerId) {
-        List<Comment> comments = commentRepository.findVisibleTree(groupId, viewerId);
+    public List<CommentTreeResDTO> getTree(Long groupId, User viewer) {
+        Groups group = getGroup(groupId);
+        CommentContext context = commentAccessPolicy.resolveContext(group);
+        commentAccessPolicy.validateAccess(context, groupId, viewer);
+
+        List<Comment> comments = commentRepository.findVisibleTree(groupId, viewer.getId());
 
         // 그룹 멤버 역할 전체 로드 (user_id, mm.RoleStatus 가져옴)
         Map<Long, WriterRole> writerRoleMap = matchedMemberRepository.findWriterRowsByGroupId(groupId)
@@ -136,8 +156,11 @@ public class CommentService {
 
     @Transactional
     public void delete(Long groupId, Long commentId, User user) {
-        Comment comment = commentRepository.findByIdAndGroupIdWithUser(commentId, groupId)
-                .orElseThrow(() -> new CommentException(CommentErrorCode.COMMENT_NOT_FOUND));
+        Groups group = getGroup(groupId);
+        CommentContext context = commentAccessPolicy.resolveContext(group);
+        commentAccessPolicy.validateAccess(context, groupId, user);
+
+        Comment comment = getComment(groupId, commentId);
 
         if (!comment.getUser().getId().equals(user.getId())) {
             throw new CommentException(CommentErrorCode.COMMENT_DELETE_FORBIDDEN);
@@ -146,6 +169,16 @@ public class CommentService {
         if (comment.isDeleted()) return;
 
         comment.markDeleted();
+    }
+
+    private Groups getGroup(Long groupId) {
+        return groupRepository.findByIdWithBookAndHost(groupId)
+                .orElseThrow(() -> new GroupException(GroupErrorCode.GROUP_NOT_FOUND));
+    }
+
+    private Comment getComment(Long groupId, Long commentId) {
+        return commentRepository.findByIdAndGroupIdWithUser(commentId, groupId)
+                .orElseThrow(() -> new CommentException(CommentErrorCode.COMMENT_NOT_FOUND));
     }
 
     private static WriterRole toWriterRole(RoleStatus roleStatus) {

--- a/src/main/java/com/example/bookiibookii/domain/comment/service/CommentService.java
+++ b/src/main/java/com/example/bookiibookii/domain/comment/service/CommentService.java
@@ -7,6 +7,7 @@ import com.example.bookiibookii.domain.comment.dto.req.CommentCreateReqDTO;
 import com.example.bookiibookii.domain.comment.entity.Comment;
 import com.example.bookiibookii.domain.comment.enums.CommentContext;
 import com.example.bookiibookii.domain.comment.enums.WriterRole;
+import com.example.bookiibookii.domain.comment.event.CommentEvent;
 import com.example.bookiibookii.domain.comment.exception.code.CommentErrorCode;
 import com.example.bookiibookii.domain.comment.exception.CommentException;
 import com.example.bookiibookii.domain.comment.repository.CommentRepository;
@@ -16,6 +17,8 @@ import com.example.bookiibookii.domain.group.exception.GroupException;
 import com.example.bookiibookii.domain.group.exception.code.GroupErrorCode;
 import com.example.bookiibookii.domain.group.repository.GroupsRepository;
 import com.example.bookiibookii.domain.group.repository.MatchedMemberRepository;
+import com.example.bookiibookii.domain.notification.enums.NotificationType;
+import com.example.bookiibookii.domain.notification.publisher.DomainEventPublisher;
 import com.example.bookiibookii.domain.user.entity.User;
 import com.example.bookiibookii.domain.user.service.UserImageS3Service;
 import lombok.RequiredArgsConstructor;
@@ -36,6 +39,7 @@ public class CommentService {
     private final GroupsRepository groupRepository;
     private final MatchedMemberRepository matchedMemberRepository;
     private final CommentAccessPolicy commentAccessPolicy;
+    private final DomainEventPublisher eventPublisher;
     private final UserImageS3Service userImageS3Service;
 
     private static final int PRESIGNED_GET_URL_EXPIRATION_MINUTES = 60;
@@ -64,7 +68,7 @@ public class CommentService {
             WriterRole writerRole
     ) {
         Comment saved = saveComment(group, user, req);
-        // NOTI-GRP-004/005 trigger point: group-detail comment/reply created.
+        publishGroupDetailCommentNotification(group, user, saved);
         return toCreateResDTO(saved, writerRole);
     }
 
@@ -75,8 +79,47 @@ public class CommentService {
             WriterRole writerRole
     ) {
         Comment saved = saveComment(group, user, req);
-        // NOTI-TRK-003 trigger point: tracker comment/reply created.
+        // NOTI-TRK-003 is intentionally implemented in a later PR.
         return toCreateResDTO(saved, writerRole);
+    }
+
+    private void publishGroupDetailCommentNotification(Groups group, User writer, Comment comment) {
+        Comment parent = comment.getParent();
+        if (parent != null) {
+            Long parentWriterId = parent.getUser().getId();
+            if (!parentWriterId.equals(writer.getId())) {
+                eventPublisher.publish(new CommentEvent(
+                        NotificationType.GROUP_COMMENT_REPLIED,
+                        writer.getNickName(),
+                        groupTitle(group),
+                        List.of(parentWriterId),
+                        group.getId(),
+                        comment.getId(),
+                        parent.getId()
+                ));
+            }
+            return;
+        }
+
+        Long hostId = group.getHost().getId();
+        if (hostId.equals(writer.getId())) return;
+
+        eventPublisher.publish(new CommentEvent(
+                NotificationType.GROUP_COMMENT_CREATED,
+                writer.getNickName(),
+                groupTitle(group),
+                List.of(hostId),
+                group.getId(),
+                comment.getId(),
+                null
+        ));
+    }
+
+    private String groupTitle(Groups group) {
+        if (group.getGroupName() != null && !group.getGroupName().isBlank()) {
+            return group.getGroupName();
+        }
+        return group.getBook().getTitle();
     }
 
     private Comment saveComment(Groups group, User user, CommentCreateReqDTO req) {

--- a/src/main/java/com/example/bookiibookii/domain/group/enums/GroupNotiType.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/enums/GroupNotiType.java
@@ -11,16 +11,16 @@ public enum GroupNotiType {
 
     JOIN_REQUESTED(
             NotificationType.GROUP_JOIN_REQUEST,
-            "똑똑! 새로운 참여 요청이 왔어요",
-            "{nickname}님이 {bookTitle} 그룹에 함께하고 싶어 해요. 프로필을 확인해볼까요?",
+            "새로운 참여 요청이 왔어요",
+            "{nickname}님이 {groupTitle} 그룹에 참여를 신청했어요.",
             RedirectType.APPLICATION_MANAGEMENT
     ),
 
     MATCH_SUCCEEDED(
-            NotificationType.GROUP_MATCH_SUCCESS,
-            "그룹 매칭이 성공했어요!",
-            "[{nickname}] {bookTitle} 그룹의 게스트로 참여합니다! 호스트가 책을 읽기 시작하면 알려드릴게요.",
-            RedirectType.TRACKER_HOME
+            NotificationType.GROUP_REQUEST_ACCEPTED,
+            "참여 신청이 수락됐어요!",
+            "{nickname}님의 {groupTitle} 그룹 참여가 확정됐어요. 지금 바로 확인해보세요.",
+            RedirectType.TRACKER_DETAIL
     ),
 
     MATCH_EXPIRED(
@@ -31,9 +31,9 @@ public enum GroupNotiType {
     ),
 
     MATCH_REJECTED(
-            NotificationType.GROUP_MATCH_REJECTED,
-            "그룹 매칭에 실패했어요",
-            "[{nickname}] {bookTitle} 그룹의 정원이 마감되었어요. 다른 그룹을 찾아볼까요?",
+            NotificationType.GROUP_REQUEST_REJECTED,
+            "참여 신청이 거절됐어요",
+            "{nickname}님의 {groupTitle} 그룹 참여 신청이 거절됐어요. 다른 그룹을 찾아볼까요?",
             RedirectType.EXPLORE_HOME
     ),
 

--- a/src/main/java/com/example/bookiibookii/domain/group/event/GroupNotificationEvent.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/event/GroupNotificationEvent.java
@@ -1,6 +1,7 @@
 package com.example.bookiibookii.domain.group.event;
 
 import com.example.bookiibookii.domain.group.enums.GroupNotiType;
+import com.example.bookiibookii.domain.notification.enums.ExchangeType;
 
 import java.util.List;
 
@@ -10,7 +11,7 @@ public record GroupNotificationEvent(
         // 발신자
         Long actorId,
 
-        String bookTitle,
+        String groupTitle,
 
         // 특정 수신자
         Long receiverId,
@@ -18,5 +19,7 @@ public record GroupNotificationEvent(
         List<Long> receiverIds,
 
         // redirect
-        Long groupId
+        Long groupId,
+        Long requestId,
+        ExchangeType exchangeType
 ) {}

--- a/src/main/java/com/example/bookiibookii/domain/group/repository/MatchedMemberRepository.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/repository/MatchedMemberRepository.java
@@ -4,6 +4,7 @@ import com.example.bookiibookii.domain.group.entity.Groups;
 import com.example.bookiibookii.domain.group.entity.MatchedMember;
 import com.example.bookiibookii.domain.group.enums.GroupStatus;
 import com.example.bookiibookii.domain.group.enums.GroupType;
+import com.example.bookiibookii.domain.group.enums.MemberStatus;
 import com.example.bookiibookii.domain.group.enums.RoleStatus;
 import com.example.bookiibookii.domain.tracker.enums.ReadingStatus;
 import jakarta.persistence.LockModeType;
@@ -91,6 +92,8 @@ public interface MatchedMemberRepository extends JpaRepository<MatchedMember, Lo
 
     // 유저가 그룹의 멤버인지 검증
     boolean existsByGroup_IdAndUser_Id(Long groupId, Long userId);
+
+    boolean existsByGroup_IdAndUser_IdAndStatus(Long groupId, Long userId, MemberStatus status);
 
     @Query("""
         select mm.user.id

--- a/src/main/java/com/example/bookiibookii/domain/group/service/ApplicationService.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/service/ApplicationService.java
@@ -17,6 +17,7 @@ import com.example.bookiibookii.domain.group.repository.ApplicationRepository;
 import com.example.bookiibookii.domain.group.repository.GroupsRepository;
 import com.example.bookiibookii.domain.group.repository.MatchedMemberRepository;
 import com.example.bookiibookii.domain.notification.publisher.DomainEventPublisher;
+import com.example.bookiibookii.domain.notification.enums.ExchangeType;
 import com.example.bookiibookii.domain.user.entity.User;
 import com.example.bookiibookii.domain.user.service.UserImageS3Service;
 import com.example.bookiibookii.domain.user.exception.UserException;
@@ -131,8 +132,9 @@ public class ApplicationService {
 
             // 개별 수락 알림 발송
             publisher.publish(new GroupNotificationEvent(
-                    MATCH_SUCCEEDED, userId, thisGroup.getBook().getTitle(),
-                    newMember.getUser().getId(), null, group.getId()
+                    MATCH_SUCCEEDED, userId, groupTitle(thisGroup),
+                    newMember.getUser().getId(), null, group.getId(),
+                    application.getApplicationId(), ExchangeType.from(group.getTradeType())
             ));
 
             // 수락일이 독서 시작일 → 즉시 MATCHED 전환
@@ -153,7 +155,7 @@ public class ApplicationService {
             if (!autoRejectedReceiverIds.isEmpty()) {
                 publisher.publish(new GroupNotificationEvent(
                         MATCH_AUTO_REJECTED, userId, thisGroup.getBook().getTitle(),
-                        null, autoRejectedReceiverIds, group.getId()
+                        null, autoRejectedReceiverIds, group.getId(), null, null
                 ));
             }
 
@@ -162,8 +164,9 @@ public class ApplicationService {
         else {
             application.updateStatus(ApplicationStatus.REJECTED);
             publisher.publish(new GroupNotificationEvent(
-                    MATCH_REJECTED, userId, thisGroup.getBook().getTitle(),
-                    application.getGuest().getId(), null, group.getId()
+                    MATCH_REJECTED, userId, groupTitle(thisGroup),
+                    application.getGuest().getId(), null, group.getId(),
+                    application.getApplicationId(), null
             ));
         }
 
@@ -238,13 +241,29 @@ public class ApplicationService {
         }
 
         // 알림 publish
-        publisher.publish( new GroupNotificationEvent(JOIN_REQUESTED, userId, group.getBook().getTitle(), group.getHost().getId(), null, groupId) );
+        publisher.publish(new GroupNotificationEvent(
+                JOIN_REQUESTED,
+                userId,
+                groupTitle(group),
+                group.getHost().getId(),
+                null,
+                groupId,
+                application.getApplicationId(),
+                null
+        ));
 
         return ApplicationResponseDTO.JoinResultDTO.builder()
                 .applicationId(application.getApplicationId())
                 .status(application.getApplicationStatus().name())
                 .createdAt(LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy. MM. dd.")))
                 .build();
+    }
+
+    private String groupTitle(Groups group) {
+        if (group.getGroupName() != null && !group.getGroupName().isBlank()) {
+            return group.getGroupName();
+        }
+        return group.getBook().getTitle();
     }
 
     //참여 취소하기

--- a/src/main/java/com/example/bookiibookii/domain/group/service/GroupNotificationService.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/service/GroupNotificationService.java
@@ -34,11 +34,12 @@ public class GroupNotificationService {
         String actorNickname = userRepository.findNickNameById(event.actorId())
                 .orElse("알 수 없음");
 
-        String bookTitle = event.bookTitle();
+        String groupTitle = event.groupTitle();
 
         var vars = java.util.Map.of(
                 "nickname", actorNickname,
-                "bookTitle", bookTitle
+                "bookTitle", groupTitle,
+                "groupTitle", groupTitle
         );
         String bodyMessage = templateRenderer.render(type.getBodyTemplate(), vars);
 
@@ -46,6 +47,8 @@ public class GroupNotificationService {
                 NotificationPayload.builder()
                         .redirectType(type.getRedirectType())
                         .groupId(event.groupId())
+                        .requestId(event.requestId())
+                        .exchangeType(event.exchangeType())
                         .build()
         );
 
@@ -57,6 +60,7 @@ public class GroupNotificationService {
         if (receivers.isEmpty()) return;
 
         for (Long receiverId : receivers) {
+            String dedupKey = dedupKey(type, event.requestId());
             notificationStore.save(
                     notificationFactory.create(
                             receiverId,
@@ -64,9 +68,20 @@ public class GroupNotificationService {
                             notiType,
                             type.title,
                             bodyMessage,
-                            payload
+                            payload,
+                            dedupKey
                     )
             );
         }
+    }
+
+    private String dedupKey(GroupNotiType type, Long requestId) {
+        if (requestId == null) return null;
+        return switch (type) {
+            case JOIN_REQUESTED -> "NOTI-GRP-001:" + requestId;
+            case MATCH_SUCCEEDED -> "NOTI-GRP-002:" + requestId;
+            case MATCH_REJECTED -> "NOTI-GRP-003:" + requestId;
+            default -> null;
+        };
     }
 }

--- a/src/main/java/com/example/bookiibookii/domain/group/service/GroupService.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/service/GroupService.java
@@ -137,12 +137,15 @@ public class GroupService {
 
         matchedMemberRepository.save(hostMember);
 
-        List<Keyword> matched = keywordMatchService.matchForBook(book.getTitle(), book.getAuthor());
+        List<Keyword> matched = keywordMatchService.matchForGroup(
+                book.getTitle(),
+                book.getAuthor(),
+                savedGroup.getGroupName()
+        );
 
         List<Long> ids = matched.stream().map(Keyword::getId).toList();
-        List<String> texts = matched.stream().map(Keyword::getContent).toList();
 
-        publisher.publish(new KeywordGroupCreatedEvent(group.getId(), texts, ids));
+        publisher.publish(new KeywordGroupCreatedEvent(group.getId(), host.getId(), ids));
 
         return GroupResponseDTO.CreateResultDTO.builder()
                 .groupId(savedGroup.getId()) //
@@ -387,7 +390,16 @@ public class GroupService {
                 .toList();
 
         // 알림 publish
-        publisher.publish(new GroupNotificationEvent(GROUP_DELETED, host.getId(), group.getBook().getTitle(), null, receiverIds, group.getId()));
+        publisher.publish(new GroupNotificationEvent(
+                GROUP_DELETED,
+                host.getId(),
+                group.getBook().getTitle(),
+                null,
+                receiverIds,
+                group.getId(),
+                null,
+                null
+        ));
 
         //soft delete 실행
         group.markAsDELETED();

--- a/src/main/java/com/example/bookiibookii/domain/notification/dto/NotificationPayload.java
+++ b/src/main/java/com/example/bookiibookii/domain/notification/dto/NotificationPayload.java
@@ -20,6 +20,7 @@ public record NotificationPayload(
         Long bookCardId,
         Long noticeId,
         Long keywordId,
+        String keyword,
         Long requestId
 ) {
 }

--- a/src/main/java/com/example/bookiibookii/domain/notification/entity/Notification.java
+++ b/src/main/java/com/example/bookiibookii/domain/notification/entity/Notification.java
@@ -6,6 +6,8 @@ import com.example.bookiibookii.domain.user.entity.User;
 import com.example.bookiibookii.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 import java.time.LocalDateTime;
 
@@ -39,11 +41,13 @@ public class Notification extends BaseEntity {
     private User actor;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "category", nullable = false)
+    @JdbcTypeCode(SqlTypes.VARCHAR)
+    @Column(name = "category", nullable = false, length = 32)
     private NotificationCategory category;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "type", nullable = false)
+    @JdbcTypeCode(SqlTypes.VARCHAR)
+    @Column(name = "type", nullable = false, length = 64)
     private NotificationType type; // 라우팅 용도
 
     @Column(name = "title", nullable = false)

--- a/src/main/java/com/example/bookiibookii/domain/notification/enums/NotificationType.java
+++ b/src/main/java/com/example/bookiibookii/domain/notification/enums/NotificationType.java
@@ -9,10 +9,13 @@ public enum NotificationType {
 
     // GROUP / MATCHING (SYSTEM)
     GROUP_JOIN_REQUEST(NotificationCategory.SYSTEM),          // GRP-030 (요청관리)
+    GROUP_REQUEST_ACCEPTED(NotificationCategory.SYSTEM),
+    GROUP_REQUEST_REJECTED(NotificationCategory.SYSTEM),
     GROUP_MATCH_SUCCESS(NotificationCategory.SYSTEM),         // TRK-010 (트래커)
     GROUP_MATCH_REJECTED(NotificationCategory.SYSTEM),        // GRP-001 (리스트)
     GROUP_MATCH_AUTO_REJECTED(NotificationCategory.SYSTEM),   // GRP-001 (리스트)
     GROUP_COMMENT_CREATED(NotificationCategory.SYSTEM),       // GRP-010 (그룹 상세/댓글)
+    GROUP_COMMENT_REPLIED(NotificationCategory.SYSTEM),
     GROUP_DELETED(NotificationCategory.SYSTEM),               // 문의하기 or GRP-001
     GROUP_MATCH_FAILED_BY_EXPIRE(NotificationCategory.SYSTEM),// GRP-001 (리스트)
     GROUP_MATCH_FAILED_BY_CAPACITY(NotificationCategory.SYSTEM), // GRP-001 (리스트)

--- a/src/main/java/com/example/bookiibookii/domain/notification/event/KeywordGroupCreatedEvent.java
+++ b/src/main/java/com/example/bookiibookii/domain/notification/event/KeywordGroupCreatedEvent.java
@@ -4,6 +4,6 @@ import java.util.List;
 
 public record KeywordGroupCreatedEvent(
         Long groupId,
-        List<String> keywordTexts,
+        Long hostId,
         List<Long> keywordIds
 ) {}

--- a/src/main/java/com/example/bookiibookii/domain/notification/repository/UserKeywordRepository.java
+++ b/src/main/java/com/example/bookiibookii/domain/notification/repository/UserKeywordRepository.java
@@ -39,13 +39,14 @@ public interface UserKeywordRepository extends JpaRepository<UserKeyword, Long> 
 
     boolean existsByUserAndKeyword_Content(User user, String content);
 
-    // 키워드 알림 발송 관련
     @Query("""
-    select distinct uk.user.id
-    from UserKeyword uk
-    where uk.keyword.id in :keywordIds
+        select uk
+        from UserKeyword uk
+        join fetch uk.user u
+        join fetch uk.keyword k
+        where k.id in :keywordIds
     """)
-    List<Long> findDistinctUserIdsByKeywordIds(@Param("keywordIds") List<Long> keywordIds);
+    List<UserKeyword> findAllWithUserAndKeywordByKeywordIds(@Param("keywordIds") List<Long> keywordIds);
 
     boolean existsByUserAndKeyword_NormalizedContent(User user, String normalizedContent);
 }

--- a/src/main/java/com/example/bookiibookii/domain/notification/service/KeywordMatchService.java
+++ b/src/main/java/com/example/bookiibookii/domain/notification/service/KeywordMatchService.java
@@ -17,13 +17,20 @@ public class KeywordMatchService {
 
     @Transactional(readOnly = true)
     public List<Keyword> matchForBook(String bookTitle, String authorName) {
+        return matchForGroup(bookTitle, authorName, null);
+    }
+
+    @Transactional(readOnly = true)
+    public List<Keyword> matchForGroup(String bookTitle, String authorName, String groupTitle) {
         String titleNorm = KeywordNormalizer.normalize(bookTitle);
         String authorNorm = KeywordNormalizer.normalize(authorName);
+        String groupTitleNorm = KeywordNormalizer.normalize(groupTitle);
 
         // 완전 조회
         Set<String> exactTargets = new HashSet<>();
         if (notBlank(titleNorm)) exactTargets.add(titleNorm);
         if (notBlank(authorNorm)) exactTargets.add(authorNorm);
+        if (notBlank(groupTitleNorm)) exactTargets.add(groupTitleNorm);
 
         Map<Long, Keyword> matched = new LinkedHashMap<>();
         if (!exactTargets.isEmpty()) {
@@ -34,8 +41,9 @@ public class KeywordMatchService {
 
         // 부분 조회
         Set<String> prefixes = new HashSet<>();
-        prefixes.addAll(twoGrams(titleNorm));
-        prefixes.addAll(twoGrams(authorNorm));
+        prefixes.addAll(candidatePrefixes(titleNorm));
+        prefixes.addAll(candidatePrefixes(authorNorm));
+        prefixes.addAll(candidatePrefixes(groupTitleNorm));
         if (!prefixes.isEmpty()) {
             List<Keyword> candidates = keywordRepository.findAllByPrefix2In(prefixes);
 
@@ -44,7 +52,8 @@ public class KeywordMatchService {
                 if (kn == null || kn.length() < 2) continue;
 
                 if ((notBlank(titleNorm) && titleNorm.contains(kn)) ||
-                        (notBlank(authorNorm) && authorNorm.contains(kn))) {
+                        (notBlank(authorNorm) && authorNorm.contains(kn)) ||
+                        (notBlank(groupTitleNorm) && groupTitleNorm.contains(kn))) {
                     matched.putIfAbsent(k.getId(), k);
                 }
             }
@@ -55,10 +64,10 @@ public class KeywordMatchService {
 
     private boolean notBlank(String s) { return s != null && !s.isBlank(); }
 
-    private Set<String> twoGrams(String s) {
+    private Set<String> candidatePrefixes(String s) {
         if (s == null) return Set.of();
-        if (s.length() < 2) return Set.of(); // 2-gram
         Set<String> out = new HashSet<>();
+        for (int i = 0; i < s.length(); i++) out.add(s.substring(i, i + 1));
         for (int i = 0; i <= s.length() - 2; i++) out.add(s.substring(i, i + 2));
         return out;
     }

--- a/src/main/java/com/example/bookiibookii/domain/notification/service/KeywordNotificationService.java
+++ b/src/main/java/com/example/bookiibookii/domain/notification/service/KeywordNotificationService.java
@@ -1,6 +1,7 @@
 package com.example.bookiibookii.domain.notification.service;
 
 import com.example.bookiibookii.domain.notification.dto.NotificationPayload;
+import com.example.bookiibookii.domain.notification.entity.UserKeyword;
 import com.example.bookiibookii.domain.notification.enums.NotificationCategory;
 import com.example.bookiibookii.domain.notification.enums.NotificationType;
 import com.example.bookiibookii.domain.notification.enums.RedirectType;
@@ -13,7 +14,6 @@ import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -27,42 +27,44 @@ public class KeywordNotificationService {
     public void send(KeywordGroupCreatedEvent event) {
         if (event.keywordIds() == null || event.keywordIds().isEmpty()) return;
 
-        List<Long> receiverIds =
-                userKeywordRepository.findDistinctUserIdsByKeywordIds(event.keywordIds());
-        if (receiverIds.isEmpty()) return;
+        List<UserKeyword> subscriptions =
+                userKeywordRepository.findAllWithUserAndKeywordByKeywordIds(event.keywordIds());
 
-        String payload = notificationFactory.toJson(
-                NotificationPayload.builder()
-                        .redirectType(RedirectType.GROUP_DETAIL)
-                        .groupId(event.groupId())
-                        .build()
-        );
-        String title = "찾으시는 책이 올라왔어요!";
-        String keywordPart = formatKeywords(event.keywordTexts());
-        String message = String.format("%s 관련 새 그룹이 생성되었습니다. 마감되기 전에 신청해보세요.", keywordPart);
+        for (UserKeyword subscription : subscriptions) {
+            Long receiverId = subscription.getUser().getId();
+            if (receiverId.equals(event.hostId())) continue;
 
-        receiverIds.forEach(id -> notificationStore.save(
-                notificationFactory.create(
-                        id,
+            String keyword = subscription.getKeyword().getContent();
+            String payload = notificationFactory.toJson(
+                    NotificationPayload.builder()
+                            .redirectType(RedirectType.GROUP_DETAIL)
+                            .groupId(event.groupId())
+                            .keywordId(subscription.getKeyword().getId())
+                            .keyword(keyword)
+                            .build()
+            );
+            String title = String.format("%s 관련 그룹을 확인해보세요", keyword);
+            String message = String.format(
+                    "키워드 %s 관련 새 그룹이 생성됐어요. 마감되기 전에 확인해보세요.",
+                    keyword
+            );
+            String dedupKey = String.format(
+                    "NOTI-KWD-001:%d:%d",
+                    event.groupId(),
+                    subscription.getKeyword().getId()
+            );
+
+            notificationStore.save(
+                    notificationFactory.create(
+                        receiverId,
                         NotificationCategory.KEYWORD,
                         NotificationType.KEYWORD_GROUP_CREATED,
                         title,
                         message,
-                        payload
+                        payload,
+                        dedupKey
                 )
-        ));
-    }
-
-    // keyword 알림 메시지 format
-    private String formatKeywords(List<String> keywordTexts) {
-        if (keywordTexts == null || keywordTexts.isEmpty()) {
-            return "키워드";
+            );
         }
-        String joined = keywordTexts.stream()
-                .filter(s -> s != null && !s.isBlank())
-                .distinct()
-                .collect(Collectors.joining(", "));
-        if (joined.isBlank()) return "키워드";
-        return "키워드 " + joined;
     }
 }


### PR DESCRIPTION
## 개요
<!---- 자신이 완료한 이슈를 닫아주세요 -->
- closed #551 
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
* NOTI-GRP-001~005 그룹/댓글 알림을 구현했습니다.
* NOTI-KWD-001 키워드 알림을 구현했습니다.
* 알림 payload / redirectType / dedupKey 기반 저장 구조를 반영했습니다.
* 매칭 전 그룹 댓글 알림 수신자를 호스트 기준으로 정리했습니다.
* 답글 알림은 원 댓글 작성자에게만 발송되도록 처리했습니다.
* 그룹 매칭 이후에는 호스트/게스트만 댓글 조회·작성·삭제가 가능하도록 권한을 제한했습니다.
* `notification.type`, `notification.category`를 VARCHAR 기반 enum 저장 방식으로 정리했습니다.


<!---- Resolves: #(Isuue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

📣 **To Reviewers**
---
<!-- 전달사항 -->

- Reviewers : 팀 선택
- Labels : 작업 유형, 자기 자신


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 댓글 알림 시스템을 확장하여 다중 수신자 지원 및 댓글 답글 알림 기능 추가
  * 그룹 요청 수락/거절 알림 추가

* **개선사항**
  * 알림 중복 제거 메커니즘 적용으로 알림 정확성 향상
  * 그룹 타이틀 기반 알림 처리로 사용자 경험 개선
  * 키워드 매칭 알고리즘 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->