### PR TITLE
[Feat]#569 택배교환 관련 알림 3종 구현

### DIFF
--- a/src/main/java/com/example/bookiibookii/domain/notification/enums/NotificationType.java
+++ b/src/main/java/com/example/bookiibookii/domain/notification/enums/NotificationType.java
@@ -26,7 +26,9 @@ public enum NotificationType {
     TRACKER_READING_REVIEW_COMPLETED(NotificationCategory.SYSTEM),
     TRACKER_SHIPMENT_REGISTERED(NotificationCategory.SYSTEM), // TRK-010
     TRACKER_DELIVERY_CONFIRMED(NotificationCategory.SYSTEM),  // TRK-010
+    TRACKER_DELIVERY_RECEIVE_REMINDER(NotificationCategory.SYSTEM), // TRK-010
     TRACKER_RETURN_SHIPMENT_REGISTERED(NotificationCategory.SYSTEM), // TRK-010 (반납 출발)
+    // TODO: 외부 택배사 상태 API 연동 전까지 배송 상태 업데이트 알림(NOTI-DEL-002)은 구현하지 않는다.
     TRACKER_EXCHANGE_COMPLETED(NotificationCategory.SYSTEM),  // TRK-030 (후기작성)
     TRACKER_COMMENT_CREATED(NotificationCategory.SYSTEM),
     TRACKER_EXCHANGE_REVIEW_CREATED(NotificationCategory.SYSTEM),

--- a/src/main/java/com/example/bookiibookii/domain/notification/listener/NotificationEventListener.java
+++ b/src/main/java/com/example/bookiibookii/domain/notification/listener/NotificationEventListener.java
@@ -11,6 +11,8 @@ import com.example.bookiibookii.domain.notification.service.DirectExchangeNotifi
 import com.example.bookiibookii.domain.notification.service.KeywordNotificationService;
 import com.example.bookiibookii.domain.notification.service.ReadingCardReactionNotificationService;
 import com.example.bookiibookii.domain.tracker.event.TrackerNotificationEvent;
+import com.example.bookiibookii.domain.tracker.event.DeliveryNotificationEvent;
+import com.example.bookiibookii.domain.tracker.service.DeliveryNotificationService;
 import com.example.bookiibookii.domain.tracker.service.TrackerNotificationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Async;
@@ -28,6 +30,7 @@ public class NotificationEventListener {
     private final GroupNotificationService groupNotificationService;
     private final DirectExchangeNotificationService directExchangeNotificationService;
     private final ReadingCardReactionNotificationService readingCardReactionNotificationService;
+    private final DeliveryNotificationService deliveryNotificationService;
 
     @Async("notiExecutor")
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
@@ -45,6 +48,12 @@ public class NotificationEventListener {
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleTracker(TrackerNotificationEvent event) {
         trackerNotificationService.send(event);
+    }
+
+    @Async("notiExecutor")
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleDelivery(DeliveryNotificationEvent event) {
+        deliveryNotificationService.send(event);
     }
 
     @Async("notiExecutor")

--- a/src/main/java/com/example/bookiibookii/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/example/bookiibookii/domain/notification/repository/NotificationRepository.java
@@ -14,6 +14,8 @@ import java.util.List;
 @Repository
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
+    boolean existsByReceiver_IdAndDedupKey(Long receiverId, String dedupKey);
+
     @Query("""
         select n from Notification n
         where n.receiver.id = :receiverId

--- a/src/main/java/com/example/bookiibookii/domain/tracker/event/DeliveryNotificationEvent.java
+++ b/src/main/java/com/example/bookiibookii/domain/tracker/event/DeliveryNotificationEvent.java
@@ -1,0 +1,16 @@
+package com.example.bookiibookii.domain.tracker.event;
+
+import com.example.bookiibookii.domain.notification.enums.NotificationType;
+import com.example.bookiibookii.domain.tracker.enums.ExchangeRound;
+
+public record DeliveryNotificationEvent(
+        NotificationType notificationType,
+        Long actorId,
+        String actorNickname,
+        Long receiverId,
+        Long groupId,
+        ExchangeRound exchangeRound,
+        String deliveryId,
+        String bookTitle
+) {
+}

--- a/src/main/java/com/example/bookiibookii/domain/tracker/repository/DeliveryRepository.java
+++ b/src/main/java/com/example/bookiibookii/domain/tracker/repository/DeliveryRepository.java
@@ -3,8 +3,11 @@ package com.example.bookiibookii.domain.tracker.repository;
 import com.example.bookiibookii.domain.tracker.entity.Delivery;
 import com.example.bookiibookii.domain.tracker.enums.ExchangeRound;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -38,4 +41,28 @@ public interface DeliveryRepository extends JpaRepository<Delivery, String> {
             Long senderId,
             Long receiverId
     );
+
+    @Query("""
+        select distinct d from Delivery d
+        join fetch d.group g
+        join fetch d.sender sender
+        join fetch sender.user
+        join fetch sender.memberBooks senderBook
+        join fetch senderBook.book
+        join fetch d.receiver receiver
+        join fetch receiver.user
+        where d.createdAt <= :cutoff
+          and d.receivedConfirmedAt is null
+          and g.tradeType = com.example.bookiibookii.domain.group.enums.TradeType.DELIVERY
+          and g.groupStatus = com.example.bookiibookii.domain.group.enums.GroupStatus.MATCHED
+          and (
+               (d.exchangeRound = com.example.bookiibookii.domain.tracker.enums.ExchangeRound.FIRST_EXCHANGE
+                and sender.readingStatus = com.example.bookiibookii.domain.tracker.enums.ReadingStatus.EXCHANGING
+                and receiver.readingStatus = com.example.bookiibookii.domain.tracker.enums.ReadingStatus.EXCHANGING)
+            or (d.exchangeRound = com.example.bookiibookii.domain.tracker.enums.ExchangeRound.RETURN_EXCHANGE
+                and sender.readingStatus = com.example.bookiibookii.domain.tracker.enums.ReadingStatus.RETURNING
+                and receiver.readingStatus = com.example.bookiibookii.domain.tracker.enums.ReadingStatus.RETURNING)
+          )
+    """)
+    List<Delivery> findReceiveReminderCandidates(@Param("cutoff") LocalDateTime cutoff);
 }

--- a/src/main/java/com/example/bookiibookii/domain/tracker/scheduler/DeliveryReceiveReminderScheduler.java
+++ b/src/main/java/com/example/bookiibookii/domain/tracker/scheduler/DeliveryReceiveReminderScheduler.java
@@ -8,6 +8,7 @@ import com.example.bookiibookii.domain.tracker.event.DeliveryNotificationEvent;
 import com.example.bookiibookii.domain.tracker.repository.DeliveryRepository;
 import com.example.bookiibookii.domain.tracker.service.PackageDeliveryService;
 import com.example.bookiibookii.domain.tracker.util.DeliveryNotificationDedupKey;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -17,6 +18,7 @@ import java.time.Clock;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 
+@Slf4j
 @Component
 public class DeliveryReceiveReminderScheduler {
 
@@ -59,27 +61,45 @@ public class DeliveryReceiveReminderScheduler {
                 .minusHours(REMINDER_DELAY_HOURS);
 
         for (Delivery delivery : deliveryRepository.findReceiveReminderCandidates(cutoff)) {
-            String dedupKey = DeliveryNotificationDedupKey.create(
-                    NotificationType.TRACKER_DELIVERY_RECEIVE_REMINDER,
-                    delivery.getGroup().getId(),
-                    delivery.getExchangeRound(),
-                    delivery.getId()
-            );
-            Long receiverId = delivery.getReceiver().getUser().getId();
-            if (notificationRepository.existsByReceiver_IdAndDedupKey(receiverId, dedupKey)) {
-                continue;
+            try {
+                processReceiveReminderCandidate(delivery);
+            } catch (Exception exception) {
+                log.error(
+                        "Delivery receive reminder candidate processing failed. "
+                                + "deliveryId={}, groupId={}, exchangeRound={}, receiverId={}",
+                        delivery == null ? null : delivery.getId(),
+                        delivery == null || delivery.getGroup() == null ? null : delivery.getGroup().getId(),
+                        delivery == null ? null : delivery.getExchangeRound(),
+                        delivery == null || delivery.getReceiver() == null
+                                || delivery.getReceiver().getUser() == null
+                                ? null : delivery.getReceiver().getUser().getId(),
+                        exception
+                );
             }
-
-            eventPublisher.publish(new DeliveryNotificationEvent(
-                    NotificationType.TRACKER_DELIVERY_RECEIVE_REMINDER,
-                    delivery.getSender().getUser().getId(),
-                    delivery.getSender().getUser().getNickName(),
-                    receiverId,
-                    delivery.getGroup().getId(),
-                    delivery.getExchangeRound(),
-                    delivery.getId(),
-                    PackageDeliveryService.findDeliveredBookTitle(delivery)
-            ));
         }
+    }
+
+    private void processReceiveReminderCandidate(Delivery delivery) {
+        String dedupKey = DeliveryNotificationDedupKey.create(
+                NotificationType.TRACKER_DELIVERY_RECEIVE_REMINDER,
+                delivery.getGroup().getId(),
+                delivery.getExchangeRound(),
+                delivery.getId()
+        );
+        Long receiverId = delivery.getReceiver().getUser().getId();
+        if (notificationRepository.existsByReceiver_IdAndDedupKey(receiverId, dedupKey)) {
+            return;
+        }
+
+        eventPublisher.publish(new DeliveryNotificationEvent(
+                NotificationType.TRACKER_DELIVERY_RECEIVE_REMINDER,
+                delivery.getSender().getUser().getId(),
+                delivery.getSender().getUser().getNickName(),
+                receiverId,
+                delivery.getGroup().getId(),
+                delivery.getExchangeRound(),
+                delivery.getId(),
+                PackageDeliveryService.findDeliveredBookTitle(delivery)
+        ));
     }
 }

--- a/src/main/java/com/example/bookiibookii/domain/tracker/scheduler/DeliveryReceiveReminderScheduler.java
+++ b/src/main/java/com/example/bookiibookii/domain/tracker/scheduler/DeliveryReceiveReminderScheduler.java
@@ -1,0 +1,85 @@
+package com.example.bookiibookii.domain.tracker.scheduler;
+
+import com.example.bookiibookii.domain.notification.enums.NotificationType;
+import com.example.bookiibookii.domain.notification.publisher.DomainEventPublisher;
+import com.example.bookiibookii.domain.notification.repository.NotificationRepository;
+import com.example.bookiibookii.domain.tracker.entity.Delivery;
+import com.example.bookiibookii.domain.tracker.event.DeliveryNotificationEvent;
+import com.example.bookiibookii.domain.tracker.repository.DeliveryRepository;
+import com.example.bookiibookii.domain.tracker.service.PackageDeliveryService;
+import com.example.bookiibookii.domain.tracker.util.DeliveryNotificationDedupKey;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+@Component
+public class DeliveryReceiveReminderScheduler {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+    private static final long REMINDER_DELAY_HOURS = 72;
+
+    private final DeliveryRepository deliveryRepository;
+    private final NotificationRepository notificationRepository;
+    private final DomainEventPublisher eventPublisher;
+    private final Clock clock;
+
+    @Autowired
+    public DeliveryReceiveReminderScheduler(
+            DeliveryRepository deliveryRepository,
+            NotificationRepository notificationRepository,
+            DomainEventPublisher eventPublisher
+    ) {
+        this(deliveryRepository, notificationRepository, eventPublisher, Clock.system(KST));
+    }
+
+    DeliveryReceiveReminderScheduler(
+            DeliveryRepository deliveryRepository,
+            NotificationRepository notificationRepository,
+            DomainEventPublisher eventPublisher,
+            Clock clock
+    ) {
+        this.deliveryRepository = deliveryRepository;
+        this.notificationRepository = notificationRepository;
+        this.eventPublisher = eventPublisher;
+        this.clock = clock;
+    }
+
+    @Scheduled(
+            cron = "${scheduler.delivery-receive-reminder.cron:0 */5 * * * *}",
+            zone = "Asia/Seoul"
+    )
+    @Transactional(readOnly = true)
+    public void sendReceiveReminders() {
+        LocalDateTime cutoff = LocalDateTime.ofInstant(clock.instant(), clock.getZone())
+                .minusHours(REMINDER_DELAY_HOURS);
+
+        for (Delivery delivery : deliveryRepository.findReceiveReminderCandidates(cutoff)) {
+            String dedupKey = DeliveryNotificationDedupKey.create(
+                    NotificationType.TRACKER_DELIVERY_RECEIVE_REMINDER,
+                    delivery.getGroup().getId(),
+                    delivery.getExchangeRound(),
+                    delivery.getId()
+            );
+            Long receiverId = delivery.getReceiver().getUser().getId();
+            if (notificationRepository.existsByReceiver_IdAndDedupKey(receiverId, dedupKey)) {
+                continue;
+            }
+
+            eventPublisher.publish(new DeliveryNotificationEvent(
+                    NotificationType.TRACKER_DELIVERY_RECEIVE_REMINDER,
+                    delivery.getSender().getUser().getId(),
+                    delivery.getSender().getUser().getNickName(),
+                    receiverId,
+                    delivery.getGroup().getId(),
+                    delivery.getExchangeRound(),
+                    delivery.getId(),
+                    PackageDeliveryService.findDeliveredBookTitle(delivery)
+            ));
+        }
+    }
+}

--- a/src/main/java/com/example/bookiibookii/domain/tracker/service/DeliveryNotificationService.java
+++ b/src/main/java/com/example/bookiibookii/domain/tracker/service/DeliveryNotificationService.java
@@ -1,0 +1,94 @@
+package com.example.bookiibookii.domain.tracker.service;
+
+import com.example.bookiibookii.domain.notification.dto.NotificationPayload;
+import com.example.bookiibookii.domain.notification.enums.ExchangeType;
+import com.example.bookiibookii.domain.notification.enums.NotificationCategory;
+import com.example.bookiibookii.domain.notification.enums.NotificationType;
+import com.example.bookiibookii.domain.notification.enums.RedirectType;
+import com.example.bookiibookii.domain.notification.service.NotificationStore;
+import com.example.bookiibookii.domain.notification.util.NotificationFactory;
+import com.example.bookiibookii.domain.tracker.event.DeliveryNotificationEvent;
+import com.example.bookiibookii.domain.tracker.util.DeliveryNotificationDedupKey;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DeliveryNotificationService {
+
+    private final NotificationStore notificationStore;
+    private final NotificationFactory notificationFactory;
+
+    public void send(DeliveryNotificationEvent event) {
+        if (event.receiverId() == null || event.receiverId().equals(event.actorId())) {
+            return;
+        }
+
+        try {
+            notificationStore.save(notificationFactory.create(
+                    event.receiverId(),
+                    null,
+                    NotificationCategory.SYSTEM,
+                    event.notificationType(),
+                    title(event.notificationType()),
+                    message(event),
+                    notificationFactory.toJson(payload(event)),
+                    DeliveryNotificationDedupKey.create(
+                            event.notificationType(),
+                            event.groupId(),
+                            event.exchangeRound(),
+                            event.deliveryId()
+                    )
+            ));
+        } catch (RuntimeException exception) {
+            log.warn(
+                    "Delivery notification save failed. type={}, receiverId={}, deliveryId={}",
+                    event.notificationType(),
+                    event.receiverId(),
+                    event.deliveryId(),
+                    exception
+            );
+        }
+    }
+
+    private NotificationPayload payload(DeliveryNotificationEvent event) {
+        return NotificationPayload.builder()
+                .redirectType(RedirectType.TRACKER_DETAIL)
+                .groupId(event.groupId())
+                .exchangeType(ExchangeType.DELIVERY)
+                .exchangeRound(event.exchangeRound())
+                .deliveryId(event.deliveryId())
+                .build();
+    }
+
+    private String title(NotificationType type) {
+        return switch (type) {
+            case TRACKER_SHIPMENT_REGISTERED -> "책이 오고 있어요!";
+            case TRACKER_DELIVERY_CONFIRMED -> "내가 보낸 책이 안전하게 도착했어요";
+            case TRACKER_DELIVERY_RECEIVE_REMINDER -> "책을 받으셨나요?";
+            default -> throw new IllegalArgumentException("Unsupported delivery notification type: " + type);
+        };
+    }
+
+    private String message(DeliveryNotificationEvent event) {
+        return switch (event.notificationType()) {
+            case TRACKER_SHIPMENT_REGISTERED -> String.format(
+                    "%s님이 %s을 발송했어요. 운송장 번호를 확인해보세요.",
+                    event.actorNickname(), event.bookTitle()
+            );
+            case TRACKER_DELIVERY_CONFIRMED -> String.format(
+                    "%s님이 %s을 잘 받았다고 해요!",
+                    event.actorNickname(), event.bookTitle()
+            );
+            case TRACKER_DELIVERY_RECEIVE_REMINDER -> String.format(
+                    "%s님이 %s을 보낸 지 3일이 지났어요. 책을 받으셨다면 수령 확인을 눌러주세요.",
+                    event.actorNickname(), event.bookTitle()
+            );
+            default -> throw new IllegalArgumentException(
+                    "Unsupported delivery notification type: " + event.notificationType()
+            );
+        };
+    }
+}

--- a/src/main/java/com/example/bookiibookii/domain/tracker/service/DeliveryNotificationService.java
+++ b/src/main/java/com/example/bookiibookii/domain/tracker/service/DeliveryNotificationService.java
@@ -11,6 +11,7 @@ import com.example.bookiibookii.domain.tracker.event.DeliveryNotificationEvent;
 import com.example.bookiibookii.domain.tracker.util.DeliveryNotificationDedupKey;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataAccessException;
 import org.springframework.stereotype.Service;
 
 @Slf4j
@@ -27,7 +28,7 @@ public class DeliveryNotificationService {
         }
 
         try {
-            notificationStore.save(notificationFactory.create(
+            boolean saved = notificationStore.save(notificationFactory.create(
                     event.receiverId(),
                     null,
                     NotificationCategory.SYSTEM,
@@ -41,10 +42,27 @@ public class DeliveryNotificationService {
                             event.exchangeRound(),
                             event.deliveryId()
                     )
-            ));
+            )).isPresent();
+            if (!saved) {
+                log.debug(
+                        "Duplicate delivery notification ignored. type={}, receiverId={}, deliveryId={}",
+                        event.notificationType(),
+                        event.receiverId(),
+                        event.deliveryId()
+                );
+            }
+        } catch (DataAccessException exception) {
+            // 알림 저장 실패는 비즈니스 성공을 롤백하지 않지만, 중복 외 장애는 error 로그로 남긴다.
+            log.error(
+                    "Delivery notification database operation failed. type={}, receiverId={}, deliveryId={}",
+                    event.notificationType(),
+                    event.receiverId(),
+                    event.deliveryId(),
+                    exception
+            );
         } catch (RuntimeException exception) {
-            log.warn(
-                    "Delivery notification save failed. type={}, receiverId={}, deliveryId={}",
+            log.error(
+                    "Unexpected delivery notification processing failure. type={}, receiverId={}, deliveryId={}",
                     event.notificationType(),
                     event.receiverId(),
                     event.deliveryId(),

--- a/src/main/java/com/example/bookiibookii/domain/tracker/service/PackageDeliveryService.java
+++ b/src/main/java/com/example/bookiibookii/domain/tracker/service/PackageDeliveryService.java
@@ -12,6 +12,8 @@ import com.example.bookiibookii.domain.location.exception.LocationException;
 import com.example.bookiibookii.domain.location.exception.code.LocationErrorCode;
 import com.example.bookiibookii.domain.location.repository.UserDeliveryRepository;
 import com.example.bookiibookii.domain.memberbook.entity.MemberBook;
+import com.example.bookiibookii.domain.notification.enums.NotificationType;
+import com.example.bookiibookii.domain.notification.publisher.DomainEventPublisher;
 import com.example.bookiibookii.domain.tracker.dto.req.DeliveryAddressDirectUpdateRequestDTO;
 import com.example.bookiibookii.domain.tracker.dto.req.DeliveryRegisterRequestDTO;
 import com.example.bookiibookii.domain.tracker.dto.req.DeliveryAddressSavedUpdateRequestDTO;
@@ -19,6 +21,7 @@ import com.example.bookiibookii.domain.tracker.dto.res.DeliveryAddressResponseDT
 import com.example.bookiibookii.domain.tracker.dto.res.PartnerDeliveryResponseDTO;
 import com.example.bookiibookii.domain.tracker.entity.Delivery;
 import com.example.bookiibookii.domain.tracker.entity.DeliveryAddress;
+import com.example.bookiibookii.domain.tracker.event.DeliveryNotificationEvent;
 import com.example.bookiibookii.domain.tracker.enums.ExchangeRound;
 import com.example.bookiibookii.domain.tracker.enums.ExchangeStatus;
 import com.example.bookiibookii.domain.tracker.enums.ReadingStatus;
@@ -48,6 +51,7 @@ public class PackageDeliveryService {
     private final DeliveryAddressRepository deliveryAddressRepository;
     private final DeliveryRepository deliveryRepository;
     private final UserDeliveryRepository userDeliveryRepository;
+    private final DomainEventPublisher eventPublisher;
 
     public DeliveryAddressResponseDTO getAddresses(Long groupId, User user) {
         Groups group = validatePackageGroup(groupId);
@@ -168,6 +172,17 @@ public class PackageDeliveryService {
         }
 
         me.updateExchangeStatus(ExchangeStatus.TRACKING_REGISTERED);
+
+        eventPublisher.publish(new DeliveryNotificationEvent(
+                NotificationType.TRACKER_SHIPMENT_REGISTERED,
+                me.getUser().getId(),
+                me.getUser().getNickName(),
+                delivery.getReceiver().getUser().getId(),
+                group.getId(),
+                currentExchangeRound,
+                delivery.getId(),
+                findDeliveredBookTitle(delivery)
+        ));
     }
 
     public PartnerDeliveryResponseDTO getPartnerDelivery(Long groupId, User user) {
@@ -210,6 +225,17 @@ public class PackageDeliveryService {
 
         partnerDelivery.confirmReceived(LocalDateTime.now());
         me.updateExchangeStatus(ExchangeStatus.RECEIVED_CONFIRMED);
+
+        eventPublisher.publish(new DeliveryNotificationEvent(
+                NotificationType.TRACKER_DELIVERY_CONFIRMED,
+                me.getUser().getId(),
+                me.getUser().getNickName(),
+                partnerDelivery.getSender().getUser().getId(),
+                groupId,
+                currentExchangeRound,
+                partnerDelivery.getId(),
+                findDeliveredBookTitle(partnerDelivery)
+        ));
 
         if (members.stream().allMatch(member -> member.getExchangeStatus() == ExchangeStatus.RECEIVED_CONFIRMED)) {
             LocalDateTime now = LocalDateTime.now();
@@ -388,6 +414,15 @@ public class PackageDeliveryService {
         return matchedMember.getMemberBooks().stream()
                 .filter(MemberBook::isMine)
                 .findFirst()
+                .orElseThrow(() -> new TrackerException(TrackerErrorCode.INVALID_CURRENT_MEMBER_BOOK));
+    }
+
+    public static String findDeliveredBookTitle(Delivery delivery) {
+        boolean sentBookIsMine = delivery.getExchangeRound() == ExchangeRound.FIRST_EXCHANGE;
+        return delivery.getSender().getMemberBooks().stream()
+                .filter(memberBook -> memberBook.isMine() == sentBookIsMine)
+                .findFirst()
+                .map(memberBook -> memberBook.getBook().getTitle())
                 .orElseThrow(() -> new TrackerException(TrackerErrorCode.INVALID_CURRENT_MEMBER_BOOK));
     }
 }

--- a/src/main/java/com/example/bookiibookii/domain/tracker/util/DeliveryNotificationDedupKey.java
+++ b/src/main/java/com/example/bookiibookii/domain/tracker/util/DeliveryNotificationDedupKey.java
@@ -1,0 +1,31 @@
+package com.example.bookiibookii.domain.tracker.util;
+
+import com.example.bookiibookii.domain.notification.enums.NotificationType;
+import com.example.bookiibookii.domain.tracker.enums.ExchangeRound;
+
+public final class DeliveryNotificationDedupKey {
+
+    private DeliveryNotificationDedupKey() {
+    }
+
+    public static String create(
+            NotificationType type,
+            Long groupId,
+            ExchangeRound exchangeRound,
+            String deliveryId
+    ) {
+        String eventName = switch (type) {
+            case TRACKER_SHIPMENT_REGISTERED -> "tracking-registered";
+            case TRACKER_DELIVERY_CONFIRMED -> "received-confirmed";
+            case TRACKER_DELIVERY_RECEIVE_REMINDER -> "receive-reminder";
+            default -> throw new IllegalArgumentException("Unsupported delivery notification type: " + type);
+        };
+        return String.format(
+                "delivery:%s:group:%d:round:%s:delivery:%s",
+                eventName,
+                groupId,
+                exchangeRound,
+                deliveryId
+        );
+    }
+}


### PR DESCRIPTION
## 개요
<!---- 자신이 완료한 이슈를 닫아주세요 -->
- closed #569 

<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 택배 교환 운송장 등록 알림 추가
- 택배 교환 수령 인증 완료 알림 추가
- 운송장 등록 후 72시간 미수령 리마인더 알림 추가

참고
- 72시간 기준은 DeliveryAddress가 아닌 Delivery.createdAt을 사용
- DeliveryAddress는 주소 정보이며, 운송장 등록 전에도 생성될 수 있어 리마인더 기준에서 제외
- 배송 상태 업데이트 알림은 외부 택배사 배송 API 연동이 필요하므로 이번 PR 범위에서 제외

<!---- Resolves: #(Isuue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

📣 **To Reviewers**
---
<!-- 전달사항 -->
석진 스케줄러 테스트 대비해서 한번 확인해주면 될듯해요

- Reviewers : 팀 선택
- Labels : 작업 유형, 자기 자신


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* 배송 수령 알림: 72시간 이상 미수령된 배송에 대해 정기적으로 자동 상기 알림이 발송됩니다.

* 배송 알림 이벤트 처리: 배송 관련 알림 생성 및 전송 로직이 강화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->