### PR TITLE
[Refactor]#580 시간 필드 Instant 전환 및 UTC 저장 기준 통일

### DIFF
--- a/src/main/java/com/example/bookiibookii/domain/comment/dto/res/CommentCreateResDTO.java
+++ b/src/main/java/com/example/bookiibookii/domain/comment/dto/res/CommentCreateResDTO.java
@@ -4,7 +4,7 @@ import com.example.bookiibookii.domain.comment.dto.WriterDto;
 import lombok.Builder;
 import lombok.Getter;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @Getter
 @Builder
@@ -13,6 +13,6 @@ public class CommentCreateResDTO {
     private Long groupId;
     private Long parentId;
     private String content;
-    private LocalDateTime createdAt;
+    private Instant createdAt;
     private WriterDto writer;
 }

--- a/src/main/java/com/example/bookiibookii/domain/comment/dto/res/CommentTreeResDTO.java
+++ b/src/main/java/com/example/bookiibookii/domain/comment/dto/res/CommentTreeResDTO.java
@@ -4,7 +4,7 @@ import com.example.bookiibookii.domain.comment.dto.WriterDto;
 import lombok.Builder;
 import lombok.Getter;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -17,7 +17,7 @@ public class CommentTreeResDTO {
     private String content;
     private Long parentId;
     private WriterDto writer;
-    private LocalDateTime createdAt;
+    private Instant createdAt;
 
     @Builder.Default
     private List<CommentTreeResDTO> children = new ArrayList<>();

--- a/src/main/java/com/example/bookiibookii/domain/group/dto/res/MatchedMemberResponseDTO.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/dto/res/MatchedMemberResponseDTO.java
@@ -2,7 +2,7 @@ package com.example.bookiibookii.domain.group.dto.res;
 
 import lombok.Builder;
 import lombok.Getter;
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @Getter
 @Builder
@@ -13,6 +13,6 @@ public class MatchedMemberResponseDTO {
     public static class CompleteReadingResultDTO {
         private Long matchedMemberId;     // 수정된 멤버 ID
         private Integer currentReadingRate; // 최종 독서율 (100)
-        private LocalDateTime completedAt;  // 완독 시각
+        private Instant completedAt;  // 완독 시각
     }
 }

--- a/src/main/java/com/example/bookiibookii/domain/group/entity/MatchedMember.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/entity/MatchedMember.java
@@ -90,6 +90,9 @@ public class MatchedMember extends BaseEntity {
     private Instant partnerReviewingStartedAt;
 
     public void updateReadingStatus(ReadingStatus newStatus) {
+        if (newStatus == ReadingStatus.PARTNER_REVIEWING) {
+            throw new TrackerException(TrackerErrorCode.INVALID_TRACKER_STATUS);
+        }
         this.readingStatus = newStatus;
     }
 

--- a/src/main/java/com/example/bookiibookii/domain/group/entity/MatchedMember.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/entity/MatchedMember.java
@@ -12,7 +12,7 @@ import com.example.bookiibookii.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -76,25 +76,30 @@ public class MatchedMember extends BaseEntity {
 
     // 독서 시작 날짜 (교환독서 내 1차 읽는중, 2차 읽는중 시작 시점으로 설정)
     @Column(name = "reading_started_at")
-    private LocalDateTime readingStartedAt;
+    private Instant readingStartedAt;
 
     // 이거 모르겠음
     @Column(name = "completed_at")
-    private LocalDateTime completedAt;
+    private Instant completedAt;
 
     @Builder.Default
     @Column(name = "is_review_written", nullable = false)
     private boolean isReviewWritten = false;
 
     @Column(name = "partner_reviewing_started_at")
-    private LocalDateTime partnerReviewingStartedAt;
-
-    private static final java.time.ZoneId SEOUL_ZONE = java.time.ZoneId.of("Asia/Seoul");
+    private Instant partnerReviewingStartedAt;
 
     public void updateReadingStatus(ReadingStatus newStatus) {
+        this.readingStatus = newStatus;
+    }
+
+    public void updateReadingStatus(ReadingStatus newStatus, Instant changedAt) {
         if (this.readingStatus != ReadingStatus.PARTNER_REVIEWING
                 && newStatus == ReadingStatus.PARTNER_REVIEWING) {
-            this.partnerReviewingStartedAt = LocalDateTime.now(SEOUL_ZONE);
+            if (changedAt == null) {
+                throw new TrackerException(TrackerErrorCode.INVALID_TRACKER_STATUS);
+            }
+            this.partnerReviewingStartedAt = changedAt;
         }
         this.readingStatus = newStatus;
     }
@@ -107,7 +112,7 @@ public class MatchedMember extends BaseEntity {
         this.isReviewWritten = true;
     }
 
-    public void completeReading(LocalDateTime completedAt) {
+    public void completeReading(Instant completedAt) {
         if (completedAt == null) {
             throw new TrackerException(TrackerErrorCode.INVALID_TRACKER_STATUS);
         }
@@ -115,7 +120,7 @@ public class MatchedMember extends BaseEntity {
         this.completedAt = completedAt;
     }
 
-    public void startMatchedReading(MemberBook initialBook, LocalDateTime matchedAt) {
+    public void startMatchedReading(MemberBook initialBook, Instant matchedAt) {
         validateCurrentBook(initialBook);
 
         if (!initialBook.isMine()) {
@@ -129,7 +134,7 @@ public class MatchedMember extends BaseEntity {
         this.currentMemberBook = initialBook;
         this.readingStartedAt = matchedAt;
     }
-    public void changeCurrentBook(MemberBook nextBook, LocalDateTime changedAt) {
+    public void changeCurrentBook(MemberBook nextBook, Instant changedAt) {
         validateCurrentBook(nextBook);
 
         if (changedAt == null) {
@@ -143,7 +148,7 @@ public class MatchedMember extends BaseEntity {
         this.readingStartedAt = changedAt;
     }
 
-    public void changeCurrentMemberBook(MemberBook memberBook, LocalDateTime changedAt) {
+    public void changeCurrentMemberBook(MemberBook memberBook, Instant changedAt) {
         changeCurrentBook(memberBook, changedAt);
     }
 

--- a/src/main/java/com/example/bookiibookii/domain/group/entity/Meeting.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/entity/Meeting.java
@@ -21,7 +21,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.math.BigDecimal;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.Objects;
 
 @Entity
@@ -73,8 +73,8 @@ public class Meeting extends BaseEntity {
     @Column(name = "address_detail", length = 200)
     private String addressDetail;
 
-    @Column(name = "scheduled_at", nullable = false)
-    private LocalDateTime scheduledAt;
+    @Column(name = "meeting_at", nullable = false)
+    private Instant meetingAt;
 
     public static Meeting create(
             Groups group,
@@ -86,9 +86,9 @@ public class Meeting extends BaseEntity {
             BigDecimal x,
             BigDecimal y,
             String addressDetail,
-            LocalDateTime scheduledAt
+            Instant meetingAt
     ) {
-        validate(group, createdBy, exchangeRound, placeName, address, x, y, scheduledAt);
+        validate(group, createdBy, exchangeRound, placeName, address, x, y, meetingAt);
 
         return Meeting.builder()
                 .group(group)
@@ -100,7 +100,7 @@ public class Meeting extends BaseEntity {
                 .x(x)
                 .y(y)
                 .addressDetail(normalizeNullable(addressDetail))
-                .scheduledAt(scheduledAt)
+                .meetingAt(meetingAt)
                 .build();
     }
 
@@ -111,13 +111,13 @@ public class Meeting extends BaseEntity {
             BigDecimal x,
             BigDecimal y,
             String addressDetail,
-            LocalDateTime scheduledAt
+            Instant meetingAt
     ) {
         Objects.requireNonNull(placeName, "placeName must not be null");
         Objects.requireNonNull(address, "address must not be null");
         Objects.requireNonNull(x, "x must not be null");
         Objects.requireNonNull(y, "y must not be null");
-        Objects.requireNonNull(scheduledAt, "scheduledAt must not be null");
+        Objects.requireNonNull(meetingAt, "meetingAt must not be null");
 
         this.placeName = normalize(placeName);
         this.address = normalize(address);
@@ -125,7 +125,7 @@ public class Meeting extends BaseEntity {
         this.x = x;
         this.y = y;
         this.addressDetail = normalizeNullable(addressDetail);
-        this.scheduledAt = scheduledAt;
+        this.meetingAt = meetingAt;
     }
 
     public boolean hasSameScheduleAndPlace(
@@ -135,7 +135,7 @@ public class Meeting extends BaseEntity {
             BigDecimal x,
             BigDecimal y,
             String addressDetail,
-            LocalDateTime scheduledAt
+            Instant meetingAt
     ) {
         return Objects.equals(normalize(this.placeName), normalize(placeName))
                 && Objects.equals(normalize(this.address), normalize(address))
@@ -143,7 +143,7 @@ public class Meeting extends BaseEntity {
                 && sameNumber(this.x, x)
                 && sameNumber(this.y, y)
                 && Objects.equals(normalizeNullable(this.addressDetail), normalizeNullable(addressDetail))
-                && Objects.equals(this.scheduledAt, scheduledAt);
+                && Objects.equals(this.meetingAt, meetingAt);
     }
 
     private boolean sameNumber(BigDecimal current, BigDecimal requested) {
@@ -166,7 +166,7 @@ public class Meeting extends BaseEntity {
             String address,
             BigDecimal x,
             BigDecimal y,
-            LocalDateTime scheduledAt
+            Instant meetingAt
     ) {
         Objects.requireNonNull(group, "group must not be null");
         Objects.requireNonNull(createdBy, "createdBy must not be null");
@@ -175,6 +175,6 @@ public class Meeting extends BaseEntity {
         Objects.requireNonNull(address, "address must not be null");
         Objects.requireNonNull(x, "x must not be null");
         Objects.requireNonNull(y, "y must not be null");
-        Objects.requireNonNull(scheduledAt, "scheduledAt must not be null");
+        Objects.requireNonNull(meetingAt, "meetingAt must not be null");
     }
 }

--- a/src/main/java/com/example/bookiibookii/domain/group/repository/GroupQueryRepository.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/repository/GroupQueryRepository.java
@@ -23,7 +23,7 @@ import org.springframework.data.domain.*;
 import org.springframework.stereotype.Repository;
 
 import java.math.BigDecimal;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -190,7 +190,7 @@ public class GroupQueryRepository {
 
     public List<Groups> findRecentGroups(
             Long userId,
-            LocalDateTime createdAfter,
+            Instant createdAfter,
             int limit
     ) {
         return homeGroupQuery(userId)
@@ -209,7 +209,7 @@ public class GroupQueryRepository {
                         ? isbn13WithVisibleRecruitingGroups(userId)
                         : null;
         NumberExpression<Long> groupCount = groups.id.count();
-        DateTimeExpression<LocalDateTime> latestGroupCreatedAt = groups.createdAt.max();
+        DateTimeExpression<Instant> latestGroupCreatedAt = groups.createdAt.max();
 
         return queryFactory
                 .select(Projections.constructor(

--- a/src/main/java/com/example/bookiibookii/domain/group/repository/GroupsRepository.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/repository/GroupsRepository.java
@@ -13,8 +13,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 
@@ -117,5 +116,5 @@ public interface GroupsRepository extends JpaRepository<Groups, Long> {
                 AND COALESCE(mm.partner_reviewing_started_at, mm.updated_at) <= :cutoff
             ) >= 2
             """, nativeQuery = true)
-    List<Groups> findGroupsForForceComplete(@Param("cutoff") LocalDateTime cutoff);
+	    List<Groups> findGroupsForForceComplete(@Param("cutoff") Instant cutoff);
 }

--- a/src/main/java/com/example/bookiibookii/domain/group/repository/MeetingRepository.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/repository/MeetingRepository.java
@@ -20,7 +20,16 @@ import java.util.Optional;
 @Repository
 public interface MeetingRepository extends JpaRepository<Meeting, Long> {
 
-    boolean existsByGroup_IdAndExchangeRound(Long groupId, ExchangeRound exchangeRound);
+    @Query("""
+        select count(m) > 0
+        from Meeting m
+        where m.group.id = :groupId
+          and m.exchangeRound = :exchangeRound
+    """)
+    boolean existsByGroupIdAndExchangeRound(
+            @Param("groupId") Long groupId,
+            @Param("exchangeRound") ExchangeRound exchangeRound
+    );
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("""

--- a/src/main/java/com/example/bookiibookii/domain/group/repository/MeetingRepository.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/repository/MeetingRepository.java
@@ -13,7 +13,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 
@@ -65,7 +65,7 @@ public interface MeetingRepository extends JpaRepository<Meeting, Long> {
         join fetch g.book
         where g.tradeType = :tradeType
           and g.groupStatus = :groupStatus
-          and m.scheduledAt <= :cutoff
+          and m.meetingAt <= :cutoff
           and exists (
               select mm.id
               from MatchedMember mm
@@ -103,7 +103,7 @@ public interface MeetingRepository extends JpaRepository<Meeting, Long> {
           )
     """)
     List<Meeting> findDueDirectMeetingReminders(
-            @Param("cutoff") LocalDateTime cutoff,
+            @Param("cutoff") Instant cutoff,
             @Param("tradeType") TradeType tradeType,
             @Param("groupStatus") GroupStatus groupStatus,
             @Param("scheduledStatus") ExchangeStatus scheduledStatus,

--- a/src/main/java/com/example/bookiibookii/domain/group/scheduler/GroupScheduler.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/scheduler/GroupScheduler.java
@@ -9,8 +9,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
-import java.time.LocalDateTime;
-import java.time.ZoneId;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.List;
 
 @Slf4j
@@ -20,12 +21,13 @@ public class GroupScheduler {
 
     private final GroupsRepository groupsRepository;
     private final GroupCompletionService groupCompletionService;
+    private final Clock clock;
 
     @Scheduled(cron = "0 0 3 * * *", zone="Asia/Seoul")
     public void forceCompleteGroups() {
         log.info("[Scheduler] 파트너 후기 미작성 그룹 강제 종료 프로세스 시작");
 
-        LocalDateTime cutoff = LocalDateTime.now(ZoneId.of("Asia/Seoul")).minusDays(14);
+        Instant cutoff = clock.instant().minus(Duration.ofDays(14));
         List<Groups> timeoutGroups = groupsRepository.findGroupsForForceComplete(cutoff);
 
         for (Groups group : timeoutGroups) {

--- a/src/main/java/com/example/bookiibookii/domain/group/service/ApplicationService.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/service/ApplicationService.java
@@ -25,15 +25,16 @@ import com.example.bookiibookii.domain.user.exception.code.UserErrorCode;
 import com.example.bookiibookii.domain.user.repository.UserRepository;
 import com.example.bookiibookii.domain.memberbook.service.MemberBookService;
 import com.example.bookiibookii.domain.memberbook.service.MatchedMemberCardStateCleanupService;
+import com.example.bookiibookii.global.time.TimeUtils;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Clock;
+import java.time.Instant;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -53,6 +54,7 @@ public class ApplicationService {
     private final MatchedMemberCardStateCleanupService matchedMemberCardStateCleanupService;
     private final UserImageS3Service userImageS3Service;
     private final BookService bookService;
+    private final Clock clock;
 
     private static final int PRESIGNED_GET_URL_EXPIRATION_MINUTES = 60;
 
@@ -127,7 +129,7 @@ public class ApplicationService {
                     .build();
             matchedMemberRepository.save(newMember);
 
-            LocalDateTime matchedAt = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
+            Instant matchedAt = clock.instant();
 
             // 서재: MemberBook 4건(멤버당 2권)
             memberBookService.createLibraryOnMatch(group, newMember, application.getBook(), matchedAt);
@@ -140,7 +142,7 @@ public class ApplicationService {
             ));
 
             // 수락일이 독서 시작일 → 즉시 MATCHED 전환
-            group.setStartDate(LocalDate.now(ZoneId.of("Asia/Seoul")));
+            group.setStartDate(TimeUtils.todayKst());
             group.updateStatus(GroupStatus.MATCHED);
 
             // 나머지 대기자들 자동 거절 처리
@@ -176,7 +178,7 @@ public class ApplicationService {
                 .applicationId(application.getApplicationId())
                 .status(application.getApplicationStatus())
                 .groupStatus(group.getGroupStatus())
-                .updatedAt(LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy. MM. dd. HH:mm")))
+                .updatedAt(TimeUtils.formatKst(clock.instant(), DateTimeFormatter.ofPattern("yyyy. MM. dd. HH:mm")))
                 .build();
     }
 
@@ -257,7 +259,7 @@ public class ApplicationService {
         return ApplicationResponseDTO.JoinResultDTO.builder()
                 .applicationId(application.getApplicationId())
                 .status(application.getApplicationStatus().name())
-                .createdAt(LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy. MM. dd.")))
+                .createdAt(TimeUtils.formatKst(application.getCreatedAt(), DateTimeFormatter.ofPattern("yyyy. MM. dd.")))
                 .build();
     }
 
@@ -302,7 +304,7 @@ public class ApplicationService {
 
         return ApplicationResponseDTO.CancelResultDTO.builder()
                 .groupId(groupId)
-                .canceledAt(LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy. MM. dd. HH:mm")))
+                .canceledAt(TimeUtils.formatKst(clock.instant(), DateTimeFormatter.ofPattern("yyyy. MM. dd. HH:mm")))
                 .build();
     }
 
@@ -358,7 +360,7 @@ public class ApplicationService {
                 .user(guest.getId())
                 .name(guest.getNickName())
                 .profileImageUrl(profileImageUrl)
-                .createdAt(application.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy. MM. dd.")))
+                .createdAt(TimeUtils.formatKst(application.getCreatedAt(), DateTimeFormatter.ofPattern("yyyy. MM. dd.")))
                 .applyMsg(application.getApplyMsg())
                 .bookTitle(book != null ? book.getTitle() : null)
                 .bookAuthor(book != null ? book.getAuthor() : null)

--- a/src/main/java/com/example/bookiibookii/domain/group/service/GroupCompletionService.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/service/GroupCompletionService.java
@@ -19,7 +19,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
+import java.time.Clock;
+import java.time.Instant;
 import java.util.List;
 
 @Service
@@ -30,6 +31,7 @@ public class GroupCompletionService {
     private final GroupsRepository groupsRepository;
     private final MatchedMemberRepository matchedMemberRepository;
     private final DomainEventPublisher eventPublisher;
+    private final Clock clock;
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void forceCompleteSingleGroup(Long groupId) {
@@ -51,7 +53,7 @@ public class GroupCompletionService {
             return;
         }
 
-        LocalDateTime completedAt = LocalDateTime.now(java.time.ZoneId.of("Asia/Seoul"));
+        Instant completedAt = clock.instant();
         members.forEach(member -> member.completeReading(completedAt));
         group.updateStatus(GroupStatus.COMPLETED);
 

--- a/src/main/java/com/example/bookiibookii/domain/group/service/GroupService.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/service/GroupService.java
@@ -27,6 +27,7 @@ import com.example.bookiibookii.domain.user.exception.UserException;
 import com.example.bookiibookii.domain.user.exception.code.UserErrorCode;
 import com.example.bookiibookii.domain.user.service.BadWordService;
 import com.example.bookiibookii.domain.user.service.UserImageS3Service;
+import com.example.bookiibookii.global.time.TimeUtils;
 import com.example.bookiibookii.global.util.RedisUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -34,9 +35,9 @@ import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -66,6 +67,7 @@ public class GroupService {
     private final UserExchangeRepository userExchangeRepository;
     private final UserDeliveryRepository userDeliveryRepository;
     private final GroupPlaceRepository groupPlaceRepository;
+    private final Clock clock;
 
     private static final int PRESIGNED_GET_URL_EXPIRATION_MINUTES = 60;
     private static final Set<Tag> READING_STYLE_TAGS = Set.of(Tag.MEMO, Tag.POSTIT, Tag.PHOTO, Tag.All_ROUNDER);
@@ -150,7 +152,7 @@ public class GroupService {
         return GroupResponseDTO.CreateResultDTO.builder()
                 .groupId(savedGroup.getId()) //
                 .groupStatus(savedGroup.getGroupStatus()) //
-                .createdAt(LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy. MM. dd.")))
+                .createdAt(TimeUtils.formatKst(savedGroup.getCreatedAt(), DateTimeFormatter.ofPattern("yyyy. MM. dd.")))
                 .build();
     }
 
@@ -362,7 +364,7 @@ public class GroupService {
 
         return GroupResponseDTO.UpdateResultDTO.builder()
                 .groupId(group.getId())
-                .updatedAt(LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy. MM. dd. HH:mm")))
+                .updatedAt(TimeUtils.formatKst(clock.instant(), DateTimeFormatter.ofPattern("yyyy. MM. dd. HH:mm")))
                 .build();
     }
 
@@ -406,7 +408,7 @@ public class GroupService {
 
         return GroupResponseDTO.DeleteResultDTO.builder()
                 .groupId(groupId)
-                .deletedAt(LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy. MM. dd. HH:mm")))
+                .deletedAt(TimeUtils.formatKst(clock.instant(), DateTimeFormatter.ofPattern("yyyy. MM. dd. HH:mm")))
                 .build();
 
     }
@@ -453,7 +455,7 @@ public class GroupService {
                 .isHot(isHot)
                 .hostNickname(group.getHost().getNickName())
                 .hostProfileImageUrl(userProfileImageUrl(group.getHost()))
-                .createdAt(group.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy. MM. dd."))) // 그룹생성일
+                .createdAt(TimeUtils.formatKst(group.getCreatedAt(), DateTimeFormatter.ofPattern("yyyy. MM. dd."))) // 그룹생성일
                 .startDate(group.getStartDate() != null ? group.getStartDate().toString() : null)
                 .participantSlots(participantSlots)
                 .buttonStatus(buttonStatus)

--- a/src/main/java/com/example/bookiibookii/domain/group/util/HomeSeedUtil.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/util/HomeSeedUtil.java
@@ -15,6 +15,7 @@ public final class HomeSeedUtil {
     }
 
     public static String currentSeedKey() {
+        // TODO: Clock 주입 가능 구조로 바꾸면 테스트 가능한 현재시각으로 교체한다.
         return seedKey(ZonedDateTime.now(KST));
     }
 
@@ -44,6 +45,7 @@ public final class HomeSeedUtil {
     }
 
     public static Instant twentyFourHoursAgoKst() {
+        // TODO: Clock 주입 가능 구조로 바꾸면 테스트 가능한 현재시각으로 교체한다.
         return Instant.now().minusSeconds(24 * 60 * 60);
     }
 }

--- a/src/main/java/com/example/bookiibookii/domain/group/util/HomeSeedUtil.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/util/HomeSeedUtil.java
@@ -1,7 +1,9 @@
 package com.example.bookiibookii.domain.group.util;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 
 public final class HomeSeedUtil {
@@ -13,7 +15,12 @@ public final class HomeSeedUtil {
     }
 
     public static String currentSeedKey() {
-        return seedKey(LocalDateTime.now(KST));
+        return seedKey(ZonedDateTime.now(KST));
+    }
+
+    public static String seedKey(ZonedDateTime kstDateTime) {
+        int sixHourSlot = kstDateTime.getHour() / 6;
+        return kstDateTime.format(SEED_DATE_FORMATTER) + "_" + sixHourSlot;
     }
 
     public static String seedKey(LocalDateTime kstDateTime) {
@@ -36,7 +43,7 @@ public final class HomeSeedUtil {
         return userId + "_" + sixHourSeedKey;
     }
 
-    public static LocalDateTime twentyFourHoursAgoKst() {
-        return LocalDateTime.now(KST).minusHours(24);
+    public static Instant twentyFourHoursAgoKst() {
+        return Instant.now().minusSeconds(24 * 60 * 60);
     }
 }

--- a/src/main/java/com/example/bookiibookii/domain/memberbook/dto/res/LibraryMemberBookResponseDTO.java
+++ b/src/main/java/com/example/bookiibookii/domain/memberbook/dto/res/LibraryMemberBookResponseDTO.java
@@ -6,7 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @Getter
 @Builder
@@ -22,7 +22,7 @@ public class LibraryMemberBookResponseDTO {
     private String image;
     private Integer totalPages;
     private String genre;
-    private LocalDateTime completedAt;
+    private Instant completedAt;
     private Long hostId;
     private String hostNickName;
     private String hostProfileImageUrl;

--- a/src/main/java/com/example/bookiibookii/domain/memberbook/dto/res/MemberCardCreateResponseDTO.java
+++ b/src/main/java/com/example/bookiibookii/domain/memberbook/dto/res/MemberCardCreateResponseDTO.java
@@ -4,7 +4,7 @@ import com.example.bookiibookii.domain.memberbook.enums.CardType;
 import lombok.Builder;
 import lombok.Getter;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @Getter
 @Builder
@@ -15,7 +15,7 @@ public class MemberCardCreateResponseDTO {
     private String memo;
     private String quotation;
     private MemberCardImageResponseDTO cardImage;
-    private LocalDateTime createdAt;
+    private Instant createdAt;
     private String creatorName;
     private String creatorProfileImageUrl;
 }

--- a/src/main/java/com/example/bookiibookii/domain/memberbook/dto/res/MemberCardResponseDTO.java
+++ b/src/main/java/com/example/bookiibookii/domain/memberbook/dto/res/MemberCardResponseDTO.java
@@ -5,7 +5,7 @@ import com.example.bookiibookii.domain.memberbook.enums.CardType;
 import lombok.Builder;
 import lombok.Getter;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.List;
 
 @Getter
@@ -18,11 +18,11 @@ public class MemberCardResponseDTO {
     private String memo;
     private String quotation;
     private MemberCardImageResponseDTO cardImage;
-    private LocalDateTime createdAt;
+    private Instant createdAt;
     private String bookTitle;
     private Integer totalPages;
     private String genre;
-    private LocalDateTime completedAt;
+    private Instant completedAt;
     private Boolean isMine;
     private Boolean isBookmarked;
     private String creatorName;

--- a/src/main/java/com/example/bookiibookii/domain/memberbook/entity/CardShareToken.java
+++ b/src/main/java/com/example/bookiibookii/domain/memberbook/entity/CardShareToken.java
@@ -6,7 +6,7 @@ import com.example.bookiibookii.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.UUID;
 
 @Entity
@@ -44,7 +44,7 @@ public class CardShareToken extends BaseEntity {
     private ShareLayout shareLayout;
 
     @Column(name = "revoked_at")
-    private LocalDateTime revokedAt;
+    private Instant revokedAt;
 
     public static CardShareToken create(Cards card, User createdBy, ShareLayout shareLayout) {
         return CardShareToken.builder()
@@ -55,7 +55,7 @@ public class CardShareToken extends BaseEntity {
                 .build();
     }
 
-    public void revoke(LocalDateTime revokedAt) {
+    public void revoke(Instant revokedAt) {
         this.revokedAt = revokedAt;
     }
 

--- a/src/main/java/com/example/bookiibookii/domain/memberbook/entity/Cards.java
+++ b/src/main/java/com/example/bookiibookii/domain/memberbook/entity/Cards.java
@@ -5,7 +5,7 @@ import com.example.bookiibookii.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -41,7 +41,7 @@ public class Cards extends BaseEntity {
     private String quotation;
 
     @Column(name = "deleted_at")
-    private LocalDateTime deletedAt;
+    private Instant deletedAt;
 
     @OneToOne(mappedBy = "card", cascade = CascadeType.ALL, orphanRemoval = true)
     private CardImages cardImages;
@@ -62,7 +62,7 @@ public class Cards extends BaseEntity {
         this.quotation = quotation;
     }
 
-    public void markDeleted() {
-        this.deletedAt = LocalDateTime.now();
+    public void markDeleted(Instant deletedAt) {
+        this.deletedAt = deletedAt;
     }
 }

--- a/src/main/java/com/example/bookiibookii/domain/memberbook/entity/MemberBook.java
+++ b/src/main/java/com/example/bookiibookii/domain/memberbook/entity/MemberBook.java
@@ -7,7 +7,7 @@ import com.example.bookiibookii.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -57,14 +57,14 @@ public class MemberBook extends BaseEntity {
 
     /** 서재에서 제거한 시점. null이면 목록에 노출, 값이 있으면 라이브러리에서 제외 */
     @Column(name = "removed_at")
-    private LocalDateTime removedAt;
+    private Instant removedAt;
 
     @Builder.Default
     @OneToMany(mappedBy = "memberBook", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Cards> cards = new ArrayList<>();
 
-    public void markRemoved() {
-        this.removedAt = LocalDateTime.now();
+    public void markRemoved(Instant removedAt) {
+        this.removedAt = removedAt;
     }
 
     public void updateCurrentPage(int currentPage) {

--- a/src/main/java/com/example/bookiibookii/domain/memberbook/service/MemberBookCardService.java
+++ b/src/main/java/com/example/bookiibookii/domain/memberbook/service/MemberBookCardService.java
@@ -42,7 +42,8 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
+import java.time.Clock;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.EnumMap;
@@ -72,6 +73,7 @@ public class MemberBookCardService {
     private final UserImageS3Service userImageS3Service;
     private final ReadingCardShareService readingCardShareService;
     private final DomainEventPublisher eventPublisher;
+    private final Clock clock;
 
     @Transactional(readOnly = true)
     public MemberCardListResponseDTO getCardsByGroupId(Long groupId, Long userId, int presignedGetUrlExpirationMinutes) {
@@ -296,7 +298,7 @@ public class MemberBookCardService {
                     throw new MemberBookException(MemberBookErrorCode.BOOKMARKED_CARD_CANNOT_DELETE);
                 });
 
-        card.markDeleted();
+        card.markDeleted(clock.instant());
         readingCardShareService.revokeActiveTokensForCard(card.getId());
     }
 
@@ -604,7 +606,7 @@ public class MemberBookCardService {
         String bookTitle = "";
         Integer totalPages = null;
         String genre = null;
-        LocalDateTime completedAt = null;
+        Instant completedAt = null;
         if (memberBook != null && memberBook.getBook() != null) {
             bookTitle = memberBook.getBook().getTitle() != null ? memberBook.getBook().getTitle() : "";
             totalPages = memberBook.getBook().getTotalPages();

--- a/src/main/java/com/example/bookiibookii/domain/memberbook/service/MemberBookLibraryService.java
+++ b/src/main/java/com/example/bookiibookii/domain/memberbook/service/MemberBookLibraryService.java
@@ -14,6 +14,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Clock;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
@@ -27,6 +28,7 @@ public class MemberBookLibraryService {
     private final MemberBookRepository memberBookRepository;
     private final BookReviewRepository bookReviewRepository;
     private final UserImageS3Service userImageS3Service;
+    private final Clock clock;
 
     private static final int PRESIGNED_GET_URL_EXPIRATION_MINUTES = 60;
 
@@ -38,7 +40,7 @@ public class MemberBookLibraryService {
     public void removeFromLibrary(Long memberBookId, Long userId) {
         MemberBook memberBook = memberBookRepository.findByIdAndMatchedMember_User_Id(memberBookId, userId)
                 .orElseThrow(() -> new MemberBookException(MemberBookErrorCode.MEMBER_BOOK_NOT_FOUND));
-        memberBook.markRemoved();
+        memberBook.markRemoved(clock.instant());
     }
 
     /**

--- a/src/main/java/com/example/bookiibookii/domain/memberbook/service/MemberBookService.java
+++ b/src/main/java/com/example/bookiibookii/domain/memberbook/service/MemberBookService.java
@@ -14,7 +14,7 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.List;
 
 @Service
@@ -34,7 +34,7 @@ public class MemberBookService {
             Groups group,
             MatchedMember guestMember,
             Book guestBook,
-            LocalDateTime matchedAt
+            Instant matchedAt
     ) {
         MatchedMember hostMember = matchedMemberRepository
                 .findByGroup_IdAndRole(group.getId(), RoleStatus.HOST)

--- a/src/main/java/com/example/bookiibookii/domain/memberbook/service/ReadingCardShareService.java
+++ b/src/main/java/com/example/bookiibookii/domain/memberbook/service/ReadingCardShareService.java
@@ -23,7 +23,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
+import java.time.Clock;
+import java.time.Instant;
 import java.util.List;
 
 @Slf4j
@@ -40,6 +41,7 @@ public class ReadingCardShareService {
     private final CardImageS3Service cardImageS3Service;
     private final ShareWebProperties shareWebProperties;
     private final UserRepository userRepository;
+    private final Clock clock;
 
     @Transactional
     public ShareTokenResponseDTO createShareToken(Long cardId, User user, ShareLayout shareLayout) {
@@ -70,7 +72,7 @@ public class ReadingCardShareService {
 
     @Transactional
     public void revokeActiveTokensForCard(Long cardId) {
-        LocalDateTime now = LocalDateTime.now();
+        Instant now = clock.instant();
         List<CardShareToken> activeTokens = cardShareTokenRepository.findAllActiveByCardId(cardId);
         activeTokens.forEach(token -> token.revoke(now));
     }

--- a/src/main/java/com/example/bookiibookii/domain/notification/dto/NotificationResDTO.java
+++ b/src/main/java/com/example/bookiibookii/domain/notification/dto/NotificationResDTO.java
@@ -1,6 +1,6 @@
 package com.example.bookiibookii.domain.notification.dto;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 
@@ -12,7 +12,7 @@ public class NotificationResDTO {
             String title,
             String message,
             boolean isRead,
-            LocalDateTime createdAt,
+            Instant createdAt,
             Map<String, Object> payload
     ) {}
 
@@ -26,7 +26,7 @@ public class NotificationResDTO {
             Long id,
             String type,
             boolean isRead,
-            LocalDateTime readAt,
+            Instant readAt,
             Map<String, Object> payload
     ) {}
 }

--- a/src/main/java/com/example/bookiibookii/domain/notification/entity/Notification.java
+++ b/src/main/java/com/example/bookiibookii/domain/notification/entity/Notification.java
@@ -10,6 +10,7 @@ import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 
 import java.time.Instant;
+import java.util.Objects;
 
 @Entity
 @Table(
@@ -70,6 +71,7 @@ public class Notification extends BaseEntity {
 
     // Future scheduledAt/sentAt notification timestamps should also use Instant.
     public void markAsRead(Instant readAt) {
+        Objects.requireNonNull(readAt, "readAt must not be null");
         if (!this.read) {
             this.read = true;
             this.readAt = readAt;

--- a/src/main/java/com/example/bookiibookii/domain/notification/entity/Notification.java
+++ b/src/main/java/com/example/bookiibookii/domain/notification/entity/Notification.java
@@ -9,7 +9,7 @@ import lombok.*;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @Entity
 @Table(
@@ -66,12 +66,13 @@ public class Notification extends BaseEntity {
     private boolean read;
 
     @Column(name = "read_at")
-    private LocalDateTime readAt;
+    private Instant readAt;
 
-    public void markAsRead() {
+    // Future scheduledAt/sentAt notification timestamps should also use Instant.
+    public void markAsRead(Instant readAt) {
         if (!this.read) {
             this.read = true;
-            this.readAt = LocalDateTime.now();
+            this.readAt = readAt;
         }
     }
 }

--- a/src/main/java/com/example/bookiibookii/domain/notification/event/DirectExchangeNotificationEvent.java
+++ b/src/main/java/com/example/bookiibookii/domain/notification/event/DirectExchangeNotificationEvent.java
@@ -3,7 +3,7 @@ package com.example.bookiibookii.domain.notification.event;
 import com.example.bookiibookii.domain.notification.enums.NotificationType;
 import com.example.bookiibookii.domain.tracker.enums.ExchangeRound;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.UUID;
 
 public record DirectExchangeNotificationEvent(
@@ -14,7 +14,7 @@ public record DirectExchangeNotificationEvent(
         Long groupId,
         Long meetingId,
         ExchangeRound exchangeRound,
-        LocalDateTime meetingAt,
+        Instant meetingAt,
         UUID eventId,
         String bookTitle
 ) {

--- a/src/main/java/com/example/bookiibookii/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/example/bookiibookii/domain/notification/repository/NotificationRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.List;
 
 @Repository
@@ -43,7 +43,7 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
             @Param("receiverId") Long receiverId,
             @Param("category") NotificationCategory category,
             @Param("cursorRead") boolean cursorRead,
-            @Param("cursorCreatedAt") LocalDateTime cursorCreatedAt,
+            @Param("cursorCreatedAt") Instant cursorCreatedAt,
             @Param("cursorId") Long cursorId,
             Pageable pageable
     );

--- a/src/main/java/com/example/bookiibookii/domain/notification/service/DirectExchangeNotificationService.java
+++ b/src/main/java/com/example/bookiibookii/domain/notification/service/DirectExchangeNotificationService.java
@@ -20,8 +20,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
-import java.time.LocalDateTime;
-import java.time.ZoneId;
+import java.time.Clock;
+import java.time.Duration;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
@@ -31,13 +31,14 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class DirectExchangeNotificationService {
 
-    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+    private static final Duration REMINDER_DELAY = Duration.ofHours(1);
 
     private final NotificationStore notificationStore;
     private final NotificationFactory notificationFactory;
     private final MeetingRepository meetingRepository;
     private final MatchedMemberRepository matchedMemberRepository;
     private final ActiveExchangeRoundResolver activeExchangeRoundResolver;
+    private final Clock clock;
 
     public void send(DirectExchangeNotificationEvent event) {
         if (event.receiverId() == null || isSelfNotification(event) || !isCurrentlyEligible(event)) {
@@ -88,8 +89,8 @@ public class DirectExchangeNotificationService {
                 || meeting.getGroup().getTradeType() != TradeType.DIRECT
                 || meeting.getGroup().getGroupStatus() != GroupStatus.MATCHED
                 || meeting.getExchangeRound() != event.exchangeRound()
-                || !meeting.getScheduledAt().equals(event.meetingAt())
-                || meeting.getScheduledAt().isAfter(LocalDateTime.now(KST).minusHours(1))) {
+                || !meeting.getMeetingAt().equals(event.meetingAt())
+                || meeting.getMeetingAt().isAfter(clock.instant().minus(REMINDER_DELAY))) {
             return false;
         }
 

--- a/src/main/java/com/example/bookiibookii/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/example/bookiibookii/domain/notification/service/NotificationService.java
@@ -13,7 +13,8 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
+import java.time.Clock;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 
@@ -23,6 +24,7 @@ public class NotificationService {
 
     private final NotificationRepository notificationRepository;
     private final ObjectMapper objectMapper;
+    private final Clock clock;
 
     public NotificationResDTO.NotificationListRes getNotifications(
             Long receiverId,
@@ -65,7 +67,7 @@ public class NotificationService {
             throw new NotificationException(NotificationErrorCode.NOTIFICATION_FORBIDDEN);
         }
 
-        n.markAsRead();
+        n.markAsRead(clock.instant());
 
         return toReadRes(n);
     }
@@ -109,7 +111,7 @@ public class NotificationService {
     }
 
     //  cursor utils
-    private record Cursor(boolean read, LocalDateTime createdAt, Long id) {
+    private record Cursor(boolean read, Instant createdAt, Long id) {
     }
 
     private Cursor parseCursor(String cursor) {
@@ -124,7 +126,7 @@ public class NotificationService {
 
         try {
             boolean read = Boolean.parseBoolean(cursor.substring(0, first));
-            LocalDateTime createdAt = LocalDateTime.parse(cursor.substring(first + 1, last));
+            Instant createdAt = Instant.parse(cursor.substring(first + 1, last));
             Long id = Long.parseLong(cursor.substring(last + 1));
             return new Cursor(read, createdAt, id);
         } catch (Exception e) {
@@ -132,8 +134,7 @@ public class NotificationService {
         }
     }
 
-    private String buildCursor(boolean read, LocalDateTime createdAt, Long id) {
+    private String buildCursor(boolean read, Instant createdAt, Long id) {
         return read + "_" + createdAt + "_" + id;
     }
 }
-

--- a/src/main/java/com/example/bookiibookii/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/example/bookiibookii/domain/notification/service/NotificationService.java
@@ -125,13 +125,23 @@ public class NotificationService {
         }
 
         try {
-            boolean read = Boolean.parseBoolean(cursor.substring(0, first));
+            boolean read = parseCursorRead(cursor.substring(0, first));
             Instant createdAt = Instant.parse(cursor.substring(first + 1, last));
             Long id = Long.parseLong(cursor.substring(last + 1));
             return new Cursor(read, createdAt, id);
         } catch (Exception e) {
             throw new NotificationException(NotificationErrorCode.INVALID_CURSOR);
         }
+    }
+
+    private boolean parseCursorRead(String value) {
+        if ("true".equals(value)) {
+            return true;
+        }
+        if ("false".equals(value)) {
+            return false;
+        }
+        throw new NotificationException(NotificationErrorCode.INVALID_CURSOR);
     }
 
     private String buildCursor(boolean read, Instant createdAt, Long id) {

--- a/src/main/java/com/example/bookiibookii/domain/policy/dto/res/PolicyResponseDTO.java
+++ b/src/main/java/com/example/bookiibookii/domain/policy/dto/res/PolicyResponseDTO.java
@@ -2,7 +2,7 @@ package com.example.bookiibookii.domain.policy.dto.res;
 
 import com.example.bookiibookii.domain.policy.enums.PolicyType;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.List;
 
 public class PolicyResponseDTO {
@@ -18,9 +18,9 @@ public class PolicyResponseDTO {
             String title,
             String content,
             boolean required,
-            LocalDateTime effectiveFrom,
+            Instant effectiveFrom,
             boolean agreed,
-            LocalDateTime agreedAt
+            Instant agreedAt
     ) {}
 
     public record AgreePolicies(

--- a/src/main/java/com/example/bookiibookii/domain/policy/entity/PolicyDocument.java
+++ b/src/main/java/com/example/bookiibookii/domain/policy/entity/PolicyDocument.java
@@ -4,7 +4,7 @@ import com.example.bookiibookii.domain.policy.enums.PolicyType;
 import jakarta.persistence.*;
 import lombok.*;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @Entity
 @Table(
@@ -48,5 +48,5 @@ public class PolicyDocument {
      * 현재 노출할 약관 조회 시 effectiveFrom <= now 중 type별 최신 문서를 가져온다.
      */
     @Column(name = "effective_from", nullable = false)
-    private LocalDateTime effectiveFrom;
+    private Instant effectiveFrom;
 }

--- a/src/main/java/com/example/bookiibookii/domain/policy/entity/UserPolicyAgreement.java
+++ b/src/main/java/com/example/bookiibookii/domain/policy/entity/UserPolicyAgreement.java
@@ -4,7 +4,7 @@ import com.example.bookiibookii.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 import static jakarta.persistence.FetchType.LAZY;
 
@@ -47,23 +47,23 @@ public class UserPolicyAgreement {
     private boolean agreed;
 
     @Column(name = "acted_at")
-    private LocalDateTime actedAt;
+    private Instant actedAt;
 
-    public static UserPolicyAgreement agree(User user, PolicyDocument policyDocument) {
+    public static UserPolicyAgreement agree(User user, PolicyDocument policyDocument, Instant actedAt) {
         return UserPolicyAgreement.builder()
                 .user(user)
                 .policyDocument(policyDocument)
                 .agreed(true)
-                .actedAt(LocalDateTime.now())
+                .actedAt(actedAt)
                 .build();
     }
 
-    public static UserPolicyAgreement disagree(User user, PolicyDocument policyDocument) {
+    public static UserPolicyAgreement disagree(User user, PolicyDocument policyDocument, Instant actedAt) {
         return UserPolicyAgreement.builder()
                 .user(user)
                 .policyDocument(policyDocument)
                 .agreed(false)
-                .actedAt(LocalDateTime.now())
+                .actedAt(actedAt)
                 .build();
     }
 }

--- a/src/main/java/com/example/bookiibookii/domain/policy/repository/PolicyDocumentRepository.java
+++ b/src/main/java/com/example/bookiibookii/domain/policy/repository/PolicyDocumentRepository.java
@@ -5,7 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.List;
 
 public interface PolicyDocumentRepository extends JpaRepository<PolicyDocument, Long> {
@@ -23,5 +23,5 @@ public interface PolicyDocumentRepository extends JpaRepository<PolicyDocument, 
         )
         order by p.required desc, p.type asc
     """)
-    List<PolicyDocument> findCurrentPolicies(@Param("now") LocalDateTime now);
+    List<PolicyDocument> findCurrentPolicies(@Param("now") Instant now);
 }

--- a/src/main/java/com/example/bookiibookii/domain/policy/service/PolicyAgreementService.java
+++ b/src/main/java/com/example/bookiibookii/domain/policy/service/PolicyAgreementService.java
@@ -14,7 +14,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
+import java.time.Clock;
+import java.time.Instant;
 import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -27,9 +28,10 @@ public class PolicyAgreementService {
     private final PolicyDocumentRepository policyDocumentRepository;
     private final UserPolicyAgreementRepository userPolicyAgreementRepository;
     private final UserRepository userRepository;
+    private final Clock clock;
 
     public PolicyResponseDTO.AgreementStatus getMyPolicyAgreementStatus(Long userId) {
-        LocalDateTime now = LocalDateTime.now();
+        Instant now = clock.instant();
 
         List<PolicyDocument> currentPolicies =
                 policyDocumentRepository.findCurrentPolicies(now);
@@ -52,7 +54,7 @@ public class PolicyAgreementService {
                     UserPolicyAgreement latestAgreement = latestAgreementMap.get(policy.getId());
 
                     boolean agreed = latestAgreement != null && latestAgreement.isAgreed();
-                    LocalDateTime actedAt = latestAgreement != null
+                    Instant actedAt = latestAgreement != null
                             ? latestAgreement.getActedAt()
                             : null;
 
@@ -85,7 +87,7 @@ public class PolicyAgreementService {
             throw new PolicyException(PolicyErrorCode.POLICY_AGREEMENT_EMPTY);
         }
 
-        LocalDateTime now = LocalDateTime.now();
+        Instant now = clock.instant();
 
         List<PolicyDocument> currentPolicies =
                 policyDocumentRepository.findCurrentPolicies(now);
@@ -119,10 +121,10 @@ public class PolicyAgreementService {
             UserPolicyAgreement agreement;
 
             if (Boolean.TRUE.equals(item.agreed())) {
-                agreement = UserPolicyAgreement.agree(user, policyDocument);
+                agreement = UserPolicyAgreement.agree(user, policyDocument, now);
                 agreedPolicyDocumentIds.add(policyDocument.getId());
             } else {
-                agreement = UserPolicyAgreement.disagree(user, policyDocument);
+                agreement = UserPolicyAgreement.disagree(user, policyDocument, now);
             }
 
             agreementsToSave.add(agreement);

--- a/src/main/java/com/example/bookiibookii/domain/push/entity/DeviceToken.java
+++ b/src/main/java/com/example/bookiibookii/domain/push/entity/DeviceToken.java
@@ -21,7 +21,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @Entity
 @Table(
@@ -54,9 +54,9 @@ public class DeviceToken extends BaseEntity {
     private boolean active;
 
     @Column(name = "last_used_at", nullable = false)
-    private LocalDateTime lastUsedAt;
+    private Instant lastUsedAt;
 
-    public static DeviceToken register(User user, String token, DevicePlatform platform, LocalDateTime usedAt) {
+    public static DeviceToken register(User user, String token, DevicePlatform platform, Instant usedAt) {
         return DeviceToken.builder()
                 .user(user)
                 .token(token)
@@ -66,7 +66,7 @@ public class DeviceToken extends BaseEntity {
                 .build();
     }
 
-    public void refresh(User user, DevicePlatform platform, LocalDateTime usedAt) {
+    public void refresh(User user, DevicePlatform platform, Instant usedAt) {
         this.user = user;
         this.platform = platform;
         this.active = true;

--- a/src/main/java/com/example/bookiibookii/domain/push/service/DeviceTokenRegistrationExecutor.java
+++ b/src/main/java/com/example/bookiibookii/domain/push/service/DeviceTokenRegistrationExecutor.java
@@ -10,7 +10,8 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
+import java.time.Clock;
+import java.time.Instant;
 
 @Component
 @RequiredArgsConstructor
@@ -18,11 +19,12 @@ public class DeviceTokenRegistrationExecutor {
 
     private final DeviceTokenRepository deviceTokenRepository;
     private final UserRepository userRepository;
+    private final Clock clock;
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void register(Long userId, DeviceTokenRequest.Register request) {
         User user = userRepository.getReferenceById(userId);
-        LocalDateTime now = LocalDateTime.now();
+        Instant now = clock.instant();
 
         DeviceToken deviceToken = deviceTokenRepository.findByToken(request.token())
                 .map(existing -> {
@@ -39,7 +41,7 @@ public class DeviceTokenRegistrationExecutor {
         return deviceTokenRepository.findByToken(request.token())
                 .map(existing -> {
                     User user = userRepository.getReferenceById(userId);
-                    existing.refresh(user, request.platform(), LocalDateTime.now());
+                    existing.refresh(user, request.platform(), clock.instant());
                     deviceTokenRepository.saveAndFlush(existing);
                     return true;
                 })

--- a/src/main/java/com/example/bookiibookii/domain/review/dto/res/MyBookReviewsResponseDTO.java
+++ b/src/main/java/com/example/bookiibookii/domain/review/dto/res/MyBookReviewsResponseDTO.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.List;
 
 @Builder
@@ -40,10 +40,10 @@ public record MyBookReviewsResponseDTO(
             @Schema(description = "수정 가능 여부", example = "true")
             @JsonProperty("isEditable")
             boolean isEditable,
-            @Schema(description = "리뷰 작성 시각", example = "2026-06-08T10:30:00")
-            LocalDateTime createdAt,
-            @Schema(description = "리뷰 수정 시각", example = "2026-06-08T11:00:00")
-            LocalDateTime updatedAt
+            @Schema(description = "리뷰 작성 시각", example = "2026-06-08T01:30:00Z")
+            Instant createdAt,
+            @Schema(description = "리뷰 수정 시각", example = "2026-06-08T02:00:00Z")
+            Instant updatedAt
     ) {
 
         public static BookReviewItem from(BookReview review) {

--- a/src/main/java/com/example/bookiibookii/domain/review/service/MypageReviewService.java
+++ b/src/main/java/com/example/bookiibookii/domain/review/service/MypageReviewService.java
@@ -8,6 +8,7 @@ import com.example.bookiibookii.domain.review.enums.MemberReviewReaction;
 import com.example.bookiibookii.domain.review.repository.BookReviewRepository;
 import com.example.bookiibookii.domain.review.repository.MemberReviewRepository;
 import com.example.bookiibookii.domain.tracker.resolver.UserProfileImageUrlResolver;
+import com.example.bookiibookii.global.time.TimeUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -66,7 +67,7 @@ public class MypageReviewService {
                 review.getComment(),
                 exchangeType,
                 exchangeTypeLabel(exchangeType),
-                review.getCreatedAt().format(DATE_FMT)
+                TimeUtils.formatKst(review.getCreatedAt(), DATE_FMT)
         );
     }
 
@@ -81,7 +82,7 @@ public class MypageReviewService {
                 review.getReaction(),
                 partnerReviewLabel(review.getReaction()),
                 review.getComment(),
-                review.getCreatedAt().format(DATE_FMT)
+                TimeUtils.formatKst(review.getCreatedAt(), DATE_FMT)
         );
     }
 

--- a/src/main/java/com/example/bookiibookii/domain/review/service/ReviewService.java
+++ b/src/main/java/com/example/bookiibookii/domain/review/service/ReviewService.java
@@ -32,12 +32,14 @@ import com.example.bookiibookii.domain.tracker.event.TrackerNotificationEvent;
 import com.example.bookiibookii.domain.tracker.service.DeliveryAddressService;
 import com.example.bookiibookii.domain.tracker.resolver.UserProfileImageUrlResolver;
 import com.example.bookiibookii.domain.user.entity.User;
+import com.example.bookiibookii.global.time.TimeUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
+import java.time.Clock;
+import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 
@@ -58,6 +60,7 @@ public class ReviewService {
     private final DeliveryAddressService deliveryAddressService;
     private final UserProfileImageUrlResolver userProfileImageUrlResolver;
     private final DomainEventPublisher eventPublisher;
+    private final Clock clock;
 
     @Transactional
     public BookReviewResponseDTO createBookReview(
@@ -166,7 +169,7 @@ public class ReviewService {
 
         boolean partnerAlreadyReviewed = memberReviewRepository.existsByGroup_IdAndWriter_Id(group.getId(), partner.getId());
         if (partnerAlreadyReviewed) {
-            LocalDateTime completedAt = LocalDateTime.now();
+            Instant completedAt = clock.instant();
             members.forEach(member -> member.completeReading(completedAt));
             group.updateStatus(GroupStatus.COMPLETED);
         }
@@ -394,7 +397,7 @@ public class ReviewService {
                 .writerProfileImageUrl(userProfileImageUrlResolver.resolve(writer))
                 .star(bookReview.getStar())
                 .comment(bookReview.getComment())
-                .createdAt(bookReview.getCreatedAt().format(DATE_FMT))
+                .createdAt(TimeUtils.formatKst(bookReview.getCreatedAt(), DATE_FMT))
                 .build();
     }
 

--- a/src/main/java/com/example/bookiibookii/domain/support/inquiry/dto/res/InquiryResponseDTO.java
+++ b/src/main/java/com/example/bookiibookii/domain/support/inquiry/dto/res/InquiryResponseDTO.java
@@ -4,7 +4,7 @@ import com.example.bookiibookii.domain.support.inquiry.enums.SupportStatus;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Builder;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 public class InquiryResponseDTO {
     public record InquiryListDTO(
@@ -12,13 +12,13 @@ public class InquiryResponseDTO {
             Long userId,
             String nickname,
             @JsonFormat(pattern = "yyyy.MM.dd")
-            LocalDateTime createdAt,
+            Instant createdAt,
             String title,
             String content,
             SupportStatus supportStatus,
             String adminReply,
             @JsonFormat(pattern = "yyyy.MM.dd")
-            LocalDateTime resolvedAt
+            Instant resolvedAt
     ){}
 
 

--- a/src/main/java/com/example/bookiibookii/domain/support/inquiry/entity/Inquiry.java
+++ b/src/main/java/com/example/bookiibookii/domain/support/inquiry/entity/Inquiry.java
@@ -6,7 +6,7 @@ import com.example.bookiibookii.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @Entity
 @Table(name = "inquiry")
@@ -38,15 +38,15 @@ public class Inquiry extends BaseEntity {
     @Column(name = "admin_reply", length = 255)
     private String adminReply;
 
-    private LocalDateTime resolvedAt;
+    private Instant resolvedAt;
 
 
     /**
      * 관리자 답변 등록 및 상태 변경
      */
-    public void updateAnswer(String adminReply) {
+    public void updateAnswer(String adminReply, Instant resolvedAt) {
         this.adminReply = adminReply;
         this.supportStatus = SupportStatus.RESOLVED;
-        this.resolvedAt = LocalDateTime.now();
+        this.resolvedAt = resolvedAt;
     }
 }

--- a/src/main/java/com/example/bookiibookii/domain/support/inquiry/service/AdminInquiryService.java
+++ b/src/main/java/com/example/bookiibookii/domain/support/inquiry/service/AdminInquiryService.java
@@ -13,7 +13,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
+import java.time.Clock;
 
 @Service
 @RequiredArgsConstructor
@@ -21,6 +21,7 @@ import java.util.List;
 public class AdminInquiryService {
 
     private final InquiryRepository inquiryRepository;
+    private final Clock clock;
 
     /**
      * 전체 문의 리스트 조회
@@ -52,6 +53,6 @@ public class AdminInquiryService {
         Inquiry inquiry = inquiryRepository.findById(inquiryId)
                 .orElseThrow(() -> new InquiryException(InquiryErrorCode.INQUIRY_NOT_FOUND));
 
-        inquiry.updateAnswer(request.adminReply());
+        inquiry.updateAnswer(request.adminReply(), clock.instant());
     }
 }

--- a/src/main/java/com/example/bookiibookii/domain/support/notice/dto/res/NoticeResponseDTO.java
+++ b/src/main/java/com/example/bookiibookii/domain/support/notice/dto/res/NoticeResponseDTO.java
@@ -2,7 +2,7 @@ package com.example.bookiibookii.domain.support.notice.dto.res;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 public class NoticeResponseDTO {
     public record NoticeDetailDTO(
@@ -10,19 +10,19 @@ public class NoticeResponseDTO {
             String title,
             String content,
             @JsonFormat(pattern = "yyyy.MM.dd HH:mm")
-            LocalDateTime createdAt
+            Instant createdAt
     ) {}
 
     public record NoticeListDTO(
             Long id,
-            LocalDateTime createdAt,
+            Instant createdAt,
             String title,
             String summary
     ) {}
 
     public record AdminNoticeListDTO(
             Long id,
-            LocalDateTime createdAt,
+            Instant createdAt,
             String title
     ) {}
 }

--- a/src/main/java/com/example/bookiibookii/domain/support/report/dto/res/ReportResponseDTO.java
+++ b/src/main/java/com/example/bookiibookii/domain/support/report/dto/res/ReportResponseDTO.java
@@ -4,7 +4,7 @@ import com.example.bookiibookii.domain.support.inquiry.enums.SupportStatus;
 import com.example.bookiibookii.domain.support.report.enums.ReportType;
 import com.fasterxml.jackson.annotation.JsonFormat;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 public class ReportResponseDTO {
     // 신고 내역 조회 DTO
@@ -13,13 +13,13 @@ public class ReportResponseDTO {
             String reporterNickname,
             String groupName,
             @JsonFormat(pattern = "yyyy.MM.dd")
-            LocalDateTime createdAt, // 신고 날짜
+            Instant createdAt, // 신고 날짜
             ReportType reportType,
             String content,
             SupportStatus supportStatus,
             String adminReply,
             @JsonFormat(pattern = "yyyy.MM.dd")
-            LocalDateTime resolvedAt
+            Instant resolvedAt
     ) {}
 
     public record AdminReportListDTO(
@@ -30,7 +30,7 @@ public class ReportResponseDTO {
             ReportType reportType,
             SupportStatus supportStatus,
             @JsonFormat(pattern = "yyyy.MM.dd")
-            LocalDateTime resolvedAt
+            Instant resolvedAt
     ) {}
 
     // 신고 내역 조회 DTO
@@ -42,11 +42,11 @@ public class ReportResponseDTO {
             ReportType reportType,
             String content,
             @JsonFormat(pattern = "yyyy.MM.dd hh:mm")
-            LocalDateTime createdAt, // 신고 날짜
+            Instant createdAt, // 신고 날짜
             SupportStatus supportStatus,
             String adminReply,
             String adminMemo,
             @JsonFormat(pattern = "yyyy.MM.dd")
-            LocalDateTime resolvedAt
+            Instant resolvedAt
     ) {}
 }

--- a/src/main/java/com/example/bookiibookii/domain/support/report/entity/Report.java
+++ b/src/main/java/com/example/bookiibookii/domain/support/report/entity/Report.java
@@ -8,7 +8,7 @@ import com.example.bookiibookii.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @Entity
 @Table(name = "report")
@@ -51,12 +51,12 @@ public class Report extends BaseEntity {
     @Column(name = "admin_memo", length = 1000)
     private String adminMemo;
 
-    private LocalDateTime resolvedAt;
+    private Instant resolvedAt;
 
-    public void resolveReport(String adminReply, String adminMemo) {
+    public void resolveReport(String adminReply, String adminMemo, Instant resolvedAt) {
         this.supportStatus = SupportStatus.RESOLVED;
         this.adminReply = adminReply;
         this.adminMemo = adminMemo;
-        this.resolvedAt = LocalDateTime.now();
+        this.resolvedAt = resolvedAt;
     }
 }

--- a/src/main/java/com/example/bookiibookii/domain/support/report/service/AdminReportService.java
+++ b/src/main/java/com/example/bookiibookii/domain/support/report/service/AdminReportService.java
@@ -14,12 +14,15 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Clock;
+
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class AdminReportService {
     private final UserRepository userRepository;
     private final ReportRepository reportRepository;
+    private final Clock clock;
 
     @Transactional(readOnly = true)
     public Page<ReportResponseDTO.AdminReportListDTO> getAllReports(Pageable pageable) {
@@ -71,7 +74,7 @@ public class AdminReportService {
         Report report = reportRepository.findById(reportId)
                 .orElseThrow(() -> new ReportException(ReportErrorCode.REPORT_NOT_FOUND));
 
-        report.resolveReport(request.adminReply(), request.adminMemo());
+        report.resolveReport(request.adminReply(), request.adminMemo(), clock.instant());
 
         reportRepository.save(report);
 

--- a/src/main/java/com/example/bookiibookii/domain/tracker/controller/MeetingControllerDocs.java
+++ b/src/main/java/com/example/bookiibookii/domain/tracker/controller/MeetingControllerDocs.java
@@ -34,7 +34,7 @@ public interface MeetingControllerDocs {
             - 직접교환 그룹에서만 가능합니다.
             - 두 matchedMember 모두 EXCHANGING 또는 모두 RETURNING 상태여야 합니다.
             - 등록 성공 시 두 matchedMember의 ExchangeStatus가 MEETING_SCHEDULED로 변경됩니다.
-            - scheduledAt이 미래여도 이후 교환완료 확인이 가능합니다.
+            - meetingAt이 미래여도 이후 교환완료 확인이 가능합니다.
             """
     )
     @ApiResponses({
@@ -64,7 +64,7 @@ public interface MeetingControllerDocs {
                                               "x": 127.027621,
                                               "y": 37.497942,
                                               "addressDetail": "2층",
-                                              "scheduledAt": "2026-05-20T14:30:00"
+                                              "meetingAt": "2026-05-20T14:30:00+09:00"
                                             }
                                             """
                                     ),
@@ -77,7 +77,7 @@ public interface MeetingControllerDocs {
                                               "x": 127.027621,
                                               "y": 37.497942,
                                               "addressDetail": "11번 출구 앞",
-                                              "scheduledAt": "2026-05-20T14:30:00"
+                                              "meetingAt": "2026-05-20T14:30:00+09:00"
                                             }
                                             """
                                     )
@@ -95,7 +95,7 @@ public interface MeetingControllerDocs {
             HOST가 groupId 기준으로 현재 등록된 직접교환 약속을 수정합니다.
             
             - 프론트가 meetingId를 들고 있지 않아도 됩니다.
-            - 수정 가능 필드: placeName, address, zipCode, x, y, addressDetail, scheduledAt
+            - 수정 가능 필드: placeName, address, zipCode, x, y, addressDetail, meetingAt
             """
     )
     @ApiResponses({
@@ -124,7 +124,7 @@ public interface MeetingControllerDocs {
                                               "x": 127.027621,
                                               "y": 37.497942,
                                               "addressDetail": "2층",
-                                              "scheduledAt": "2026-05-20T14:30:00"
+                                              "meetingAt": "2026-05-20T14:30:00+09:00"
                                             }
                                             """
                                     ),
@@ -137,7 +137,7 @@ public interface MeetingControllerDocs {
                                               "x": 127.027621,
                                               "y": 37.497942,
                                               "addressDetail": "11번 출구 앞",
-                                              "scheduledAt": "2026-05-20T14:30:00"
+                                              "meetingAt": "2026-05-20T14:30:00+09:00"
                                             }
                                             """
                                     )

--- a/src/main/java/com/example/bookiibookii/domain/tracker/controller/MeetingControllerDocs.java
+++ b/src/main/java/com/example/bookiibookii/domain/tracker/controller/MeetingControllerDocs.java
@@ -35,6 +35,7 @@ public interface MeetingControllerDocs {
             - 두 matchedMember 모두 EXCHANGING 또는 모두 RETURNING 상태여야 합니다.
             - 등록 성공 시 두 matchedMember의 ExchangeStatus가 MEETING_SCHEDULED로 변경됩니다.
             - meetingAt이 미래여도 이후 교환완료 확인이 가능합니다.
+            - 요청 meetingAt은 offset 포함 형식(예: 2026-05-20T14:30:00+09:00), 응답 meetingAt은 UTC Z 형식(예: 2026-05-20T05:30:00Z)입니다.
             """
     )
     @ApiResponses({
@@ -96,6 +97,7 @@ public interface MeetingControllerDocs {
             
             - 프론트가 meetingId를 들고 있지 않아도 됩니다.
             - 수정 가능 필드: placeName, address, zipCode, x, y, addressDetail, meetingAt
+            - 요청 meetingAt은 offset 포함 형식(예: 2026-05-20T14:30:00+09:00), 응답 meetingAt은 UTC Z 형식(예: 2026-05-20T05:30:00Z)입니다.
             """
     )
     @ApiResponses({
@@ -156,6 +158,7 @@ public interface MeetingControllerDocs {
             
             - 조회 전 현재 로그인 사용자가 교환 단계(EXCHANGING 또는 RETURNING)인지 먼저 검증합니다.
             - 교환완료 버튼 활성화 여부는 별도로 계산하지 않습니다.
+            - 응답 meetingAt은 UTC Z 형식(예: 2026-05-20T05:30:00Z)입니다.
             """
     )
     @ApiResponses({

--- a/src/main/java/com/example/bookiibookii/domain/tracker/dto/req/MeetingRequestDTO.java
+++ b/src/main/java/com/example/bookiibookii/domain/tracker/dto/req/MeetingRequestDTO.java
@@ -9,7 +9,7 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 import java.math.BigDecimal;
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 
 @Schema(
         description = "직접 교환 약속 등록/수정 요청",
@@ -20,7 +20,7 @@ import java.time.LocalDateTime;
           "x": 127.027621,
           "y": 37.497942,
           "addressDetail": "2층",
-          "scheduledAt": "2026-05-20T14:30:00"
+          "meetingAt": "2026-05-20T14:30:00+09:00"
         }
         """
 )
@@ -55,9 +55,9 @@ public record MeetingRequestDTO(
         @Size(max = 200, message = "상세 주소는 200자 이내로 입력해주세요.")
         String addressDetail,
 
-        @Schema(description = "약속 일시", example = "2026-05-20T14:30:00", requiredMode = Schema.RequiredMode.REQUIRED)
+        @Schema(description = "약속 일시", example = "2026-05-20T14:30:00+09:00", requiredMode = Schema.RequiredMode.REQUIRED)
         @NotNull(message = "약속 일시는 필수입니다.")
-        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
-        LocalDateTime scheduledAt
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXXX")
+        OffsetDateTime meetingAt
 ) {
 }

--- a/src/main/java/com/example/bookiibookii/domain/tracker/dto/res/MeetingResponseDTO.java
+++ b/src/main/java/com/example/bookiibookii/domain/tracker/dto/res/MeetingResponseDTO.java
@@ -7,7 +7,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 import java.math.BigDecimal;
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @Builder
 @Schema(description = "직접 교환 약속 상세 응답")
@@ -20,8 +20,8 @@ public record MeetingResponseDTO(
         LocationInfo location,
         @Schema(description = "상세 주소", example = "2층 창가 자리")
         String addressDetail,
-        @Schema(description = "약속 일시", example = "2026-05-20T14:30:00")
-        LocalDateTime scheduledAt,
+        @Schema(description = "약속 일시", example = "2026-05-20T05:30:00Z")
+        Instant meetingAt,
         @Schema(description = "약속 등록자 정보")
         CreatedByInfo createdBy
 ) {
@@ -32,7 +32,7 @@ public record MeetingResponseDTO(
                 .exchangeRound(meeting.getExchangeRound())
                 .location(LocationInfo.from(meeting))
                 .addressDetail(meeting.getAddressDetail())
-                .scheduledAt(meeting.getScheduledAt())
+                .meetingAt(meeting.getMeetingAt())
                 .createdBy(CreatedByInfo.from(meeting))
                 .build();
     }

--- a/src/main/java/com/example/bookiibookii/domain/tracker/dto/res/PartnerDeliveryResponseDTO.java
+++ b/src/main/java/com/example/bookiibookii/domain/tracker/dto/res/PartnerDeliveryResponseDTO.java
@@ -4,7 +4,7 @@ import com.example.bookiibookii.domain.tracker.entity.Delivery;
 import com.example.bookiibookii.domain.tracker.enums.DeliveryCompany;
 import lombok.Builder;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @Builder
 public record PartnerDeliveryResponseDTO(
@@ -12,7 +12,7 @@ public record PartnerDeliveryResponseDTO(
         DeliveryCompany deliveryCompany,
         String deliveryCompanyName,
         String trackingNumber,
-        LocalDateTime registeredAt,
+        Instant trackingRegisteredAt,
         boolean canConfirmReceived
 ) {
     public static PartnerDeliveryResponseDTO of(Delivery delivery, boolean canConfirmReceived) {
@@ -21,7 +21,7 @@ public record PartnerDeliveryResponseDTO(
                 .deliveryCompany(delivery.getDeliveryCompany())
                 .deliveryCompanyName(delivery.getDeliveryCompany().getDisplayName())
                 .trackingNumber(delivery.getTrackingNumber())
-                .registeredAt(delivery.getCreatedAt())
+                .trackingRegisteredAt(delivery.getTrackingRegisteredAt())
                 .canConfirmReceived(canConfirmReceived)
                 .build();
     }

--- a/src/main/java/com/example/bookiibookii/domain/tracker/dto/res/TrackerMeetingResponseDTO.java
+++ b/src/main/java/com/example/bookiibookii/domain/tracker/dto/res/TrackerMeetingResponseDTO.java
@@ -5,7 +5,7 @@ import java.time.Instant;
 
 @Schema(description = "직접 교환 약속 상세 응답")
 public record TrackerMeetingResponseDTO(
-        @Schema(description = "교환 일시", example = "2026-02-05T14:30:00")
+        @Schema(description = "교환 일시", example = "2026-02-05T05:30:00Z")
         Instant meetingTime,
         @Schema(description = "장소명", example = "강남역 2번 출구 앞")
         String placeName,

--- a/src/main/java/com/example/bookiibookii/domain/tracker/dto/res/TrackerMeetingResponseDTO.java
+++ b/src/main/java/com/example/bookiibookii/domain/tracker/dto/res/TrackerMeetingResponseDTO.java
@@ -1,12 +1,12 @@
 package com.example.bookiibookii.domain.tracker.dto.res;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @Schema(description = "직접 교환 약속 상세 응답")
 public record TrackerMeetingResponseDTO(
         @Schema(description = "교환 일시", example = "2026-02-05T14:30:00")
-        LocalDateTime meetingTime,
+        Instant meetingTime,
         @Schema(description = "장소명", example = "강남역 2번 출구 앞")
         String placeName,
         @Schema(description = "주소", example = "서울특별시 강남구 강남대로 396")

--- a/src/main/java/com/example/bookiibookii/domain/tracker/dto/res/TrackerTopBannerResponse.java
+++ b/src/main/java/com/example/bookiibookii/domain/tracker/dto/res/TrackerTopBannerResponse.java
@@ -4,7 +4,7 @@ import com.example.bookiibookii.domain.tracker.enums.TrackerTopBannerType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @Builder
 @Schema(description = "트래커 메인 상단 배너")
@@ -19,7 +19,7 @@ public record TrackerTopBannerResponse(
         String titleTemplate,
         String subtitle,
         String dDayLabel,
-        LocalDateTime targetAt,
+        Instant targetAt,
         Long remainingSeconds
 ) {
 }

--- a/src/main/java/com/example/bookiibookii/domain/tracker/entity/Delivery.java
+++ b/src/main/java/com/example/bookiibookii/domain/tracker/entity/Delivery.java
@@ -8,6 +8,7 @@ import com.example.bookiibookii.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 import java.time.Instant;
+import java.util.Objects;
 
 @Entity
 @Table(
@@ -61,11 +62,10 @@ public class Delivery extends BaseEntity {
 
 
     public void complete(Instant deliveredAt) {
-        this.deliveredAt = deliveredAt;
+        this.deliveredAt = Objects.requireNonNull(deliveredAt, "deliveredAt must not be null");
     }
 
     public void confirmReceived(Instant confirmedAt) {
-        this.receivedConfirmedAt = confirmedAt;
-        this.deliveredAt = confirmedAt;
+        this.receivedConfirmedAt = Objects.requireNonNull(confirmedAt, "confirmedAt must not be null");
     }
 }

--- a/src/main/java/com/example/bookiibookii/domain/tracker/entity/Delivery.java
+++ b/src/main/java/com/example/bookiibookii/domain/tracker/entity/Delivery.java
@@ -7,7 +7,7 @@ import com.example.bookiibookii.domain.tracker.enums.ExchangeRound;
 import com.example.bookiibookii.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @Entity
 @Table(
@@ -35,11 +35,11 @@ public class Delivery extends BaseEntity {
     @Column(name = "exchange_round", nullable = false)
     private ExchangeRound exchangeRound;
 
-    @Column(name = "start_date", nullable = false)
-    private LocalDateTime startDate;
+    @Column(name = "tracking_registered_at", nullable = false)
+    private Instant trackingRegisteredAt;
 
-    @Column(name = "end_date")
-    private LocalDateTime endDate;
+    @Column(name = "delivered_at")
+    private Instant deliveredAt;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "delivery_company")
@@ -57,15 +57,15 @@ public class Delivery extends BaseEntity {
     private MatchedMember receiver;
 
     @Column(name = "received_confirmed_at")
-    private LocalDateTime receivedConfirmedAt;
+    private Instant receivedConfirmedAt;
 
 
-    public void complete(LocalDateTime completedAt) {
-        this.endDate = completedAt;
+    public void complete(Instant deliveredAt) {
+        this.deliveredAt = deliveredAt;
     }
 
-    public void confirmReceived(LocalDateTime confirmedAt) {
+    public void confirmReceived(Instant confirmedAt) {
         this.receivedConfirmedAt = confirmedAt;
-        this.endDate = confirmedAt;
+        this.deliveredAt = confirmedAt;
     }
 }

--- a/src/main/java/com/example/bookiibookii/domain/tracker/repository/DeliveryRepository.java
+++ b/src/main/java/com/example/bookiibookii/domain/tracker/repository/DeliveryRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 
@@ -51,7 +51,7 @@ public interface DeliveryRepository extends JpaRepository<Delivery, String> {
         join fetch senderBook.book
         join fetch d.receiver receiver
         join fetch receiver.user
-        where d.createdAt <= :cutoff
+        where d.trackingRegisteredAt <= :cutoff
           and d.receivedConfirmedAt is null
           and g.tradeType = com.example.bookiibookii.domain.group.enums.TradeType.DELIVERY
           and g.groupStatus = com.example.bookiibookii.domain.group.enums.GroupStatus.MATCHED
@@ -64,5 +64,5 @@ public interface DeliveryRepository extends JpaRepository<Delivery, String> {
                 and receiver.readingStatus = com.example.bookiibookii.domain.tracker.enums.ReadingStatus.RETURNING)
           )
     """)
-    List<Delivery> findReceiveReminderCandidates(@Param("cutoff") LocalDateTime cutoff);
+    List<Delivery> findReceiveReminderCandidates(@Param("cutoff") Instant cutoff);
 }

--- a/src/main/java/com/example/bookiibookii/domain/tracker/resolver/TrackerDueDateResolver.java
+++ b/src/main/java/com/example/bookiibookii/domain/tracker/resolver/TrackerDueDateResolver.java
@@ -3,6 +3,7 @@ package com.example.bookiibookii.domain.tracker.resolver;
 import com.example.bookiibookii.domain.group.entity.Groups;
 import com.example.bookiibookii.domain.group.util.ReadingPeriodDateCalculator;
 import com.example.bookiibookii.domain.tracker.enums.TrackerDisplayStatus;
+import com.example.bookiibookii.global.time.TimeConfig;
 import org.springframework.stereotype.Component;
 
 import java.time.Clock;
@@ -35,6 +36,6 @@ public class TrackerDueDateResolver {
             return null;
         }
 
-        return ReadingPeriodDateCalculator.remainingDaysUntil(dueDate, LocalDate.now(clock));
+        return ReadingPeriodDateCalculator.remainingDaysUntil(dueDate, LocalDate.now(clock.withZone(TimeConfig.KST)));
     }
 }

--- a/src/main/java/com/example/bookiibookii/domain/tracker/resolver/TrackerDueDateResolver.java
+++ b/src/main/java/com/example/bookiibookii/domain/tracker/resolver/TrackerDueDateResolver.java
@@ -14,10 +14,6 @@ public class TrackerDueDateResolver {
 
     private final Clock clock;
 
-    public TrackerDueDateResolver() {
-        this(Clock.system(ReadingPeriodDateCalculator.KST));
-    }
-
     public TrackerDueDateResolver(Clock clock) {
         this.clock = clock;
     }

--- a/src/main/java/com/example/bookiibookii/domain/tracker/resolver/TrackerTopBannerContext.java
+++ b/src/main/java/com/example/bookiibookii/domain/tracker/resolver/TrackerTopBannerContext.java
@@ -7,7 +7,7 @@ import com.example.bookiibookii.domain.tracker.enums.ExchangeStatus;
 import com.example.bookiibookii.domain.tracker.enums.ReadingStatus;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 public record TrackerTopBannerContext(
         Long groupId,
@@ -25,7 +25,7 @@ public record TrackerTopBannerContext(
         String firstExchangeSendBookTitle,
         String returnExchangeSendBookTitle,
         boolean partnerReviewWritten,
-        LocalDateTime meetingScheduledAt,
+        Instant meetingAt,
         String meetingPlaceName
 ) {
 }

--- a/src/main/java/com/example/bookiibookii/domain/tracker/resolver/TrackerTopBannerResolver.java
+++ b/src/main/java/com/example/bookiibookii/domain/tracker/resolver/TrackerTopBannerResolver.java
@@ -8,12 +8,13 @@ import com.example.bookiibookii.domain.tracker.enums.ExchangeRound;
 import com.example.bookiibookii.domain.tracker.enums.ExchangeStatus;
 import com.example.bookiibookii.domain.tracker.enums.ReadingStatus;
 import com.example.bookiibookii.domain.tracker.enums.TrackerTopBannerType;
+import com.example.bookiibookii.global.time.TimeConfig;
 import org.springframework.stereotype.Component;
 
 import java.time.Clock;
 import java.time.Duration;
+import java.time.Instant;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
@@ -65,8 +66,8 @@ public class TrackerTopBannerResolver {
     }
 
     Optional<TrackerTopBannerResponse> resolve(TrackerTopBannerContext context) {
-        LocalDate today = LocalDate.now(clock);
-        LocalDateTime now = LocalDateTime.now(clock);
+        LocalDate today = LocalDate.now(clock.withZone(TimeConfig.KST));
+        Instant now = clock.instant();
 
         if (isReading(context.readingStatus()) && context.readingEndDate() != null
                 && !context.readingEndDate().isAfter(today)) {
@@ -84,10 +85,10 @@ public class TrackerTopBannerResolver {
             ));
         }
 
-        if (isDirectExchange(context) && context.meetingScheduledAt() != null
+        if (isDirectExchange(context) && context.meetingAt() != null
                 && !isDirectExchangeCompleted(context)) {
-            long remainingSeconds = Math.max(Duration.between(now, context.meetingScheduledAt()).getSeconds(), 0L);
-            boolean meetingOverdue = !context.meetingScheduledAt().isAfter(now);
+            long remainingSeconds = Math.max(Duration.between(now, context.meetingAt()).getSeconds(), 0L);
+            boolean meetingOverdue = !context.meetingAt().isAfter(now);
             // TODO: 약속 시간이 지난 뒤 미완료 상태에서 별도 CTA/상세 문구가 필요한지 PM 확인 후 수정
             return Optional.of(banner(
                     context,
@@ -98,8 +99,8 @@ public class TrackerTopBannerResolver {
                             : DIRECT_MEETING_SCHEDULED_TITLE_TEMPLATE,
                     meetingOverdue ? null : DIRECT_MEETING_SCHEDULED_TITLE_TEMPLATE,
                     context.meetingPlaceName() + "에서 만나요.",
-                    directMeetingDDayLabel(today, context.meetingScheduledAt().toLocalDate()),
-                    context.meetingScheduledAt(),
+                    directMeetingDDayLabel(today, context.meetingAt().atZone(ReadingPeriodDateCalculator.KST).toLocalDate()),
+                    context.meetingAt(),
                     remainingSeconds
             ));
         }
@@ -198,7 +199,7 @@ public class TrackerTopBannerResolver {
             String titleTemplate,
             String subtitle,
             String dDayLabel,
-            LocalDateTime targetAt,
+            Instant targetAt,
             Long remainingSeconds
     ) {
         return TrackerTopBannerResponse.builder()
@@ -232,7 +233,7 @@ public class TrackerTopBannerResolver {
     }
 
     private boolean isDirectMeetingRegistrationRequired(TrackerTopBannerContext context) {
-        if (!isDirectExchange(context) || context.meetingScheduledAt() != null) {
+        if (!isDirectExchange(context) || context.meetingAt() != null) {
             return false;
         }
         return context.myExchangeStatus() == ExchangeStatus.MEETING_SCHEDULE_WAITING

--- a/src/main/java/com/example/bookiibookii/domain/tracker/resolver/TrackerTopBannerResolver.java
+++ b/src/main/java/com/example/bookiibookii/domain/tracker/resolver/TrackerTopBannerResolver.java
@@ -39,10 +39,6 @@ public class TrackerTopBannerResolver {
             "{nickname} 님과의 교환독서 후기를 남겨주세요.";
     private final Clock clock;
 
-    public TrackerTopBannerResolver() {
-        this(Clock.system(ReadingPeriodDateCalculator.KST));
-    }
-
     public TrackerTopBannerResolver(Clock clock) {
         this.clock = clock;
     }

--- a/src/main/java/com/example/bookiibookii/domain/tracker/scheduler/DeliveryReceiveReminderScheduler.java
+++ b/src/main/java/com/example/bookiibookii/domain/tracker/scheduler/DeliveryReceiveReminderScheduler.java
@@ -15,15 +15,14 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Clock;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
+import java.time.Duration;
+import java.time.Instant;
 
 @Slf4j
 @Component
 public class DeliveryReceiveReminderScheduler {
 
-    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
-    private static final long REMINDER_DELAY_HOURS = 72;
+    private static final Duration REMINDER_DELAY = Duration.ofHours(72);
 
     private final DeliveryRepository deliveryRepository;
     private final NotificationRepository notificationRepository;
@@ -36,7 +35,7 @@ public class DeliveryReceiveReminderScheduler {
             NotificationRepository notificationRepository,
             DomainEventPublisher eventPublisher
     ) {
-        this(deliveryRepository, notificationRepository, eventPublisher, Clock.system(KST));
+        this(deliveryRepository, notificationRepository, eventPublisher, Clock.systemUTC());
     }
 
     DeliveryReceiveReminderScheduler(
@@ -57,8 +56,7 @@ public class DeliveryReceiveReminderScheduler {
     )
     @Transactional(readOnly = true)
     public void sendReceiveReminders() {
-        LocalDateTime cutoff = LocalDateTime.ofInstant(clock.instant(), clock.getZone())
-                .minusHours(REMINDER_DELAY_HOURS);
+        Instant cutoff = clock.instant().minus(REMINDER_DELAY);
 
         for (Delivery delivery : deliveryRepository.findReceiveReminderCandidates(cutoff)) {
             try {

--- a/src/main/java/com/example/bookiibookii/domain/tracker/scheduler/DirectExchangeReminderScheduler.java
+++ b/src/main/java/com/example/bookiibookii/domain/tracker/scheduler/DirectExchangeReminderScheduler.java
@@ -18,20 +18,22 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
-import java.time.ZoneId;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.List;
 
 @Component
 @RequiredArgsConstructor
 public class DirectExchangeReminderScheduler {
 
-    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+    private static final Duration REMINDER_DELAY = Duration.ofHours(1);
 
     private final MeetingRepository meetingRepository;
     private final MatchedMemberRepository matchedMemberRepository;
     private final DomainEventPublisher eventPublisher;
     private final ActiveExchangeRoundResolver activeExchangeRoundResolver;
+    private final Clock clock;
 
     @Scheduled(
             cron = "${scheduler.direct-exchange-reminder.cron:0 */5 * * * *}",
@@ -39,7 +41,7 @@ public class DirectExchangeReminderScheduler {
     )
     @Transactional(readOnly = true)
     public void sendOverdueMeetingReminders() {
-        LocalDateTime cutoff = LocalDateTime.now(KST).minusHours(1);
+        Instant cutoff = clock.instant().minus(REMINDER_DELAY);
         List<Meeting> meetings = meetingRepository.findDueDirectMeetingReminders(
                 cutoff,
                 TradeType.DIRECT,
@@ -73,7 +75,7 @@ public class DirectExchangeReminderScheduler {
                 meeting.getGroup().getId(),
                 meeting.getId(),
                 meeting.getExchangeRound(),
-                meeting.getScheduledAt(),
+                meeting.getMeetingAt(),
                 null,
                 meeting.getGroup().getBook().getTitle()
         ));

--- a/src/main/java/com/example/bookiibookii/domain/tracker/service/MeetingService.java
+++ b/src/main/java/com/example/bookiibookii/domain/tracker/service/MeetingService.java
@@ -301,7 +301,7 @@ public class MeetingService {
 
         members.forEach(member -> {
             member.changeCurrentMemberBook(findMyBook(member), now);
-            member.updateReadingStatus(ReadingStatus.PARTNER_REVIEWING);
+            member.updateReadingStatus(ReadingStatus.PARTNER_REVIEWING, now);
             member.updateExchangeStatus(ExchangeStatus.NOT_STARTED);
         });
     }

--- a/src/main/java/com/example/bookiibookii/domain/tracker/service/MeetingService.java
+++ b/src/main/java/com/example/bookiibookii/domain/tracker/service/MeetingService.java
@@ -31,7 +31,8 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
+import java.time.Clock;
+import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 
@@ -45,6 +46,7 @@ public class MeetingService {
     private final MatchedMemberRepository matchedMemberRepository;
     private final GroupPlaceRepository groupPlaceRepository;
     private final DomainEventPublisher eventPublisher;
+    private final Clock clock;
 
     @Transactional
     public MeetingResponseDTO createMeeting(Long groupId, MeetingRequestDTO request, User user) {
@@ -68,7 +70,7 @@ public class MeetingService {
                 request.x(),
                 request.y(),
                 request.addressDetail(),
-                request.scheduledAt()
+                request.meetingAt().toInstant()
         );
 
         try {
@@ -106,7 +108,7 @@ public class MeetingService {
                 request.x(),
                 request.y(),
                 request.addressDetail(),
-                request.scheduledAt()
+                request.meetingAt().toInstant()
         );
         meeting.update(
                 request.placeName(),
@@ -115,7 +117,7 @@ public class MeetingService {
                 request.x(),
                 request.y(),
                 request.addressDetail(),
-                request.scheduledAt()
+                request.meetingAt().toInstant()
         );
         if (changed) {
             publishMeetingNotification(
@@ -278,7 +280,7 @@ public class MeetingService {
                 meeting.getGroup().getId(),
                 meeting.getId(),
                 meeting.getExchangeRound(),
-                meeting.getScheduledAt(),
+                meeting.getMeetingAt(),
                 eventId,
                 meeting.getGroup().getBook().getTitle()
         ));
@@ -286,7 +288,7 @@ public class MeetingService {
 
     private void completeMeetingPhase(List<MatchedMember> members) {
         ReadingStatus phase = validateMeetingPhase(members);
-        LocalDateTime now = LocalDateTime.now();
+        Instant now = clock.instant();
 
         if (phase == ReadingStatus.EXCHANGING) {
             members.forEach(member -> {

--- a/src/main/java/com/example/bookiibookii/domain/tracker/service/MeetingService.java
+++ b/src/main/java/com/example/bookiibookii/domain/tracker/service/MeetingService.java
@@ -56,7 +56,7 @@ public class MeetingService {
         validateHost(me);
         ExchangeRound exchangeRound = resolveExchangeRound(validateMeetingPhase(members));
 
-        if (meetingRepository.existsByGroup_IdAndExchangeRound(groupId, exchangeRound)) {
+        if (meetingRepository.existsByGroupIdAndExchangeRound(groupId, exchangeRound)) {
             throw new TrackerException(TrackerErrorCode.MEETING_ALREADY_EXISTS);
         }
 

--- a/src/main/java/com/example/bookiibookii/domain/tracker/service/PackageDeliveryService.java
+++ b/src/main/java/com/example/bookiibookii/domain/tracker/service/PackageDeliveryService.java
@@ -35,7 +35,8 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
+import java.time.Clock;
+import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 
@@ -52,6 +53,7 @@ public class PackageDeliveryService {
     private final DeliveryRepository deliveryRepository;
     private final UserDeliveryRepository userDeliveryRepository;
     private final DomainEventPublisher eventPublisher;
+    private final Clock clock;
 
     public DeliveryAddressResponseDTO getAddresses(Long groupId, User user) {
         Groups group = validatePackageGroup(groupId);
@@ -162,7 +164,7 @@ public class PackageDeliveryService {
                 .receiver(partner)
                 .deliveryCompany(request.deliveryCompany())
                 .trackingNumber(request.trackingNumber())
-                .startDate(LocalDateTime.now())
+                .trackingRegisteredAt(clock.instant())
                 .build();
 
         try {
@@ -223,7 +225,7 @@ public class PackageDeliveryService {
             throw new TrackerException(TrackerErrorCode.DELIVERY_ALREADY_RECEIVED);
         }
 
-        partnerDelivery.confirmReceived(LocalDateTime.now());
+        partnerDelivery.confirmReceived(clock.instant());
         me.updateExchangeStatus(ExchangeStatus.RECEIVED_CONFIRMED);
 
         eventPublisher.publish(new DeliveryNotificationEvent(
@@ -238,7 +240,7 @@ public class PackageDeliveryService {
         ));
 
         if (members.stream().allMatch(member -> member.getExchangeStatus() == ExchangeStatus.RECEIVED_CONFIRMED)) {
-            LocalDateTime now = LocalDateTime.now();
+            Instant now = clock.instant();
             if (currentExchangeRound == ExchangeRound.RETURN_EXCHANGE) {
                 members.forEach(member -> {
                     member.changeCurrentMemberBook(findMyBook(member), now);

--- a/src/main/java/com/example/bookiibookii/domain/tracker/service/PackageDeliveryService.java
+++ b/src/main/java/com/example/bookiibookii/domain/tracker/service/PackageDeliveryService.java
@@ -244,7 +244,7 @@ public class PackageDeliveryService {
             if (currentExchangeRound == ExchangeRound.RETURN_EXCHANGE) {
                 members.forEach(member -> {
                     member.changeCurrentMemberBook(findMyBook(member), now);
-                    member.updateReadingStatus(ReadingStatus.PARTNER_REVIEWING);
+                    member.updateReadingStatus(ReadingStatus.PARTNER_REVIEWING, now);
                     member.updateExchangeStatus(ExchangeStatus.NOT_STARTED);
                 });
                 return;

--- a/src/main/java/com/example/bookiibookii/domain/tracker/service/TrackerService.java
+++ b/src/main/java/com/example/bookiibookii/domain/tracker/service/TrackerService.java
@@ -387,7 +387,7 @@ public class TrackerService {
                 exchangeRound == ExchangeRound.FIRST_EXCHANGE ? currentBookTitle : null,
                 exchangeRound == ExchangeRound.RETURN_EXCHANGE ? currentBookTitle : null,
                 me.isReviewWritten(),
-                meeting == null ? null : meeting.getScheduledAt(),
+                meeting == null ? null : meeting.getMeetingAt(),
                 meeting == null ? null : meeting.getPlaceName()
         );
     }

--- a/src/main/java/com/example/bookiibookii/domain/user/entity/ProfileShareToken.java
+++ b/src/main/java/com/example/bookiibookii/domain/user/entity/ProfileShareToken.java
@@ -4,7 +4,7 @@ import com.example.bookiibookii.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.UUID;
 
 @Entity
@@ -34,7 +34,7 @@ public class ProfileShareToken extends BaseEntity {
     private String token;
 
     @Column(name = "revoked_at")
-    private LocalDateTime revokedAt;
+    private Instant revokedAt;
 
     public static ProfileShareToken create(User user) {
         return ProfileShareToken.builder()
@@ -43,7 +43,7 @@ public class ProfileShareToken extends BaseEntity {
                 .build();
     }
 
-    public void revoke(LocalDateTime revokedAt) {
+    public void revoke(Instant revokedAt) {
         if (revokedAt == null) {
             throw new IllegalArgumentException("revokedAt must not be null");
         }

--- a/src/main/java/com/example/bookiibookii/domain/user/enums/AgeGroup.java
+++ b/src/main/java/com/example/bookiibookii/domain/user/enums/AgeGroup.java
@@ -1,5 +1,7 @@
 package com.example.bookiibookii.domain.user.enums;
 
+import com.example.bookiibookii.global.time.TimeUtils;
+
 import java.time.LocalDate;
 import java.time.Period;
 
@@ -11,7 +13,7 @@ public enum AgeGroup {
     ;
 
     public static AgeGroup from(LocalDate birth) {
-        int age = Period.between(birth, LocalDate.now()).getYears();
+        int age = Period.between(birth, TimeUtils.todayKst()).getYears();
         if (age < 20) return TEENS;
         if (age < 30) return TWENTIES;
         if (age < 40) return THIRTIES;

--- a/src/main/java/com/example/bookiibookii/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/bookiibookii/domain/user/repository/UserRepository.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Repository;
 
 import jakarta.persistence.LockModeType;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 
@@ -49,7 +49,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
     WHERE u.status = 'WITHDRAWN'
     AND u.updatedAt <= :deleteBefore
     """)
-    int deleteWithdrawnUsersBefore(@Param("deleteBefore") LocalDateTime deleteBefore);
+    int deleteWithdrawnUsersBefore(@Param("deleteBefore") Instant deleteBefore);
 
     /*
     // 태그 기반 매칭 후보 조회

--- a/src/main/java/com/example/bookiibookii/domain/user/service/BookshelfService.java
+++ b/src/main/java/com/example/bookiibookii/domain/user/service/BookshelfService.java
@@ -20,7 +20,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -55,7 +55,7 @@ public class BookshelfService {
     private List<BookshelfResponseDTO.CompletedBookDto> buildCompletedBooks(Long userId) {
         List<MemberBook> memberBooks = memberBookRepository.findCompletedBooksByUserId(userId);
 
-        Map<Long, LocalDateTime> completionDateByGroupId = matchedMemberRepository
+        Map<Long, Instant> completionDateByGroupId = matchedMemberRepository
                 .findCompletedByUserId(userId)
                 .stream()
                 .collect(Collectors.toMap(
@@ -74,7 +74,7 @@ public class BookshelfService {
                 .map(mb -> {
                     Book book = mb.getGroup().getBook();
                     BookReview review = reviewByMemberBookId.get(mb.getId());
-                    LocalDateTime completedAt = completionDateByGroupId.get(mb.getGroup().getId());
+                    Instant completedAt = completionDateByGroupId.get(mb.getGroup().getId());
                     return new BookshelfResponseDTO.CompletedBookDto(
                             mb.getId(),
                             book.getTitle(),
@@ -82,7 +82,7 @@ public class BookshelfService {
                             book.getImage(),
                             book.getCategory() != null ? book.getCategory().name() : null,
                             review != null ? review.getStar() : null,
-                            completedAt != null ? completedAt.toLocalDate() : null
+                            completedAt != null ? completedAt.atZone(com.example.bookiibookii.global.time.TimeConfig.KST).toLocalDate() : null
                     );
                 })
                 .toList();

--- a/src/main/java/com/example/bookiibookii/domain/user/service/ProfileShareService.java
+++ b/src/main/java/com/example/bookiibookii/domain/user/service/ProfileShareService.java
@@ -19,7 +19,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
+import java.time.Clock;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -37,6 +38,7 @@ public class ProfileShareService {
     private final BookReviewRepository bookReviewRepository;
     private final UserImageS3Service userImageS3Service;
     private final ShareWebProperties shareWebProperties;
+    private final Clock clock;
 
     @Transactional
     public ProfileShareTokenResponseDTO createShareToken(User user) {
@@ -68,7 +70,7 @@ public class ProfileShareService {
 
     @Transactional
     public void revokeActiveTokensForUser(Long userId) {
-        LocalDateTime now = LocalDateTime.now();
+        Instant now = clock.instant();
         List<ProfileShareToken> activeTokens = profileShareTokenRepository.findAllActiveByUserId(userId);
         activeTokens.forEach(token -> token.revoke(now));
     }

--- a/src/main/java/com/example/bookiibookii/domain/user/service/UserService.java
+++ b/src/main/java/com/example/bookiibookii/domain/user/service/UserService.java
@@ -19,6 +19,7 @@ import com.example.bookiibookii.domain.review.enums.MemberReviewReaction;
 import com.example.bookiibookii.domain.review.repository.MemberReviewRepository;
 
 import com.example.bookiibookii.global.auth.social.SocialUserInfo;
+import com.example.bookiibookii.global.time.TimeUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.PageRequest;
@@ -189,7 +190,7 @@ public class UserService {
                         .tradeType(br.getMemberBook().getGroup().getTradeType())
                         .rating(br.getStar())
                         .comment(br.getComment())
-                        .reviewDate(br.getUpdatedAt().format(DATE_FMT))
+                        .reviewDate(TimeUtils.formatKst(br.getUpdatedAt(), DATE_FMT))
                         .build())
                 .collect(Collectors.toList());
 
@@ -211,7 +212,7 @@ public class UserService {
                             .reviewerProfileUrl(writerProfileUrl)
                             .reaction(mr.getReaction())
                             .comment(mr.getComment())
-                            .createdAt(mr.getCreatedAt().format(DATE_FMT))
+                            .createdAt(TimeUtils.formatKst(mr.getCreatedAt(), DATE_FMT))
                             .build();
                 })
                 .collect(Collectors.toList());
@@ -273,7 +274,7 @@ public class UserService {
     }
 
     private void requireValidBirth(LocalDate birth) {
-        if (!birth.isBefore(LocalDate.now())) {
+        if (!birth.isBefore(TimeUtils.todayKst())) {
             throw new UserException(UserErrorCode.INVALID_BIRTH_DATE);
         }
     }

--- a/src/main/java/com/example/bookiibookii/global/auth/jwt/JwtProvider.java
+++ b/src/main/java/com/example/bookiibookii/global/auth/jwt/JwtProvider.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Component;
 import javax.crypto.SecretKey;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.Date;
 
 // JWT 생성, 검증, Authentication 객체 생성
@@ -34,14 +35,15 @@ public class JwtProvider {
 
     // Access Token 생성
     public String createAccessToken(Long userId, String role) {
-        Date now = new Date();
-        Date expiryDate = new Date(now.getTime() + accessTokenExpireTime.toMillis());
+        Instant now = Instant.now();
+        Date issuedAt = Date.from(now);
+        Date expiryDate = Date.from(now.plus(accessTokenExpireTime));
 
         return Jwts.builder()
                 .setSubject(String.valueOf(userId))
                 .claim("type", "access")
                 .claim("role", role)
-                .setIssuedAt(now)
+                .setIssuedAt(issuedAt)
                 .setExpiration(expiryDate)
                 .signWith(secretKey, SignatureAlgorithm.HS256)
                 .compact();
@@ -49,13 +51,14 @@ public class JwtProvider {
 
     // Refresh Token 생성
     public String createRefreshToken(Long userId) {
-        Date now = new Date();
-        Date expiryDate = new Date(now.getTime() + refreshTokenExpireTime.toMillis());
+        Instant now = Instant.now();
+        Date issuedAt = Date.from(now);
+        Date expiryDate = Date.from(now.plus(refreshTokenExpireTime));
 
         return Jwts.builder()
                 .setSubject(String.valueOf(userId))
                 .claim("type", "refresh")
-                .setIssuedAt(now)
+                .setIssuedAt(issuedAt)
                 .setExpiration(expiryDate)
                 .signWith(secretKey, SignatureAlgorithm.HS256)
                 .compact();
@@ -101,8 +104,7 @@ public class JwtProvider {
     // 토큰의 남은 유효 시간 계산 (밀리초 반환)
     public long getRemainingTime(String token) {
         Date expiration = parseClaims(token).getExpiration();
-        long now = new Date().getTime();
-        return expiration.getTime() - now;
+        return expiration.toInstant().toEpochMilli() - Instant.now().toEpochMilli();
     }
 
     // 만료 예외를 무시하고 Claims를 가져오는 로직

--- a/src/main/java/com/example/bookiibookii/global/config/JacksonConfig.java
+++ b/src/main/java/com/example/bookiibookii/global/config/JacksonConfig.java
@@ -1,6 +1,7 @@
 package com.example.bookiibookii.global.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -14,6 +15,7 @@ public class JacksonConfig {
     public ObjectMapper objectMapper() {
         return JsonMapper.builder()
                 .findAndAddModules()
+                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
                 .defaultTimeZone(TimeZone.getTimeZone("UTC"))
                 .build();
     }

--- a/src/main/java/com/example/bookiibookii/global/config/JacksonConfig.java
+++ b/src/main/java/com/example/bookiibookii/global/config/JacksonConfig.java
@@ -1,14 +1,20 @@
 package com.example.bookiibookii.global.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import java.util.TimeZone;
 
 @Configuration
 public class JacksonConfig {
 
     @Bean
     public ObjectMapper objectMapper() {
-        return new ObjectMapper();
+        return JsonMapper.builder()
+                .findAndAddModules()
+                .defaultTimeZone(TimeZone.getTimeZone("UTC"))
+                .build();
     }
 }

--- a/src/main/java/com/example/bookiibookii/global/entity/BaseEntity.java
+++ b/src/main/java/com/example/bookiibookii/global/entity/BaseEntity.java
@@ -8,7 +8,7 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
@@ -16,9 +16,9 @@ import java.time.LocalDateTime;
 public abstract class BaseEntity {
     @CreatedDate
     @Column(name="created_at", nullable = false)
-    private LocalDateTime createdAt;
+    private Instant createdAt;
 
     @LastModifiedDate
     @Column(name="updated_at", nullable=false)
-    private LocalDateTime updatedAt;
+    private Instant updatedAt;
 }

--- a/src/main/java/com/example/bookiibookii/global/scheduler/WithdrawnUserCleanupScheduler.java
+++ b/src/main/java/com/example/bookiibookii/global/scheduler/WithdrawnUserCleanupScheduler.java
@@ -8,8 +8,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
 
 @Slf4j
 @Component
@@ -17,13 +19,14 @@ import java.time.ZoneId;
 public class WithdrawnUserCleanupScheduler {
 
     private final UserRepository userRepository;
+    private final Clock clock;
 
     // 매일 새벽 3시 실행
     @Scheduled(cron = "0 0 3 * * *", zone = "Asia/Seoul")
     @Transactional
     public void deleteExpiredWithdrawnUsers() {
 
-        LocalDateTime deleteBefore = LocalDateTime.now(ZoneId.of("Asia/Seoul")).minusDays(30);
+        Instant deleteBefore = clock.instant().minus(Duration.ofDays(30));
         userRepository.deleteWithdrawnUsersBefore(deleteBefore);
     }
 }

--- a/src/main/java/com/example/bookiibookii/global/time/TimeConfig.java
+++ b/src/main/java/com/example/bookiibookii/global/time/TimeConfig.java
@@ -1,0 +1,18 @@
+package com.example.bookiibookii.global.time;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Clock;
+import java.time.ZoneId;
+
+@Configuration
+public class TimeConfig {
+
+    public static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+    @Bean
+    public Clock clock() {
+        return Clock.systemUTC();
+    }
+}

--- a/src/main/java/com/example/bookiibookii/global/time/TimeUtils.java
+++ b/src/main/java/com/example/bookiibookii/global/time/TimeUtils.java
@@ -1,0 +1,24 @@
+package com.example.bookiibookii.global.time;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+public final class TimeUtils {
+
+    private TimeUtils() {
+    }
+
+    public static LocalDate todayKst() {
+        return LocalDate.now(TimeConfig.KST);
+    }
+
+    public static LocalDateTime localDateTimeKst(Instant instant) {
+        return instant == null ? null : LocalDateTime.ofInstant(instant, TimeConfig.KST);
+    }
+
+    public static String formatKst(Instant instant, DateTimeFormatter formatter) {
+        return instant == null ? null : formatter.format(instant.atZone(TimeConfig.KST));
+    }
+}

--- a/src/main/java/com/example/bookiibookii/global/util/RedisUtil.java
+++ b/src/main/java/com/example/bookiibookii/global/util/RedisUtil.java
@@ -105,6 +105,7 @@ public class RedisUtil {
 
         try {
             String cleanKeyword = keyword.trim();
+            // TODO: 검색어 랭킹 기준일도 Clock 주입으로 테스트 가능하게 정리한다.
             String todayKey = RANKING_KEY_PREFIX + TimeUtils.todayKst();
             String prefixedKey = applyPrefix(todayKey);
 
@@ -127,6 +128,7 @@ public class RedisUtil {
 
             // 합산된 결과(캐시)가 없으면 새로 생성
             if (Boolean.FALSE.equals(redisTemplate.hasKey(combinedKeyWithPrefix))) {
+                // TODO: 검색어 랭킹 기준일도 Clock 주입으로 테스트 가능하게 정리한다.
                 List<String> last90DaysKeys = IntStream.range(0, 90)
                         .mapToObj(i -> applyPrefix(RANKING_KEY_PREFIX + TimeUtils.todayKst().minusDays(i)))
                         .filter(key -> Boolean.TRUE.equals(redisTemplate.hasKey(key)))

--- a/src/main/java/com/example/bookiibookii/global/util/RedisUtil.java
+++ b/src/main/java/com/example/bookiibookii/global/util/RedisUtil.java
@@ -2,13 +2,13 @@ package com.example.bookiibookii.global.util;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.example.bookiibookii.global.time.TimeUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
 
-import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -105,7 +105,7 @@ public class RedisUtil {
 
         try {
             String cleanKeyword = keyword.trim();
-            String todayKey = RANKING_KEY_PREFIX + LocalDate.now();
+            String todayKey = RANKING_KEY_PREFIX + TimeUtils.todayKst();
             String prefixedKey = applyPrefix(todayKey);
 
             // 오늘자 키에 점수 1 증가
@@ -128,7 +128,7 @@ public class RedisUtil {
             // 합산된 결과(캐시)가 없으면 새로 생성
             if (Boolean.FALSE.equals(redisTemplate.hasKey(combinedKeyWithPrefix))) {
                 List<String> last90DaysKeys = IntStream.range(0, 90)
-                        .mapToObj(i -> applyPrefix(RANKING_KEY_PREFIX + LocalDate.now().minusDays(i)))
+                        .mapToObj(i -> applyPrefix(RANKING_KEY_PREFIX + TimeUtils.todayKst().minusDays(i)))
                         .filter(key -> Boolean.TRUE.equals(redisTemplate.hasKey(key)))
                         .collect(Collectors.toList());
 

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -14,6 +14,8 @@ spring:
     properties:
       hibernate:
         format_sql: true
+        jdbc:
+          time_zone: UTC
 
   data:
     redis:

--- a/src/main/resources/application-v1.yml
+++ b/src/main/resources/application-v1.yml
@@ -10,7 +10,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: validate
+      ddl-auto: create
     properties:
       hibernate:
         format_sql: true

--- a/src/main/resources/application-v1.yml
+++ b/src/main/resources/application-v1.yml
@@ -14,6 +14,8 @@ spring:
     properties:
       hibernate:
         format_sql: true
+        jdbc:
+          time_zone: UTC
 
   data:
     redis:

--- a/src/test/java/com/example/bookiibookii/domain/notification/entity/NotificationTest.java
+++ b/src/test/java/com/example/bookiibookii/domain/notification/entity/NotificationTest.java
@@ -1,0 +1,36 @@
+package com.example.bookiibookii.domain.notification.entity;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class NotificationTest {
+
+    @Test
+    void markAsReadRejectsNullReadAtBeforeChangingState() {
+        Notification notification = Notification.builder()
+                .read(false)
+                .build();
+
+        assertThatThrownBy(() -> notification.markAsRead(null))
+                .isInstanceOf(NullPointerException.class);
+        assertThat(notification.isRead()).isFalse();
+        assertThat(notification.getReadAt()).isNull();
+    }
+
+    @Test
+    void markAsReadStoresReadAt() {
+        Notification notification = Notification.builder()
+                .read(false)
+                .build();
+        Instant readAt = Instant.parse("2026-06-20T05:00:00Z");
+
+        notification.markAsRead(readAt);
+
+        assertThat(notification.isRead()).isTrue();
+        assertThat(notification.getReadAt()).isEqualTo(readAt);
+    }
+}

--- a/src/test/java/com/example/bookiibookii/domain/notification/service/NotificationCursorTest.java
+++ b/src/test/java/com/example/bookiibookii/domain/notification/service/NotificationCursorTest.java
@@ -1,0 +1,35 @@
+package com.example.bookiibookii.domain.notification.service;
+
+import com.example.bookiibookii.domain.notification.enums.NotificationCategory;
+import com.example.bookiibookii.domain.notification.exception.NotificationException;
+import com.example.bookiibookii.domain.notification.exception.code.NotificationErrorCode;
+import com.example.bookiibookii.domain.notification.repository.NotificationRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.time.Clock;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+
+class NotificationCursorTest {
+
+    @Test
+    void rejectsCursorWhenReadTokenIsNotBooleanLiteral() {
+        NotificationService service = new NotificationService(
+                mock(NotificationRepository.class),
+                new ObjectMapper(),
+                Clock.systemUTC()
+        );
+
+        assertThatThrownBy(() -> service.getNotifications(
+                10L,
+                NotificationCategory.SYSTEM,
+                "yes_2026-06-12T01:00:00Z_1",
+                20
+        ))
+                .isInstanceOf(NotificationException.class)
+                .extracting("code")
+                .isEqualTo(NotificationErrorCode.INVALID_CURSOR);
+    }
+}

--- a/src/test/java/com/example/bookiibookii/domain/tracker/entity/DeliveryTest.java
+++ b/src/test/java/com/example/bookiibookii/domain/tracker/entity/DeliveryTest.java
@@ -1,0 +1,34 @@
+package com.example.bookiibookii.domain.tracker.entity;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class DeliveryTest {
+
+    @Test
+    void confirmReceivedStoresOnlyReceivedConfirmedAt() {
+        Instant deliveredAt = Instant.parse("2026-06-19T05:00:00Z");
+        Instant confirmedAt = Instant.parse("2026-06-20T05:00:00Z");
+        Delivery delivery = Delivery.builder()
+                .deliveredAt(deliveredAt)
+                .build();
+
+        delivery.confirmReceived(confirmedAt);
+
+        assertThat(delivery.getReceivedConfirmedAt()).isEqualTo(confirmedAt);
+        assertThat(delivery.getDeliveredAt()).isEqualTo(deliveredAt);
+    }
+
+    @Test
+    void confirmReceivedRejectsNullConfirmedAtBeforeChangingState() {
+        Delivery delivery = Delivery.builder().build();
+
+        assertThatThrownBy(() -> delivery.confirmReceived(null))
+                .isInstanceOf(NullPointerException.class);
+        assertThat(delivery.getReceivedConfirmedAt()).isNull();
+    }
+}

--- a/src/test/java/com/example/bookiibookii/domain/tracker/service/MeetingTimeConversionTest.java
+++ b/src/test/java/com/example/bookiibookii/domain/tracker/service/MeetingTimeConversionTest.java
@@ -1,0 +1,156 @@
+package com.example.bookiibookii.domain.tracker.service;
+
+import com.example.bookiibookii.domain.book.entity.Book;
+import com.example.bookiibookii.domain.group.entity.Groups;
+import com.example.bookiibookii.domain.group.entity.MatchedMember;
+import com.example.bookiibookii.domain.group.entity.Meeting;
+import com.example.bookiibookii.domain.group.enums.GroupStatus;
+import com.example.bookiibookii.domain.group.enums.RoleStatus;
+import com.example.bookiibookii.domain.group.enums.TradeType;
+import com.example.bookiibookii.domain.group.repository.GroupPlaceRepository;
+import com.example.bookiibookii.domain.group.repository.GroupsRepository;
+import com.example.bookiibookii.domain.group.repository.MatchedMemberRepository;
+import com.example.bookiibookii.domain.group.repository.MeetingRepository;
+import com.example.bookiibookii.domain.notification.publisher.DomainEventPublisher;
+import com.example.bookiibookii.domain.tracker.dto.req.MeetingRequestDTO;
+import com.example.bookiibookii.domain.tracker.enums.ExchangeRound;
+import com.example.bookiibookii.domain.tracker.enums.ExchangeStatus;
+import com.example.bookiibookii.domain.tracker.enums.ReadingStatus;
+import com.example.bookiibookii.domain.user.entity.User;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MeetingTimeConversionTest {
+
+    @Mock
+    private MeetingRepository meetingRepository;
+    @Mock
+    private GroupsRepository groupsRepository;
+    @Mock
+    private MatchedMemberRepository matchedMemberRepository;
+    @Mock
+    private GroupPlaceRepository groupPlaceRepository;
+    @Mock
+    private DomainEventPublisher eventPublisher;
+    @Mock
+    private Clock clock;
+
+    @InjectMocks
+    private MeetingService meetingService;
+
+    @Test
+    void createMeetingConvertsOffsetRequestToUtcInstantResponse() {
+        Groups group = directGroup(1L);
+        MatchedMember host = member(1L, 10L, group, RoleStatus.HOST);
+        MatchedMember guest = member(2L, 20L, group, RoleStatus.GUEST);
+        MeetingRequestDTO request = request(OffsetDateTime.parse("2026-06-24T18:00:00+09:00"));
+
+        when(groupsRepository.findByIdForUpdate(group.getId())).thenReturn(Optional.of(group));
+        when(matchedMemberRepository.findAllByGroupIdForUpdate(group.getId())).thenReturn(List.of(host, guest));
+        when(meetingRepository.existsByGroupIdAndExchangeRound(group.getId(), ExchangeRound.FIRST_EXCHANGE))
+                .thenReturn(false);
+        when(meetingRepository.save(any(Meeting.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        var response = meetingService.createMeeting(group.getId(), request, host.getUser());
+
+        assertThat(response.meetingAt()).isEqualTo(Instant.parse("2026-06-24T09:00:00Z"));
+    }
+
+    @Test
+    void updateMeetingConvertsOffsetRequestToUtcInstantResponse() {
+        Groups group = directGroup(2L);
+        MatchedMember host = member(3L, 30L, group, RoleStatus.HOST);
+        MatchedMember guest = member(4L, 40L, group, RoleStatus.GUEST);
+        Meeting meeting = meeting(group, host, Instant.parse("2026-06-24T08:00:00Z"));
+        MeetingRequestDTO request = request(OffsetDateTime.parse("2026-06-24T18:00:00+09:00"));
+
+        when(groupsRepository.findByIdForUpdate(group.getId())).thenReturn(Optional.of(group));
+        when(matchedMemberRepository.findAllByGroupIdForUpdate(group.getId())).thenReturn(List.of(host, guest));
+        when(meetingRepository.findByGroupIdAndExchangeRoundForUpdate(group.getId(), ExchangeRound.FIRST_EXCHANGE))
+                .thenReturn(Optional.of(meeting));
+
+        var response = meetingService.updateMeeting(group.getId(), request, host.getUser());
+
+        assertThat(response.meetingAt()).isEqualTo(Instant.parse("2026-06-24T09:00:00Z"));
+    }
+
+    @Test
+    void getMeetingReturnsStoredUtcInstant() {
+        Groups group = directGroup(3L);
+        MatchedMember host = member(5L, 50L, group, RoleStatus.HOST);
+        Meeting meeting = meeting(group, host, Instant.parse("2026-06-24T09:00:00Z"));
+
+        when(groupsRepository.findById(group.getId())).thenReturn(Optional.of(group));
+        when(matchedMemberRepository.findByGroup_IdAndUser_Id(group.getId(), host.getUser().getId()))
+                .thenReturn(Optional.of(host));
+        when(meetingRepository.findByGroupIdAndExchangeRound(group.getId(), ExchangeRound.FIRST_EXCHANGE))
+                .thenReturn(Optional.of(meeting));
+
+        var response = meetingService.getMeeting(group.getId(), host.getUser());
+
+        assertThat(response.meetingAt()).isEqualTo(Instant.parse("2026-06-24T09:00:00Z"));
+    }
+
+    private MeetingRequestDTO request(OffsetDateTime meetingAt) {
+        return new MeetingRequestDTO(
+                "카페",
+                "서울시 강남구",
+                "12345",
+                BigDecimal.ONE,
+                BigDecimal.ONE,
+                "2층",
+                meetingAt
+        );
+    }
+
+    private Meeting meeting(Groups group, MatchedMember createdBy, Instant meetingAt) {
+        return Meeting.builder()
+                .id(1L)
+                .group(group)
+                .createdBy(createdBy)
+                .exchangeRound(ExchangeRound.FIRST_EXCHANGE)
+                .placeName("카페")
+                .address("서울시 강남구")
+                .zipCode("12345")
+                .x(BigDecimal.ONE)
+                .y(BigDecimal.ONE)
+                .addressDetail("2층")
+                .meetingAt(meetingAt)
+                .build();
+    }
+
+    private Groups directGroup(Long id) {
+        return Groups.builder()
+                .id(id)
+                .book(Book.builder().id(100L).title("교환 책").build())
+                .tradeType(TradeType.DIRECT)
+                .groupStatus(GroupStatus.MATCHED)
+                .build();
+    }
+
+    private MatchedMember member(Long memberId, Long userId, Groups group, RoleStatus role) {
+        return MatchedMember.builder()
+                .id(memberId)
+                .group(group)
+                .user(User.builder().id(userId).nickName("사용자" + userId).build())
+                .role(role)
+                .readingStatus(ReadingStatus.EXCHANGING)
+                .exchangeStatus(ExchangeStatus.MEETING_SCHEDULED)
+                .build();
+    }
+}

--- a/src/test/java/com/example/bookiibookii/global/config/JacksonConfigTest.java
+++ b/src/test/java/com/example/bookiibookii/global/config/JacksonConfigTest.java
@@ -1,0 +1,27 @@
+package com.example.bookiibookii.global.config;
+
+import com.example.bookiibookii.domain.tracker.dto.res.MeetingResponseDTO;
+import com.example.bookiibookii.domain.tracker.enums.ExchangeRound;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JacksonConfigTest {
+
+    private final JacksonConfig jacksonConfig = new JacksonConfig();
+
+    @Test
+    void serializesInstantAsIso8601String() throws Exception {
+        MeetingResponseDTO response = MeetingResponseDTO.builder()
+                .meetingId(10L)
+                .exchangeRound(ExchangeRound.FIRST_EXCHANGE)
+                .meetingAt(Instant.parse("2026-06-24T09:00:00Z"))
+                .build();
+
+        String json = jacksonConfig.objectMapper().writeValueAsString(response);
+
+        assertThat(json).contains("\"meetingAt\":\"2026-06-24T09:00:00Z\"");
+    }
+}


### PR DESCRIPTION
## 개요
<!---- 자신이 완료한 이슈를 닫아주세요 -->
- closed #580 
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
## 작업 내용

서버의 실제 시각 필드를 `Instant` 기준으로 전환하고, 저장/응답 기준을 UTC로 통일했습니다.

### 주요 변경

* 실제 시각 필드 `Instant` 전환

  * `createdAt`, `updatedAt`
  * `Meeting.meetingAt`
  * `Delivery.trackingRegisteredAt`, `deliveredAt`, `receivedConfirmedAt`
  * `Notification.readAt`
  * 기타 생성/수정/처리 시각 필드

* 직접교환 약속 API 변경

  * `scheduledAt` 제거
  * `meetingAt` 사용
  * 요청: `OffsetDateTime`
  * 응답/저장: `Instant`

* 배송 시간 필드명 정리

  * `trackingRegisteredAt`
  * `deliveredAt`
  * `receivedConfirmedAt`

* KST 날짜 계산 명시

  * `Asia/Seoul` 기준 사용
  * 시스템 기본 타임존 의존 제거

* UTC 설정 추가

  * `hibernate.jdbc.time_zone: UTC`
  * Jackson UTC timezone 설정
  * `Clock.systemUTC()` Bean 추가

## API 변경 사항

### 직접교환 약속 요청

```json
{
  "meetingAt": "2026-06-24T18:00:00+09:00"
}
```

### 직접교환 약속 응답

```json
{
  "meetingAt": "2026-06-24T09:00:00Z"
}
```

## 확인 필요

* 프론트는 직접교환 약속 요청 시 `scheduledAt` 대신 `meetingAt` 사용 필요
* `meetingAt` 요청값은 offset 포함 필요
* 응답은 UTC Instant로 내려가므로 화면 표시 시 KST 변환 필요
* 기존 DB를 유지하는 환경에서는 컬럼명 변경에 따른 마이그레이션 필요

<!---- Resolves: #(Isuue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

📣 **To Reviewers**
---
<!-- 전달사항 -->

- Reviewers : 팀 선택
- Labels : 작업 유형, 자기 자신


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 일정/알림/리뷰/정책 동의/문의·신고 등 전반의 날짜·시간이 `Instant`(UTC)로 더 일관되게 표시됩니다.
  * 만료/마감/삭제/리마인드 등 시간 계산이 `Clock` 기반으로 안정화됐고, KST 기준 계산은 유틸로 통일됐습니다.
  * Jackson 직렬화 기본값이 UTC로 고정됩니다.
* **Breaking Changes**
  * 일부 API의 요청/응답 타임스탬스가 `LocalDateTime` → `Instant`로 변경되었습니다.
  * 약속 입력은 `scheduledAt` 대신 `meetingAt`을 사용합니다(요청: Offset, 응답: UTC `Instant`).
* **Tests**
  * 타임 변환/직렬화/예외 동작을 검증하는 테스트들이 추가됐습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->