### PR TITLE
[Feat]#559 마이페이지 내 작성 및 수신 후기 리스트 조회

### DIFF
--- a/src/main/java/com/example/bookiibookii/domain/review/controller/MemberReviewControllerDocs.java
+++ b/src/main/java/com/example/bookiibookii/domain/review/controller/MemberReviewControllerDocs.java
@@ -29,7 +29,7 @@ public interface MemberReviewControllerDocs {
             1:1 교환독서의 상대 멤버에게 파트너 후기를 남깁니다.
 
             - 그룹 멤버만 작성할 수 있습니다.
-            - 코멘트는 필수이며 최대 20자입니다.
+            - 코멘트는 선택값이며 최대 20자입니다.
             - reaction은 선택값입니다. 전달하지 않거나 null로 보내도 등록할 수 있습니다.
             - reaction 값은 BOOM_UP, BOOM_DOWN 중 하나입니다.
             - 두 번째 교환 플로우가 양쪽 모두 완료된 후에만 작성할 수 있습니다.
@@ -77,7 +77,7 @@ public interface MemberReviewControllerDocs {
                     description = "파트너 후기 등록 성공",
                     content = @Content(schema = @Schema(implementation = MemberReviewResponseDTO.class))
             ),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "코멘트 누락, 길이 초과, 중복 후기, 작성 가능 상태가 아님"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "코멘트 길이 초과, 중복 후기, 작성 가능 상태가 아님"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "그룹 멤버가 아님"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "그룹, 매칭 멤버 또는 상대 멤버를 찾을 수 없음")
     })

--- a/src/main/java/com/example/bookiibookii/domain/review/dto/req/ReviewRequestDTO.java
+++ b/src/main/java/com/example/bookiibookii/domain/review/dto/req/ReviewRequestDTO.java
@@ -2,7 +2,6 @@ package com.example.bookiibookii.domain.review.dto.req;
 
 import com.example.bookiibookii.domain.review.enums.MemberReviewReaction;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
@@ -29,8 +28,7 @@ public class ReviewRequestDTO {
             )
             MemberReviewReaction reaction,
 
-            @Schema(description = "파트너 후기 코멘트. 필수값이며 최대 20자입니다.", example = "좋았어요", maxLength = 20, requiredMode = Schema.RequiredMode.REQUIRED)
-            @NotBlank(message = "코멘트는 필수입니다.")
+            @Schema(description = "파트너 후기 코멘트. 선택값이며 최대 20자입니다.", example = "좋았어요", maxLength = 20, nullable = true)
             @Size(max = 20, message = "파트너 후기는 20자 이내로 입력해주세요.")
             String comment
     ) {}

--- a/src/main/java/com/example/bookiibookii/domain/review/entity/MemberReview.java
+++ b/src/main/java/com/example/bookiibookii/domain/review/entity/MemberReview.java
@@ -44,7 +44,7 @@ public class MemberReview extends BaseEntity {
     @Column(name = "reaction", length = 30)
     private MemberReviewReaction reaction;
 
-    @Column(name = "comment", nullable = false, length = 20)
+    @Column(name = "comment", length = 20)
     private String comment;
 
     public static MemberReview create(
@@ -57,7 +57,7 @@ public class MemberReview extends BaseEntity {
         Objects.requireNonNull(group, "group must not be null");
         Objects.requireNonNull(writer, "writer must not be null");
         Objects.requireNonNull(target, "target must not be null");
-        validateComment(comment);
+        validateCommentLength(comment);
 
         return MemberReview.builder()
                 .group(group)
@@ -68,17 +68,14 @@ public class MemberReview extends BaseEntity {
                 .build();
     }
 
-    private static void validateComment(String comment) {
-        if (comment == null || comment.isBlank()) {
-            throw new IllegalArgumentException("comment must not be blank");
-        }
-        if (comment.length() > 20) {
+    private static void validateCommentLength(String comment) {
+        if (comment != null && comment.length() > 20) {
             throw new IllegalArgumentException("comment cannot exceed 20 characters");
         }
     }
 
     public void updateReview(MemberReviewReaction reaction, String comment) {
-        validateComment(comment);
+        validateCommentLength(comment);
         this.reaction = reaction;
         this.comment = comment;
     }

--- a/src/main/java/com/example/bookiibookii/domain/review/exception/code/ReviewSuccessCode.java
+++ b/src/main/java/com/example/bookiibookii/domain/review/exception/code/ReviewSuccessCode.java
@@ -13,7 +13,9 @@ public enum ReviewSuccessCode implements BaseCode {
     BOOK_REVIEW_UPDATED(HttpStatus.OK, "REVIEW200_4", "책 리뷰가 수정되었습니다."),
     GROUP_REVIEWS_FOUND(HttpStatus.OK, "REVIEW200_5", "그룹 리뷰 조회에 성공했습니다."),
     MY_GROUP_REVIEWS_UPDATED(HttpStatus.OK, "REVIEW200_6", "내 리뷰가 수정되었습니다."),
-    MY_BOOK_REVIEWS_FOUND(HttpStatus.OK, "REVIEW200_7", "내 책 리뷰 목록 조회에 성공했습니다.");
+    MY_BOOK_REVIEWS_FOUND(HttpStatus.OK, "REVIEW200_7", "내 책 리뷰 목록 조회에 성공했습니다."),
+    MYPAGE_WRITTEN_REVIEWS_FOUND(HttpStatus.OK, "REVIEW200_8", "마이페이지 작성 후기 조회에 성공했습니다."),
+    MYPAGE_RECEIVED_REVIEWS_FOUND(HttpStatus.OK, "REVIEW200_9", "마이페이지 받은 후기 조회에 성공했습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/example/bookiibookii/domain/review/repository/BookReviewRepository.java
+++ b/src/main/java/com/example/bookiibookii/domain/review/repository/BookReviewRepository.java
@@ -1,6 +1,7 @@
 package com.example.bookiibookii.domain.review.repository;
 
 import com.example.bookiibookii.domain.review.entity.BookReview;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -40,6 +41,27 @@ public interface BookReviewRepository extends JpaRepository<BookReview, Long> {
     );
 
     boolean existsByMemberBookId(Long memberBookId);
+
+    @Query(
+            value = """
+                SELECT br FROM BookReview br
+                JOIN FETCH br.memberBook mb
+                JOIN FETCH mb.book
+                JOIN FETCH mb.group
+                JOIN br.matchedMember mm
+                WHERE mm.user.id = :userId
+                ORDER BY br.createdAt DESC, br.id DESC
+                """,
+            countQuery = """
+                SELECT COUNT(br) FROM BookReview br
+                JOIN br.matchedMember mm
+                WHERE mm.user.id = :userId
+                """
+    )
+    Page<BookReview> findWrittenReviewsByUserId(
+            @Param("userId") Long userId,
+            Pageable pageable
+    );
 
     @Query("""
         SELECT br FROM BookReview br

--- a/src/main/java/com/example/bookiibookii/domain/review/repository/BookReviewRepository.java
+++ b/src/main/java/com/example/bookiibookii/domain/review/repository/BookReviewRepository.java
@@ -50,12 +50,15 @@ public interface BookReviewRepository extends JpaRepository<BookReview, Long> {
                 JOIN FETCH mb.group
                 JOIN br.matchedMember mm
                 WHERE mm.user.id = :userId
+                AND mb.removedAt IS NULL
                 ORDER BY br.createdAt DESC, br.id DESC
                 """,
             countQuery = """
                 SELECT COUNT(br) FROM BookReview br
                 JOIN br.matchedMember mm
+                JOIN br.memberBook mb
                 WHERE mm.user.id = :userId
+                AND mb.removedAt IS NULL
                 """
     )
     Page<BookReview> findWrittenReviewsByUserId(

--- a/src/main/java/com/example/bookiibookii/domain/review/repository/MemberReviewRepository.java
+++ b/src/main/java/com/example/bookiibookii/domain/review/repository/MemberReviewRepository.java
@@ -2,6 +2,7 @@ package com.example.bookiibookii.domain.review.repository;
 
 import com.example.bookiibookii.domain.review.entity.MemberReview;
 import com.example.bookiibookii.domain.review.enums.MemberReviewReaction;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -24,6 +25,27 @@ public interface MemberReviewRepository extends JpaRepository<MemberReview, Long
                                         @Param("reaction") MemberReviewReaction reaction);
 
     boolean existsByGroup_IdAndWriter_Id(Long groupId, Long writerMatchedMemberId);
+
+    @Query(
+            value = """
+                SELECT mr FROM MemberReview mr
+                JOIN FETCH mr.writer w
+                JOIN FETCH w.user wu
+                LEFT JOIN FETCH wu.userImage
+                JOIN mr.target t
+                WHERE t.user.id = :userId
+                ORDER BY mr.createdAt DESC, mr.id DESC
+                """,
+            countQuery = """
+                SELECT COUNT(mr) FROM MemberReview mr
+                JOIN mr.target t
+                WHERE t.user.id = :userId
+                """
+    )
+    Page<MemberReview> findReceivedReviewsByUserId(
+            @Param("userId") Long userId,
+            Pageable pageable
+    );
 
     @Query("""
         SELECT mr FROM MemberReview mr

--- a/src/main/java/com/example/bookiibookii/domain/review/service/ReviewService.java
+++ b/src/main/java/com/example/bookiibookii/domain/review/service/ReviewService.java
@@ -133,7 +133,7 @@ public class ReviewService {
             ReviewRequestDTO.MemberReviewCreateDTO request,
             User user
     ) {
-        validateCommentRequired(request.comment(), MEMBER_COMMENT_MAX_LENGTH);
+        validateCommentLength(request.comment(), MEMBER_COMMENT_MAX_LENGTH);
 
         Groups group = groupsRepository.findByIdForUpdate(groupId)
                 .orElseThrow(() -> new GroupException(GroupErrorCode.GROUP_NOT_FOUND));


### PR DESCRIPTION
## 개요
<!---- 자신이 완료한 이슈를 닫아주세요 -->
- closed #559 
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 마이페이지 후기 탭 조회 API 추가
- 작성한 후기/받은 후기 기준에 맞게 책 후기와 파트너 후기를 분리 조회
- 후기 목록 페이징 및 최신순 정렬 적용
- 파트너 후기의 붐업/붐따 리액션 값이 없는 경우도 조회 가능하도록 처리

<!---- Resolves: #(Isuue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

📣 **To Reviewers**
---
<!-- 전달사항 -->

- Reviewers : 팀 선택
- Labels : 작업 유형, 자기 자신


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 마이페이지에서 작성한 후기 및 받은 후기 조회 기능 추가 (페이징 지원)

* **Bug Fixes**
  * 후기 코멘트 필드를 선택사항으로 변경 (기존: 필수)
  * 코멘트 길이 제한 규칙 강화 (최대 20자)
  * API 오류 응답 코드 및 문서 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->