### PR TITLE
[Fix]#565 서재 및 상세 조회 응답값 변경

### DIFF
--- a/src/main/java/com/example/bookiibookii/domain/group/dto/res/GroupResponseDTO.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/dto/res/GroupResponseDTO.java
@@ -59,6 +59,7 @@ public class GroupResponseDTO {
         private String tradeType;      // DIRECT, DELIVERY
         private String placeName;
         private String address;
+        private String detailAddress;
 
         // 2. 도서 상세 정보 (Book 엔티티와 매핑)
         private String title;
@@ -194,8 +195,8 @@ public class GroupResponseDTO {
             String bookImage,
             String bookTitle,
             String author,
-            @Schema(description = "그룹 진행 방식", example = "RELAY")
-            GroupType groupType,
+            @Schema(description = "교환 방식", example = "DELIVERY")
+            String tradeType,
             @Schema(description = "책 장르 표시명", example = "한국소설")
             String genre,
             Integer readingPeriod

--- a/src/main/java/com/example/bookiibookii/domain/group/service/GroupService.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/service/GroupService.java
@@ -441,6 +441,7 @@ public class GroupService {
                 .tradeType(group.getTradeType().name())
                 .placeName(group.getGroupPlace() != null ? group.getGroupPlace().getPlaceName() : null)
                 .address(group.getGroupPlace() != null ? group.getGroupPlace().getAddress() : null)
+                .detailAddress(group.getGroupPlace() != null ? group.getGroupPlace().getAddressDetail() : null)
                 .title(group.getBook().getTitle())
                 .bookImage(group.getBook().getImage())
                 .author(group.getBook().getAuthor())
@@ -1041,7 +1042,7 @@ public class GroupService {
                 .bookImage(group.getBook().getImage())
                 .bookTitle(group.getBook().getTitle())
                 .author(group.getBook().getAuthor())
-                .groupType(group.getGroupType())
+                .tradeType(group.getTradeType() != null ? group.getTradeType().name() : null)
                 .genre(group.getBook().getCategory().getLabel())
                 .readingPeriod(group.getReadingPeriod())
                 .build();

--- a/src/main/java/com/example/bookiibookii/domain/memberbook/controller/MemberBookCardControllerDocs.java
+++ b/src/main/java/com/example/bookiibookii/domain/memberbook/controller/MemberBookCardControllerDocs.java
@@ -61,6 +61,7 @@ public interface MemberBookCardControllerDocs {
             - **엔드포인트**: `GET /api/member-books/cards/detail/{cardId}`
             - 카드 소유자(MemberBook 소유자)이거나 같은 그룹 멤버만 조회 가능합니다.
             - 내가 숨긴 카드는 404로 처리됩니다.
+            - 책 전체 페이지(`totalPages`), 장르(`genre`), 양측 파트너 후기 완료 시점(`completedAt`)을 포함합니다.
             - 응답 형식은 목록 항목과 동일합니다 (`MemberCardResponseDTO`).
             """
     )

--- a/src/main/java/com/example/bookiibookii/domain/memberbook/controller/MemberBookLibraryControllerDocs.java
+++ b/src/main/java/com/example/bookiibookii/domain/memberbook/controller/MemberBookLibraryControllerDocs.java
@@ -29,12 +29,13 @@ public interface MemberBookLibraryControllerDocs {
         - **주요 포함 정보**:
             - **멤버북 ID**: `memberBookId` (서재 내 고유 식별자)
             - **본인 책 여부**: `isMine` (true: 내가 가져온 책, false: 상대/호스트 책)
-            - **도서 정보**: 책 ID, 제목, 저자, 이미지 URL (MemberBook에 연결된 책)
+            - **도서 정보**: 책 ID, 제목, 저자, 이미지 URL, 전체 페이지, 장르 (MemberBook에 연결된 책)
             - **그룹 정보**: 그룹 ID, 그룹명(`groupName`)
             - **호스트 정보**: 호스트 ID, 닉네임, 프로필 이미지(Presigned URL)
             - **일정 정보**: 그룹 시작일(`startDate`), **실제 독서 종료일(`endDate`)**, 그룹 독서 기간(`duration`)
             - **진행률**: `progressRate` (0 ~ 100 정수 퍼센트)
             - **평가 정보**: BookReview 기준 별점(`rating`), 감상평(`comment`). 리뷰 미작성 시 null.
+            - **완료 시점**: `completedAt`은 양측 파트너 후기가 모두 작성되어 교환독서가 종료된 시각입니다.
         - **참고**: `endDate`는 트래커의 실제 기록을 바탕으로 제공되며, 기록이 없는 경우 그룹 설정상의 종료일을 반환합니다.
         """
     )

--- a/src/main/java/com/example/bookiibookii/domain/memberbook/dto/res/LibraryMemberBookResponseDTO.java
+++ b/src/main/java/com/example/bookiibookii/domain/memberbook/dto/res/LibraryMemberBookResponseDTO.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Getter
 @Builder
@@ -19,6 +20,9 @@ public class LibraryMemberBookResponseDTO {
     private String title;
     private String author;
     private String image;
+    private Integer totalPages;
+    private String genre;
+    private LocalDateTime completedAt;
     private Long hostId;
     private String hostNickName;
     private String hostProfileImageUrl;

--- a/src/main/java/com/example/bookiibookii/domain/memberbook/dto/res/MemberCardResponseDTO.java
+++ b/src/main/java/com/example/bookiibookii/domain/memberbook/dto/res/MemberCardResponseDTO.java
@@ -20,6 +20,9 @@ public class MemberCardResponseDTO {
     private MemberCardImageResponseDTO cardImage;
     private LocalDateTime createdAt;
     private String bookTitle;
+    private Integer totalPages;
+    private String genre;
+    private LocalDateTime completedAt;
     private Boolean isMine;
     private Boolean isBookmarked;
     private String creatorName;

--- a/src/main/java/com/example/bookiibookii/domain/memberbook/service/MemberBookCardService.java
+++ b/src/main/java/com/example/bookiibookii/domain/memberbook/service/MemberBookCardService.java
@@ -42,6 +42,7 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.EnumMap;
@@ -590,8 +591,18 @@ public class MemberBookCardService {
     ) {
         MemberBook memberBook = card.getMemberBook();
         String bookTitle = "";
-        if (memberBook != null && memberBook.getBook() != null && memberBook.getBook().getTitle() != null) {
-            bookTitle = memberBook.getBook().getTitle();
+        Integer totalPages = null;
+        String genre = null;
+        LocalDateTime completedAt = null;
+        if (memberBook != null && memberBook.getBook() != null) {
+            bookTitle = memberBook.getBook().getTitle() != null ? memberBook.getBook().getTitle() : "";
+            totalPages = memberBook.getBook().getTotalPages();
+            genre = memberBook.getBook().getCategory() != null
+                    ? memberBook.getBook().getCategory().getLabel()
+                    : null;
+        }
+        if (memberBook != null && memberBook.getMatchedMember() != null) {
+            completedAt = memberBook.getMatchedMember().getCompletedAt();
         }
 
         String creatorName = resolveCreatorName(memberBook);
@@ -608,6 +619,9 @@ public class MemberBookCardService {
                 .cardImage(buildCardImageResponse(card.getCardImages(), presignedGetUrlExpirationMinutes))
                 .createdAt(card.getCreatedAt())
                 .bookTitle(bookTitle)
+                .totalPages(totalPages)
+                .genre(genre)
+                .completedAt(completedAt)
                 .isMine(memberBook != null && memberBook.isMine())
                 .isBookmarked(isBookmarked)
                 .creatorName(creatorName)

--- a/src/main/java/com/example/bookiibookii/domain/memberbook/service/MemberBookLibraryService.java
+++ b/src/main/java/com/example/bookiibookii/domain/memberbook/service/MemberBookLibraryService.java
@@ -129,6 +129,11 @@ public class MemberBookLibraryService {
                 .title(book.getTitle())
                 .author(book.getAuthor())
                 .image(book.getImage())
+                .totalPages(book.getTotalPages())
+                .genre(book.getCategory() != null ? book.getCategory().getLabel() : null)
+                .completedAt(memberBook.getMatchedMember() != null
+                        ? memberBook.getMatchedMember().getCompletedAt()
+                        : null)
                 .hostId(host.getId())
                 .hostNickName(host.getNickName())
                 .hostProfileImageUrl(hostProfileImageUrl)

--- a/src/main/java/com/example/bookiibookii/domain/review/repository/BookReviewRepository.java
+++ b/src/main/java/com/example/bookiibookii/domain/review/repository/BookReviewRepository.java
@@ -16,6 +16,20 @@ public interface BookReviewRepository extends JpaRepository<BookReview, Long> {
 
     List<BookReview> findByMemberBook_IdIn(List<Long> memberBookIds);
 
+    @Query("""
+        SELECT br FROM BookReview br
+        JOIN FETCH br.memberBook mb
+        JOIN FETCH mb.book b
+        JOIN br.matchedMember mm
+        WHERE mm.user.id = :userId
+        AND b.id IN :bookIds
+        ORDER BY br.updatedAt DESC, br.id DESC
+        """)
+    List<BookReview> findLatestByUserIdAndBookIds(
+            @Param("userId") Long userId,
+            @Param("bookIds") List<Long> bookIds
+    );
+
     boolean existsByMatchedMember_IdAndMemberBook_Id(Long matchedMemberId, Long memberBookId);
 
     Optional<BookReview> findByMatchedMember_IdAndMemberBook_Id(Long matchedMemberId, Long memberBookId);

--- a/src/main/java/com/example/bookiibookii/domain/user/controller/UserControllerDocs.java
+++ b/src/main/java/com/example/bookiibookii/domain/user/controller/UserControllerDocs.java
@@ -162,7 +162,7 @@ public interface UserControllerDocs {
             description = """
             - completedBooks: 완독한 책 목록 (완독날짜, 책 제목, 작가, 장르, 별점)
             - favoriteBooks: 온보딩에서 등록한 인생 책 (최대 3개)
-            - representativeBooks: 나를 대표하는 책 (최대 7개, displayOrder 순)
+            - representativeBooks: 나를 대표하는 책 (최대 7개, displayOrder 순, 사용자가 작성한 책 후기 별점 포함)
             """
     )
     @ApiResponses({

--- a/src/main/java/com/example/bookiibookii/domain/user/dto/res/BookshelfResponseDTO.java
+++ b/src/main/java/com/example/bookiibookii/domain/user/dto/res/BookshelfResponseDTO.java
@@ -39,6 +39,7 @@ public class BookshelfResponseDTO {
             Long userBookId,
             String title,
             Integer displayOrder,
-            boolean isFavorite
+            boolean isFavorite,
+            Double rating
     ) {}
 }

--- a/src/main/java/com/example/bookiibookii/domain/user/service/BookshelfService.java
+++ b/src/main/java/com/example/bookiibookii/domain/user/service/BookshelfService.java
@@ -104,13 +104,31 @@ public class BookshelfService {
 
     // 나를 대표하는 책 조회
     private List<BookshelfResponseDTO.RepresentativeBookDto> buildRepresentativeBooks(Long userId) {
-        return userBookRepository.findRepresentativeBooks(userId)
+        List<UserBook> representativeBooks = userBookRepository.findRepresentativeBooks(userId);
+        if (representativeBooks.isEmpty()) {
+            return List.of();
+        }
+
+        List<Long> bookIds = representativeBooks.stream()
+                .map(ub -> ub.getBook().getId())
+                .distinct()
+                .toList();
+        Map<Long, Double> ratingByBookId = bookReviewRepository
+                .findLatestByUserIdAndBookIds(userId, bookIds)
                 .stream()
+                .collect(Collectors.toMap(
+                        review -> review.getMemberBook().getBook().getId(),
+                        BookReview::getStar,
+                        (latest, ignored) -> latest
+                ));
+
+        return representativeBooks.stream()
                 .map(ub -> new BookshelfResponseDTO.RepresentativeBookDto(
                         ub.getId(),
                         ub.getBook().getTitle(),
                         ub.getDisplayOrder(),
-                        ub.isFavorite()
+                        ub.isFavorite(),
+                        ratingByBookId.get(ub.getBook().getId())
                 ))
                 .toList();
     }


### PR DESCRIPTION
## 개요
<!---- 자신이 완료한 이슈를 닫아주세요 -->
- closed #565 
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 독서카드 상세 조회 API에 도서 전체 페이지 수 응답값 추가
- 그룹 상세 조회 API에 detailAddress 응답값 추가
- 홈 택배 추천 그룹 응답에서 groupType 대신 tradeType이 내려가도록 수정
- 멤버북 독서카드 상세 조회 응답에 도서 전체 페이지 수, 장르 추가
- 멤버북 독서카드 상세 조회의 서재 완료일 기준을 상호 파트너 후기 완료 시점으로 정정
- GET /api/mypage/bookshelf 응답의 representativeBooks 내부에 rating 추가

<!---- Resolves: #(Isuue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

📣 **To Reviewers**
---
<!-- 전달사항 -->

- Reviewers : 팀 선택
- Labels : 작업 유형, 자기 자신
