### PR TITLE
[Fix]#574 isMine값 잘못 노출되던 것 수정, 독서카드 링크공유 API 수정

### DIFF
--- a/src/main/java/com/example/bookiibookii/domain/group/entity/MatchedMember.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/entity/MatchedMember.java
@@ -17,7 +17,15 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Entity
-@Table(name = "matchedmember")
+@Table(
+        name = "matchedmember",
+        indexes = {
+                @Index(
+                        name = "idx_matchedmember_user_id_group_id",
+                        columnList = "user_id, group_id"
+                )
+        }
+)
 @Getter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/example/bookiibookii/domain/group/service/ApplicationService.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/service/ApplicationService.java
@@ -24,6 +24,7 @@ import com.example.bookiibookii.domain.user.exception.UserException;
 import com.example.bookiibookii.domain.user.exception.code.UserErrorCode;
 import com.example.bookiibookii.domain.user.repository.UserRepository;
 import com.example.bookiibookii.domain.memberbook.service.MemberBookService;
+import com.example.bookiibookii.domain.memberbook.service.MatchedMemberCardStateCleanupService;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -49,6 +50,7 @@ public class ApplicationService {
     private final MatchedMemberRepository matchedMemberRepository;
     private final DomainEventPublisher publisher;
     private final MemberBookService memberBookService;
+    private final MatchedMemberCardStateCleanupService matchedMemberCardStateCleanupService;
     private final UserImageS3Service userImageS3Service;
     private final BookService bookService;
 
@@ -291,6 +293,7 @@ public class ApplicationService {
                     if (member.getRole() == RoleStatus.HOST) {
                         throw new GroupException(GroupErrorCode.HOST_CANNOT_LEAVE);
                     }
+                    matchedMemberCardStateCleanupService.deleteByMatchedMember(member);
                     matchedMemberRepository.delete(member);
                 });
 

--- a/src/main/java/com/example/bookiibookii/domain/memberbook/controller/MemberBookCardController.java
+++ b/src/main/java/com/example/bookiibookii/domain/memberbook/controller/MemberBookCardController.java
@@ -9,6 +9,7 @@ import com.example.bookiibookii.domain.memberbook.dto.res.MemberCardReactionTogg
 import com.example.bookiibookii.domain.memberbook.dto.res.MemberCardCreateResponseDTO;
 import com.example.bookiibookii.domain.memberbook.dto.res.MemberCardListResponseDTO;
 import com.example.bookiibookii.domain.memberbook.dto.res.MemberCardResponseDTO;
+import com.example.bookiibookii.domain.memberbook.dto.req.ShareTokenCreateRequestDTO;
 import com.example.bookiibookii.domain.memberbook.dto.res.ShareTokenResponseDTO;
 import com.example.bookiibookii.domain.memberbook.exception.code.MemberBookCardSuccessCode;
 import com.example.bookiibookii.domain.memberbook.service.MemberBookCardService;
@@ -136,9 +137,14 @@ public class MemberBookCardController implements MemberBookCardControllerDocs {
     @PostMapping("/cards/{cardId}/share-token")
     public ApiResponse<ShareTokenResponseDTO> createShareToken(
             @AuthenticationPrincipal(expression = "user") User user,
-            @PathVariable Long cardId
+            @PathVariable Long cardId,
+            @Valid @RequestBody ShareTokenCreateRequestDTO request
     ) {
-        ShareTokenResponseDTO response = readingCardShareService.createShareToken(cardId, user);
+        ShareTokenResponseDTO response = readingCardShareService.createShareToken(
+                cardId,
+                user,
+                request.getShareLayout()
+        );
         return ApiResponse.onSuccess(MemberBookCardSuccessCode.SHARE_TOKEN_CREATED, response);
     }
 

--- a/src/main/java/com/example/bookiibookii/domain/memberbook/controller/MemberBookCardControllerDocs.java
+++ b/src/main/java/com/example/bookiibookii/domain/memberbook/controller/MemberBookCardControllerDocs.java
@@ -157,6 +157,7 @@ public interface MemberBookCardControllerDocs {
             현재 로그인한 사용자가 북마크한 memberBook 독서카드 목록을 최신 북마크 순으로 반환합니다.
 
             - **엔드포인트**: `GET /api/member-books/cards/bookmarks`
+            - 그룹에서 탈퇴(현재 MatchedMember 없음)한 그룹의 북마크는 제외합니다.
             - 각 항목은 `MemberCardResponseDTO`이며 `isBookmarked`는 true입니다.
             - 내 화면에서 숨긴 카드(`hidden=true`)는 목록에서 제외됩니다.
             """

--- a/src/main/java/com/example/bookiibookii/domain/memberbook/controller/MemberBookCardControllerDocs.java
+++ b/src/main/java/com/example/bookiibookii/domain/memberbook/controller/MemberBookCardControllerDocs.java
@@ -4,6 +4,7 @@ import com.example.bookiibookii.domain.memberbook.dto.res.PresignedUrlResponseDT
 import com.example.bookiibookii.domain.memberbook.dto.req.MemberCardCreateRequestDTO;
 import com.example.bookiibookii.domain.memberbook.dto.req.MemberCardReactionToggleRequestDTO;
 import com.example.bookiibookii.domain.memberbook.dto.req.MemberCardUpdateRequestDTO;
+import com.example.bookiibookii.domain.memberbook.dto.req.ShareTokenCreateRequestDTO;
 import com.example.bookiibookii.domain.memberbook.dto.res.MemberCardBookmarkResponseDTO;
 import com.example.bookiibookii.domain.memberbook.dto.res.MemberCardReactionToggleResponseDTO;
 import com.example.bookiibookii.domain.memberbook.dto.res.MemberCardCreateResponseDTO;
@@ -249,6 +250,8 @@ public interface MemberBookCardControllerDocs {
             독서카드 공유 버튼 클릭 시 고유 공유 링크를 발급합니다.
 
             - **엔드포인트**: `POST /api/member-books/cards/{cardId}/share-token`
+            - **요청 body**: `{ "shareLayout": "OVERLAY" }` — `OVERLAY`(이미지 위 텍스트) 또는 `SPLIT`(이미지 아래 텍스트)
+            - 링크 공유 웹 페이지는 발급 시 저장된 `shareLayout`으로 렌더링합니다.
             - 로그인 및 그룹 멤버 권한이 필요합니다.
             - 공유 불가: 삭제된 카드, 서재 제거된 memberBook, 작성자가 hidden 처리한 카드
             - 재공유 시 기존 활성 토큰은 폐기(revoke)되고 새 고유 링크가 발급됩니다.
@@ -263,6 +266,7 @@ public interface MemberBookCardControllerDocs {
     ApiResponse<ShareTokenResponseDTO> createShareToken(
             @AuthenticationPrincipal(expression = "user") User user,
             @Parameter(description = "독서카드 식별자(ID)", example = "1")
-            @PathVariable Long cardId
+            @PathVariable Long cardId,
+            @Valid @RequestBody ShareTokenCreateRequestDTO request
     );
 }

--- a/src/main/java/com/example/bookiibookii/domain/memberbook/controller/PublicReadingCardShareControllerDocs.java
+++ b/src/main/java/com/example/bookiibookii/domain/memberbook/controller/PublicReadingCardShareControllerDocs.java
@@ -23,6 +23,7 @@ public interface PublicReadingCardShareControllerDocs {
             웹 공유 페이지에서 고유 링크(token)로 독서카드를 조회합니다.
 
             - 비로그인 공개 API입니다.
+            - `shareLayout`(OVERLAY/SPLIT)과 카드 데이터를 반환하며, 웹은 이 값으로 공유 레이아웃을 분기합니다.
             - userId, groupId, 북마크, 리액션 등 내부/개인정보는 포함하지 않습니다.
             - revoked/expired 토큰, 삭제된 카드, 공유 불가 상태 카드는 404로 처리됩니다.
             """

--- a/src/main/java/com/example/bookiibookii/domain/memberbook/dto/req/ShareTokenCreateRequestDTO.java
+++ b/src/main/java/com/example/bookiibookii/domain/memberbook/dto/req/ShareTokenCreateRequestDTO.java
@@ -1,0 +1,17 @@
+package com.example.bookiibookii.domain.memberbook.dto.req;
+
+import com.example.bookiibookii.domain.memberbook.enums.ShareLayout;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Schema(description = "독서카드 공유 토큰 발급 요청")
+public class ShareTokenCreateRequestDTO {
+
+    @NotNull(message = "공유 레이아웃은 필수입니다.")
+    @Schema(description = "링크 공유 웹 렌더링 레이아웃", example = "OVERLAY", allowableValues = {"OVERLAY", "SPLIT"})
+    private ShareLayout shareLayout;
+}

--- a/src/main/java/com/example/bookiibookii/domain/memberbook/dto/res/PublicReadingCardResponseDTO.java
+++ b/src/main/java/com/example/bookiibookii/domain/memberbook/dto/res/PublicReadingCardResponseDTO.java
@@ -1,12 +1,15 @@
 package com.example.bookiibookii.domain.memberbook.dto.res;
 
 import com.example.bookiibookii.domain.memberbook.enums.CardType;
+import com.example.bookiibookii.domain.memberbook.enums.ShareLayout;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 @Builder
 @Schema(description = "공유 토큰 기반 독서카드 공개 조회 응답")
 public record PublicReadingCardResponseDTO(
+        @Schema(description = "링크 공유 웹 렌더링 레이아웃", example = "OVERLAY")
+        ShareLayout shareLayout,
         @Schema(description = "카드 타입", example = "TEXT")
         CardType cardType,
         @Schema(description = "책 제목", example = "어린 왕자")

--- a/src/main/java/com/example/bookiibookii/domain/memberbook/dto/res/ShareTokenResponseDTO.java
+++ b/src/main/java/com/example/bookiibookii/domain/memberbook/dto/res/ShareTokenResponseDTO.java
@@ -1,5 +1,6 @@
 package com.example.bookiibookii.domain.memberbook.dto.res;
 
+import com.example.bookiibookii.domain.memberbook.enums.ShareLayout;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
@@ -9,6 +10,8 @@ public record ShareTokenResponseDTO(
         @Schema(description = "공유 토큰(UUID)", example = "a1b2c3d4-e5f6-7890-abcd-ef1234567890")
         String shareToken,
         @Schema(description = "웹 공유 페이지 고유 링크", example = "https://bookiibookii.com/share/reading-card/a1b2c3d4-e5f6-7890-abcd-ef1234567890")
-        String shareUrl
+        String shareUrl,
+        @Schema(description = "저장된 링크 공유 레이아웃", example = "OVERLAY")
+        ShareLayout shareLayout
 ) {
 }

--- a/src/main/java/com/example/bookiibookii/domain/memberbook/entity/CardShareToken.java
+++ b/src/main/java/com/example/bookiibookii/domain/memberbook/entity/CardShareToken.java
@@ -1,5 +1,6 @@
 package com.example.bookiibookii.domain.memberbook.entity;
 
+import com.example.bookiibookii.domain.memberbook.enums.ShareLayout;
 import com.example.bookiibookii.domain.user.entity.User;
 import com.example.bookiibookii.global.entity.BaseEntity;
 import jakarta.persistence.*;
@@ -38,14 +39,19 @@ public class CardShareToken extends BaseEntity {
     @JoinColumn(name = "created_by_user_id", nullable = false)
     private User createdBy;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "share_layout", nullable = false, length = 20)
+    private ShareLayout shareLayout;
+
     @Column(name = "revoked_at")
     private LocalDateTime revokedAt;
 
-    public static CardShareToken create(Cards card, User createdBy) {
+    public static CardShareToken create(Cards card, User createdBy, ShareLayout shareLayout) {
         return CardShareToken.builder()
                 .card(card)
                 .token(UUID.randomUUID().toString())
                 .createdBy(createdBy)
+                .shareLayout(shareLayout)
                 .build();
     }
 

--- a/src/main/java/com/example/bookiibookii/domain/memberbook/enums/ShareLayout.java
+++ b/src/main/java/com/example/bookiibookii/domain/memberbook/enums/ShareLayout.java
@@ -1,0 +1,10 @@
+package com.example.bookiibookii.domain.memberbook.enums;
+
+/**
+ * 링크 공유 시 웹 렌더링용 독서카드 레이아웃.
+ * 앱 인스타 등 이미지 공유는 클라이언트가 동일 enum으로 로컬 렌더합니다.
+ */
+public enum ShareLayout {
+    OVERLAY,
+    SPLIT
+}

--- a/src/main/java/com/example/bookiibookii/domain/memberbook/repository/CardReactionRepository.java
+++ b/src/main/java/com/example/bookiibookii/domain/memberbook/repository/CardReactionRepository.java
@@ -3,6 +3,7 @@ package com.example.bookiibookii.domain.memberbook.repository;
 import com.example.bookiibookii.domain.memberbook.entity.CardReaction;
 import com.example.bookiibookii.domain.memberbook.enums.CardReactionType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -36,4 +37,8 @@ public interface CardReactionRepository extends JpaRepository<CardReaction, Long
             @Param("userId") Long userId,
             @Param("cardIds") List<Long> cardIds
     );
+
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM CardReaction cr WHERE cr.matchedMember.id = :matchedMemberId")
+    void deleteByMatchedMember_Id(@Param("matchedMemberId") Long matchedMemberId);
 }

--- a/src/main/java/com/example/bookiibookii/domain/memberbook/repository/MemberCardRepository.java
+++ b/src/main/java/com/example/bookiibookii/domain/memberbook/repository/MemberCardRepository.java
@@ -2,6 +2,7 @@ package com.example.bookiibookii.domain.memberbook.repository;
 
 import com.example.bookiibookii.domain.memberbook.entity.MemberCard;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -65,9 +66,17 @@ public interface MemberCardRepository extends JpaRepository<MemberCard, Long> {
         LEFT JOIN FETCH u.userImage
         WHERE mm.user.id = :userId AND mc.bookmarked = true AND mc.hidden = false
         AND c.deletedAt IS NULL
+        AND EXISTS (
+            SELECT 1 FROM MatchedMember activeMm
+            WHERE activeMm.user.id = :userId AND activeMm.group.id = mb.group.id
+        )
         ORDER BY mc.updatedAt DESC
         """)
     List<MemberCard> findByUserIdAndBookmarkedTrueWithCardDetailsOrderByCreatedAtDesc(
             @Param("userId") Long userId
     );
+
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM MemberCard mc WHERE mc.matchedMember.id = :matchedMemberId")
+    void deleteByMatchedMember_Id(@Param("matchedMemberId") Long matchedMemberId);
 }

--- a/src/main/java/com/example/bookiibookii/domain/memberbook/service/MatchedMemberCardStateCleanupService.java
+++ b/src/main/java/com/example/bookiibookii/domain/memberbook/service/MatchedMemberCardStateCleanupService.java
@@ -1,0 +1,26 @@
+package com.example.bookiibookii.domain.memberbook.service;
+
+import com.example.bookiibookii.domain.group.entity.MatchedMember;
+import com.example.bookiibookii.domain.memberbook.repository.CardReactionRepository;
+import com.example.bookiibookii.domain.memberbook.repository.MemberCardRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * MatchedMember 삭제 전 카드 부가 상태(북마크·숨김·리액션)를 정리합니다.
+ */
+@Service
+@RequiredArgsConstructor
+public class MatchedMemberCardStateCleanupService {
+
+    private final MemberCardRepository memberCardRepository;
+    private final CardReactionRepository cardReactionRepository;
+
+    @Transactional
+    public void deleteByMatchedMember(MatchedMember matchedMember) {
+        Long matchedMemberId = matchedMember.getId();
+        memberCardRepository.deleteByMatchedMember_Id(matchedMemberId);
+        cardReactionRepository.deleteByMatchedMember_Id(matchedMemberId);
+    }
+}

--- a/src/main/java/com/example/bookiibookii/domain/memberbook/service/MemberBookCardService.java
+++ b/src/main/java/com/example/bookiibookii/domain/memberbook/service/MemberBookCardService.java
@@ -252,26 +252,21 @@ public class MemberBookCardService {
      */
     @Transactional(readOnly = true)
     public List<MemberCardResponseDTO> getMyBookmarkedCards(Long userId, int presignedGetUrlExpirationMinutes) {
-        List<Cards> cards = memberCardRepository.findByUserIdAndBookmarkedTrueWithCardDetailsOrderByCreatedAtDesc(userId)
-                .stream()
-                .map(MemberCard::getCard)
+        List<MemberCard> memberCards = memberCardRepository
+                .findByUserIdAndBookmarkedTrueWithCardDetailsOrderByCreatedAtDesc(userId);
+
+        List<Long> cardIds = memberCards.stream()
+                .map(mc -> mc.getCard().getId())
                 .toList();
-
-        List<Long> cardIds = cards.stream().map(Cards::getId).toList();
         CardReactionContext reactionContext = loadCardReactionContext(userId, cardIds);
-        Map<Long, MatchedMember> viewerByGroupId = new HashMap<>();
 
-        return cards.stream()
-                .map(card -> {
-                    Long groupId = card.getMemberBook().getGroup().getId();
-                    MatchedMember viewer = viewerByGroupId.computeIfAbsent(
-                            groupId,
-                            gid -> matchedMemberRepository.findByGroup_IdAndUser_Id(gid, userId)
-                                    .orElseThrow(() -> new MemberBookException(MemberBookErrorCode.MATCHED_MEMBER_NOT_FOUND))
-                    );
-                    return buildListItemResponse(
-                            card, presignedGetUrlExpirationMinutes, true, reactionContext, viewer);
-                })
+        return memberCards.stream()
+                .map(mc -> buildListItemResponse(
+                        mc.getCard(),
+                        presignedGetUrlExpirationMinutes,
+                        true,
+                        reactionContext,
+                        mc.getMatchedMember()))
                 .toList();
     }
 

--- a/src/main/java/com/example/bookiibookii/domain/memberbook/service/MemberBookCardService.java
+++ b/src/main/java/com/example/bookiibookii/domain/memberbook/service/MemberBookCardService.java
@@ -100,13 +100,16 @@ public class MemberBookCardService {
                 : memberCardRepository.findBookmarkedCardIdsByUserIdAndCardIdIn(userId, cardIds);
 
         CardReactionContext reactionContext = loadCardReactionContext(userId, cardIds);
+        MatchedMember viewer = matchedMemberRepository.findByGroup_IdAndUser_Id(groupId, userId)
+                .orElseThrow(() -> new MemberBookException(MemberBookErrorCode.MATCHED_MEMBER_NOT_FOUND));
 
         List<MemberCardResponseDTO> cardDTOs = cards.stream()
                 .map(card -> buildListItemResponse(
                         card,
                         presignedGetUrlExpirationMinutes,
                         bookmarkedCardIds.contains(card.getId()),
-                        reactionContext
+                        reactionContext,
+                        viewer
                 ))
                 .toList();
 
@@ -127,7 +130,10 @@ public class MemberBookCardService {
 
         boolean bookmarked = stateOpt.map(MemberCard::isBookmarked).orElse(false);
         CardReactionContext reactionContext = loadCardReactionContext(userId, List.of(cardId));
-        return buildListItemResponse(card, presignedGetUrlExpirationMinutes, bookmarked, reactionContext);
+        Long groupId = card.getMemberBook().getGroup().getId();
+        MatchedMember viewer = matchedMemberRepository.findByGroup_IdAndUser_Id(groupId, userId)
+                .orElseThrow(() -> new MemberBookException(MemberBookErrorCode.MATCHED_MEMBER_NOT_FOUND));
+        return buildListItemResponse(card, presignedGetUrlExpirationMinutes, bookmarked, reactionContext, viewer);
     }
 
     /**
@@ -253,10 +259,19 @@ public class MemberBookCardService {
 
         List<Long> cardIds = cards.stream().map(Cards::getId).toList();
         CardReactionContext reactionContext = loadCardReactionContext(userId, cardIds);
+        Map<Long, MatchedMember> viewerByGroupId = new HashMap<>();
 
         return cards.stream()
-                .map(card -> buildListItemResponse(
-                        card, presignedGetUrlExpirationMinutes, true, reactionContext))
+                .map(card -> {
+                    Long groupId = card.getMemberBook().getGroup().getId();
+                    MatchedMember viewer = viewerByGroupId.computeIfAbsent(
+                            groupId,
+                            gid -> matchedMemberRepository.findByGroup_IdAndUser_Id(gid, userId)
+                                    .orElseThrow(() -> new MemberBookException(MemberBookErrorCode.MATCHED_MEMBER_NOT_FOUND))
+                    );
+                    return buildListItemResponse(
+                            card, presignedGetUrlExpirationMinutes, true, reactionContext, viewer);
+                })
                 .toList();
     }
 
@@ -587,7 +602,8 @@ public class MemberBookCardService {
             Cards card,
             int presignedGetUrlExpirationMinutes,
             boolean isBookmarked,
-            CardReactionContext reactionContext
+            CardReactionContext reactionContext,
+            MatchedMember viewer
     ) {
         MemberBook memberBook = card.getMemberBook();
         String bookTitle = "";
@@ -622,7 +638,7 @@ public class MemberBookCardService {
                 .totalPages(totalPages)
                 .genre(genre)
                 .completedAt(completedAt)
-                .isMine(memberBook != null && memberBook.isMine())
+                .isMine(isMyBookForViewer(memberBook, viewer))
                 .isBookmarked(isBookmarked)
                 .creatorName(creatorName)
                 .creatorProfileImageUrl(creatorProfileImageUrl)
@@ -709,6 +725,17 @@ public class MemberBookCardService {
                 .creatorName(resolveCreatorName(memberBook))
                 .creatorProfileImageUrl(resolveCreatorProfileImageUrl(memberBook, presignedGetUrlExpirationMinutes))
                 .build();
+    }
+
+    /**
+     * 조회자 기준 본인 책 여부. MemberBook.isMine은 카드 작성자 MatchedMember 기준이므로
+     * 그룹 카드 목록처럼 상대 카드를 함께 볼 때는 조회자 MatchedMember로 변환합니다.
+     */
+    private boolean isMyBookForViewer(MemberBook memberBook, MatchedMember viewer) {
+        if (memberBook == null || viewer == null) {
+            return false;
+        }
+        return memberBook.isMine() == memberBook.isOwnedBy(viewer);
     }
 
     private String resolveCreatorName(MemberBook memberBook) {

--- a/src/main/java/com/example/bookiibookii/domain/memberbook/service/ReadingCardShareService.java
+++ b/src/main/java/com/example/bookiibookii/domain/memberbook/service/ReadingCardShareService.java
@@ -9,6 +9,7 @@ import com.example.bookiibookii.domain.memberbook.entity.Cards;
 import com.example.bookiibookii.domain.memberbook.entity.MemberBook;
 import com.example.bookiibookii.domain.memberbook.entity.MemberCard;
 import com.example.bookiibookii.domain.memberbook.enums.CardType;
+import com.example.bookiibookii.domain.memberbook.enums.ShareLayout;
 import com.example.bookiibookii.domain.memberbook.exception.MemberBookException;
 import com.example.bookiibookii.domain.memberbook.exception.code.MemberBookErrorCode;
 import com.example.bookiibookii.domain.memberbook.repository.CardShareTokenRepository;
@@ -41,17 +42,18 @@ public class ReadingCardShareService {
     private final UserRepository userRepository;
 
     @Transactional
-    public ShareTokenResponseDTO createShareToken(Long cardId, User user) {
+    public ShareTokenResponseDTO createShareToken(Long cardId, User user, ShareLayout shareLayout) {
         Cards card = getShareableCardForMember(cardId, user.getId());
         revokeActiveTokensForCard(card.getId());
 
         CardShareToken shareToken = cardShareTokenRepository.save(
-                CardShareToken.create(card, userRepository.getReferenceById(user.getId()))
+                CardShareToken.create(card, userRepository.getReferenceById(user.getId()), shareLayout)
         );
 
         return ShareTokenResponseDTO.builder()
                 .shareToken(shareToken.getToken())
                 .shareUrl(buildShareUrl(shareToken.getToken()))
+                .shareLayout(shareToken.getShareLayout())
                 .build();
     }
 
@@ -63,7 +65,7 @@ public class ReadingCardShareService {
         Cards card = shareToken.getCard();
         validateShareableForPublic(card);
 
-        return toPublicResponse(card);
+        return toPublicResponse(card, shareToken.getShareLayout());
     }
 
     @Transactional
@@ -120,7 +122,7 @@ public class ReadingCardShareService {
                 });
     }
 
-    private PublicReadingCardResponseDTO toPublicResponse(Cards card) {
+    private PublicReadingCardResponseDTO toPublicResponse(Cards card, ShareLayout shareLayout) {
         MemberBook memberBook = card.getMemberBook();
         var book = memberBook.getBook();
         var owner = memberBook.getMatchedMember().getUser();
@@ -138,6 +140,7 @@ public class ReadingCardShareService {
         }
 
         return PublicReadingCardResponseDTO.builder()
+                .shareLayout(shareLayout)
                 .cardType(card.getCardType())
                 .bookTitle(book.getTitle())
                 .bookAuthor(book.getAuthor())


### PR DESCRIPTION
## 개요
<!---- 자신이 완료한 이슈를 닫아주세요 -->
- closed #574 
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
isMine값 잘못 노출되던 것 수정하였습니다.
 독서카드 링크공유 API 수정하였습니다.
<!---- Resolves: #(Isuue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

📣 **To Reviewers**
---
<!-- 전달사항 -->

- Reviewers : 팀 선택
- Labels : 작업 유형, 자기 자신


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 독서카드 공유 시 표시 레이아웃을 선택할 수 있도록 지원: **OVERLAY**, **SPLIT**

* **개선사항**
  * 공유 토큰 발급/공개 공유 카드 조회에 선택한 레이아웃이 반영됩니다.
  * 카드 목록의 **내 카드 여부 표시**가 조회자 기준으로 더 정확해집니다.
  * 그룹에서 탈퇴(매칭 정보 없음)한 경우, 북마크된 멤버북 독서카드 목록에서 해당 항목이 제외됩니다.

* **버그 수정**
  * 신청 취소 시 관련 카드 상태(북마크/숨김/리액션) 정리가 누락되지 않도록 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->