### PR TITLE
[Mod] 그룹스케줄러 수정, 수동스케줄러 추가

### DIFF
--- a/src/main/java/com/example/bookiibookii/domain/group/entity/MatchedMember.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/entity/MatchedMember.java
@@ -89,11 +89,14 @@ public class MatchedMember extends BaseEntity {
     @Column(name = "partner_reviewing_started_at")
     private LocalDateTime partnerReviewingStartedAt;
 
+    private static final java.time.ZoneId SEOUL_ZONE = java.time.ZoneId.of("Asia/Seoul");
+
     public void updateReadingStatus(ReadingStatus newStatus) {
-        this.readingStatus = newStatus;
-        if (newStatus == ReadingStatus.PARTNER_REVIEWING) {
-            this.partnerReviewingStartedAt = LocalDateTime.now();
+        if (this.readingStatus != ReadingStatus.PARTNER_REVIEWING
+                && newStatus == ReadingStatus.PARTNER_REVIEWING) {
+            this.partnerReviewingStartedAt = LocalDateTime.now(SEOUL_ZONE);
         }
+        this.readingStatus = newStatus;
     }
 
     public void updateExchangeStatus(ExchangeStatus newStatus) {

--- a/src/main/java/com/example/bookiibookii/domain/group/entity/MatchedMember.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/entity/MatchedMember.java
@@ -86,8 +86,14 @@ public class MatchedMember extends BaseEntity {
     @Column(name = "is_review_written", nullable = false)
     private boolean isReviewWritten = false;
 
+    @Column(name = "partner_reviewing_started_at")
+    private LocalDateTime partnerReviewingStartedAt;
+
     public void updateReadingStatus(ReadingStatus newStatus) {
         this.readingStatus = newStatus;
+        if (newStatus == ReadingStatus.PARTNER_REVIEWING) {
+            this.partnerReviewingStartedAt = LocalDateTime.now();
+        }
     }
 
     public void updateExchangeStatus(ExchangeStatus newStatus) {

--- a/src/main/java/com/example/bookiibookii/domain/group/repository/GroupsRepository.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/repository/GroupsRepository.java
@@ -106,6 +106,7 @@ public interface GroupsRepository extends JpaRepository<Groups, Long> {
     );
 
     // PARTNER_REVIEWING 진입 후 14일 이상 파트너 후기 미작성 그룹 조회
+    // partner_reviewing_started_at이 NULL인 기존 데이터는 updated_at을 기준으로 처리
     @Query(value = """
             SELECT g.* FROM `groups` g
             WHERE g.group_status = 'MATCHED'
@@ -113,7 +114,7 @@ public interface GroupsRepository extends JpaRepository<Groups, Long> {
                 SELECT COUNT(*) FROM matchedmember mm
                 WHERE mm.group_id = g.group_id
                 AND mm.reading_status = 'PARTNER_REVIEWING'
-                AND mm.partner_reviewing_started_at <= :cutoff
+                AND COALESCE(mm.partner_reviewing_started_at, mm.updated_at) <= :cutoff
             ) >= 2
             """, nativeQuery = true)
     List<Groups> findGroupsForForceComplete(@Param("cutoff") LocalDateTime cutoff);

--- a/src/main/java/com/example/bookiibookii/domain/group/repository/GroupsRepository.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/repository/GroupsRepository.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -104,9 +105,16 @@ public interface GroupsRepository extends JpaRepository<Groups, Long> {
             @Param("deletedStatus") GroupStatus deletedStatus
     );
 
-    // 독서 종료일로부터 3일이 지났는데 아직 종료되지 않은(MATCHED) 그룹 조회
-    @Query(value = "SELECT * FROM `groups` g WHERE g.group_status = 'MATCHED' " +
-            "AND DATE_ADD(g.start_date, INTERVAL (g.reading_period - 1) DAY) <= :deadline",
-            nativeQuery = true)
-    List<Groups> findGroupsPastReviewDeadline(@Param("deadline") LocalDate deadline);
+    // PARTNER_REVIEWING 진입 후 14일 이상 파트너 후기 미작성 그룹 조회
+    @Query(value = """
+            SELECT g.* FROM `groups` g
+            WHERE g.group_status = 'MATCHED'
+            AND (
+                SELECT COUNT(*) FROM matchedmember mm
+                WHERE mm.group_id = g.group_id
+                AND mm.reading_status = 'PARTNER_REVIEWING'
+                AND mm.partner_reviewing_started_at <= :cutoff
+            ) >= 2
+            """, nativeQuery = true)
+    List<Groups> findGroupsForForceComplete(@Param("cutoff") LocalDateTime cutoff);
 }

--- a/src/main/java/com/example/bookiibookii/domain/group/scheduler/GroupScheduler.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/scheduler/GroupScheduler.java
@@ -9,7 +9,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.List;
 
@@ -23,10 +23,10 @@ public class GroupScheduler {
 
     @Scheduled(cron = "0 0 3 * * *", zone="Asia/Seoul")
     public void forceCompleteGroups() {
-        log.info("[Scheduler] 리뷰 기간 만료 그룹 강제 종료 프로세스 시작");
+        log.info("[Scheduler] 파트너 후기 미작성 그룹 강제 종료 프로세스 시작");
 
-        LocalDate deadline = LocalDate.now(ZoneId.of("Asia/Seoul")).minusDays(3);
-        List<Groups> timeoutGroups = groupsRepository.findGroupsPastReviewDeadline(deadline);
+        LocalDateTime cutoff = LocalDateTime.now(ZoneId.of("Asia/Seoul")).minusDays(14);
+        List<Groups> timeoutGroups = groupsRepository.findGroupsForForceComplete(cutoff);
 
         for (Groups group : timeoutGroups) {
             try {

--- a/src/main/java/com/example/bookiibookii/domain/group/scheduler/GroupScheduler.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/scheduler/GroupScheduler.java
@@ -10,6 +10,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.List;
 
 @Slf4j
@@ -24,7 +25,7 @@ public class GroupScheduler {
     public void forceCompleteGroups() {
         log.info("[Scheduler] 리뷰 기간 만료 그룹 강제 종료 프로세스 시작");
 
-        LocalDate deadline = LocalDate.now().minusDays(3);
+        LocalDate deadline = LocalDate.now(ZoneId.of("Asia/Seoul")).minusDays(3);
         List<Groups> timeoutGroups = groupsRepository.findGroupsPastReviewDeadline(deadline);
 
         for (Groups group : timeoutGroups) {

--- a/src/main/java/com/example/bookiibookii/domain/group/service/GroupCompletionService.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/service/GroupCompletionService.java
@@ -51,7 +51,7 @@ public class GroupCompletionService {
             return;
         }
 
-        LocalDateTime completedAt = LocalDateTime.now();
+        LocalDateTime completedAt = LocalDateTime.now(java.time.ZoneId.of("Asia/Seoul"));
         members.forEach(member -> member.completeReading(completedAt));
         group.updateStatus(GroupStatus.COMPLETED);
 

--- a/src/main/java/com/example/bookiibookii/domain/group/service/GroupCompletionService.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/service/GroupCompletionService.java
@@ -7,8 +7,12 @@ import com.example.bookiibookii.domain.group.exception.GroupException;
 import com.example.bookiibookii.domain.group.exception.code.GroupErrorCode;
 import com.example.bookiibookii.domain.group.repository.GroupsRepository;
 import com.example.bookiibookii.domain.group.repository.MatchedMemberRepository;
+import com.example.bookiibookii.domain.notification.enums.ExchangeType;
+import com.example.bookiibookii.domain.notification.enums.NotificationType;
+import com.example.bookiibookii.domain.notification.publisher.DomainEventPublisher;
 import com.example.bookiibookii.domain.tracker.enums.ExchangeStatus;
 import com.example.bookiibookii.domain.tracker.enums.ReadingStatus;
+import com.example.bookiibookii.domain.tracker.event.TrackerNotificationEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -25,6 +29,7 @@ public class GroupCompletionService {
 
     private final GroupsRepository groupsRepository;
     private final MatchedMemberRepository matchedMemberRepository;
+    private final DomainEventPublisher eventPublisher;
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void forceCompleteSingleGroup(Long groupId) {
@@ -37,18 +42,27 @@ public class GroupCompletionService {
         }
 
         List<MatchedMember> members = matchedMemberRepository.findAllByGroup_Id(groupId);
-        boolean readyToComplete = members.size() == 2 && members.stream().allMatch(member ->
+        boolean readyToForceComplete = members.size() == 2 && members.stream().allMatch(member ->
                 member.getReadingStatus() == ReadingStatus.PARTNER_REVIEWING
                         && member.getExchangeStatus() == ExchangeStatus.NOT_STARTED
-                        && member.isReviewWritten()
         );
-        if (!readyToComplete) {
-            log.info("최종 교환독서 후기 작성이 완료되지 않은 그룹입니다. groupId={}", groupId);
+        if (!readyToForceComplete) {
+            log.info("강제 종료 조건 미충족 그룹입니다. groupId={}", groupId);
             return;
         }
 
         LocalDateTime completedAt = LocalDateTime.now();
         members.forEach(member -> member.completeReading(completedAt));
         group.updateStatus(GroupStatus.COMPLETED);
+
+        List<Long> receiverIds = members.stream().map(mm -> mm.getUser().getId()).toList();
+        eventPublisher.publish(new TrackerNotificationEvent(
+                NotificationType.TRACKER_GROUP_FORCE_COMPLETED,
+                null, null, null,
+                receiverIds,
+                groupId,
+                ExchangeType.from(group.getTradeType()),
+                null, null, null, null, null, null
+        ));
     }
 }

--- a/src/main/java/com/example/bookiibookii/domain/notification/enums/NotificationType.java
+++ b/src/main/java/com/example/bookiibookii/domain/notification/enums/NotificationType.java
@@ -30,6 +30,7 @@ public enum NotificationType {
     TRACKER_RETURN_SHIPMENT_REGISTERED(NotificationCategory.SYSTEM), // TRK-010 (반납 출발)
     // TODO: 외부 택배사 상태 API 연동 전까지 배송 상태 업데이트 알림(NOTI-DEL-002)은 구현하지 않는다.
     TRACKER_EXCHANGE_COMPLETED(NotificationCategory.SYSTEM),  // TRK-030 (후기작성)
+    TRACKER_GROUP_FORCE_COMPLETED(NotificationCategory.SYSTEM),
     TRACKER_COMMENT_CREATED(NotificationCategory.SYSTEM),
     TRACKER_EXCHANGE_REVIEW_CREATED(NotificationCategory.SYSTEM),
 

--- a/src/main/java/com/example/bookiibookii/domain/tracker/service/TrackerNotificationService.java
+++ b/src/main/java/com/example/bookiibookii/domain/tracker/service/TrackerNotificationService.java
@@ -55,8 +55,11 @@ public class TrackerNotificationService {
     }
 
     private boolean shouldSkipSelf(TrackerNotificationEvent event, Long receiverId) {
-        return event.notificationType() != NotificationType.TRACKER_EXCHANGE_COMPLETED
-                && receiverId.equals(event.actorId());
+        if (event.notificationType() == NotificationType.TRACKER_EXCHANGE_COMPLETED
+                || event.notificationType() == NotificationType.TRACKER_GROUP_FORCE_COMPLETED) {
+            return false;
+        }
+        return receiverId.equals(event.actorId());
     }
 
     private NotificationPayload payload(TrackerNotificationEvent event) {
@@ -79,6 +82,7 @@ public class TrackerNotificationService {
         return type == NotificationType.TRACKER_COMMENT_CREATED
                 ? RedirectType.TRACKER_COMMENT
                 : type == NotificationType.TRACKER_EXCHANGE_COMPLETED
+                || type == NotificationType.TRACKER_GROUP_FORCE_COMPLETED
                 ? RedirectType.TRACKER_HOME
                 : RedirectType.TRACKER_DETAIL;
     }
@@ -90,6 +94,7 @@ public class TrackerNotificationService {
             case TRACKER_COMMENT_CREATED -> "새로운 댓글이 달렸어요";
             case TRACKER_EXCHANGE_REVIEW_CREATED -> "파트너가 교환독서 후기를 남겼어요";
             case TRACKER_EXCHANGE_COMPLETED -> "교환독서가 종료됐어요";
+            case TRACKER_GROUP_FORCE_COMPLETED -> "교환독서가 자동 종료됐어요";
             default -> throw new IllegalArgumentException("Unsupported tracker notification type: " + type);
         };
     }
@@ -117,6 +122,8 @@ public class TrackerNotificationService {
                     "%s 교환독서가 모두 완료됐어요. 새로운 교환독서를 시작해볼까요?",
                     event.bookTitle()
             );
+            case TRACKER_GROUP_FORCE_COMPLETED ->
+                    "14일 동안 파트너 후기가 작성되지 않아 교환독서가 자동 종료됐어요.";
             default -> throw new IllegalArgumentException(
                     "Unsupported tracker notification type: " + event.notificationType()
             );
@@ -153,6 +160,11 @@ public class TrackerNotificationService {
             );
             case TRACKER_EXCHANGE_COMPLETED -> String.format(
                     "TRACKER_EXCHANGE_COMPLETED:%d:%d",
+                    receiverId,
+                    event.groupId()
+            );
+            case TRACKER_GROUP_FORCE_COMPLETED -> String.format(
+                    "TRACKER_GROUP_FORCE_COMPLETED:%d:%d",
                     receiverId,
                     event.groupId()
             );

--- a/src/main/java/com/example/bookiibookii/global/scheduler/DevSchedulerController.java
+++ b/src/main/java/com/example/bookiibookii/global/scheduler/DevSchedulerController.java
@@ -1,0 +1,48 @@
+package com.example.bookiibookii.global.scheduler;
+
+import com.example.bookiibookii.domain.group.scheduler.GroupScheduler;
+import com.example.bookiibookii.domain.tracker.scheduler.DeliveryReceiveReminderScheduler;
+import com.example.bookiibookii.domain.tracker.scheduler.DirectExchangeReminderScheduler;
+import com.example.bookiibookii.global.apiPayload.ApiResponse;
+import com.example.bookiibookii.global.apiPayload.code.GeneralSuccessCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Profile({"local", "dev"})
+@RequestMapping("/api/dev/admin/scheduler")
+@RequiredArgsConstructor
+public class DevSchedulerController {
+
+    private final WithdrawnUserCleanupScheduler withdrawnUserCleanupScheduler;
+    private final GroupScheduler groupScheduler;
+    private final DirectExchangeReminderScheduler directExchangeReminderScheduler;
+    private final DeliveryReceiveReminderScheduler deliveryReceiveReminderScheduler;
+
+    @PostMapping("/withdrawn-user/cleanup")
+    public ApiResponse<Void> runWithdrawnUserCleanup() {
+        withdrawnUserCleanupScheduler.deleteExpiredWithdrawnUsers();
+        return ApiResponse.onSuccess(GeneralSuccessCode.REQUEST_OK, null);
+    }
+
+    @PostMapping("/group/force-complete")
+    public ApiResponse<Void> runGroupForceComplete() {
+        groupScheduler.forceCompleteGroups();
+        return ApiResponse.onSuccess(GeneralSuccessCode.REQUEST_OK, null);
+    }
+
+    @PostMapping("/direct-exchange/reminder")
+    public ApiResponse<Void> runDirectExchangeReminder() {
+        directExchangeReminderScheduler.sendOverdueMeetingReminders();
+        return ApiResponse.onSuccess(GeneralSuccessCode.REQUEST_OK, null);
+    }
+
+    @PostMapping("/delivery/receive-reminder")
+    public ApiResponse<Void> runDeliveryReceiveReminder() {
+        deliveryReceiveReminderScheduler.sendReceiveReminders();
+        return ApiResponse.onSuccess(GeneralSuccessCode.REQUEST_OK, null);
+    }
+}

--- a/src/main/java/com/example/bookiibookii/global/scheduler/DevSchedulerController.java
+++ b/src/main/java/com/example/bookiibookii/global/scheduler/DevSchedulerController.java
@@ -7,12 +7,14 @@ import com.example.bookiibookii.global.apiPayload.ApiResponse;
 import com.example.bookiibookii.global.apiPayload.code.GeneralSuccessCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Profile;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @Profile({"local", "dev"})
+@PreAuthorize("hasRole('ADMIN')")
 @RequestMapping("/api/dev/admin/scheduler")
 @RequiredArgsConstructor
 public class DevSchedulerController {

--- a/src/main/java/com/example/bookiibookii/global/scheduler/WithdrawnUserCleanupScheduler.java
+++ b/src/main/java/com/example/bookiibookii/global/scheduler/WithdrawnUserCleanupScheduler.java
@@ -9,6 +9,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 
 @Slf4j
 @Component
@@ -18,11 +19,11 @@ public class WithdrawnUserCleanupScheduler {
     private final UserRepository userRepository;
 
     // 매일 새벽 3시 실행
-    @Scheduled(cron = "0 0 3 * * *")
+    @Scheduled(cron = "0 0 3 * * *", zone = "Asia/Seoul")
     @Transactional
     public void deleteExpiredWithdrawnUsers() {
 
-        LocalDateTime deleteBefore = LocalDateTime.now().minusDays(30);
+        LocalDateTime deleteBefore = LocalDateTime.now(ZoneId.of("Asia/Seoul")).minusDays(30);
         userRepository.deleteWithdrawnUsersBefore(deleteBefore);
     }
 }


### PR DESCRIPTION
## 개요
closes #577 
- WithdrawnUserCleanupScheduler: @Scheduled에 zone = "Asia/Seoul" 추가, LocalDateTime.now() → now(ZoneId.of("Asia/Seoul"))
- GroupScheduler: LocalDate.now() → now(ZoneId.of("Asia/Seoul")) 변경
- 각 스케줄러 수동 트리거 API 추가 (DevBestsellerController 패턴, local/dev 프로파일 한정)
- QA DB 기준 시각 과거로 변경 후 수동 트리거 → 리마인더 알림 정상 동작 확인    

<!---- Resolves: #(Isuue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

📣 **To Reviewers**
---
<!-- 전달사항 -->

- Reviewers : 팀 선택
- Labels : 작업 유형, 자기 자신


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 개발/운영 환경에서 관리자가 스케줄러 작업을 수동으로 실행할 수 있는 엔드포인트 추가
  * 그룹 강제 완료 시 트래커 알림이 새 타입으로 발송되도록 확장

* **버그 수정**
  * 만료/강제 완료 기준 시간을 **Asia/Seoul** 기준으로 일관되게 처리해 시간대 이슈 개선
  * 파트너 리뷰 시작 시각이 기록되어 강제 완료 대상 판정이 정확해짐
<!-- end of auto-generated comment: release notes by coderabbit.ai -->