### PR TITLE
[Chore]#585 Redis 장애 대응 및 운영 보완 강화

### DIFF
--- a/src/main/java/com/example/bookiibookii/global/auth/service/AuthService.java
+++ b/src/main/java/com/example/bookiibookii/global/auth/service/AuthService.java
@@ -76,7 +76,6 @@ public class AuthService {
         // Expiration: application.yml에 설정된 시간 (밀리초 -> 분 변환 필요)
         int rtExpirationMinutes = (int) Math.ceil(jwtProvider.getRefreshTokenExpireTime() / 1000.0 / 60);
         String rtKey = "RT:" + userId;
-        redisUtil.delete(rtKey);
         redisUtil.set(rtKey, refreshToken, rtExpirationMinutes);
 
         return AuthResponseDTO.LoginResponse.builder()
@@ -123,8 +122,6 @@ public class AuthService {
         String newRT = jwtProvider.createRefreshToken(userId);
 
         int rtExpirationMinutes = (int) Math.ceil(jwtProvider.getRefreshTokenExpireTime() / 1000.0 / 60);
-        rtKey = "RT:" + userId;
-        redisUtil.delete(rtKey);
         redisUtil.set(rtKey, newRT, rtExpirationMinutes);
 
         return AuthResponseDTO.TokenResponse.builder()

--- a/src/main/java/com/example/bookiibookii/global/auth/service/AuthService.java
+++ b/src/main/java/com/example/bookiibookii/global/auth/service/AuthService.java
@@ -170,7 +170,7 @@ public class AuthService {
             }
 
         } catch (Exception e) {
-            log.error("로그아웃 중 Redis 처리 에러 발생.", e);
+            log.error("로그아웃 처리 중 에러 발생.", e);
         }
     }
 

--- a/src/main/java/com/example/bookiibookii/global/notification/DiscordWebhookService.java
+++ b/src/main/java/com/example/bookiibookii/global/notification/DiscordWebhookService.java
@@ -29,6 +29,34 @@ public class DiscordWebhookService {
     private final DiscordWebhookProperties properties;
     private final RestClient discordWebhookRestClient;
 
+    public void sendRedisErrorAlert(String operation, Exception exception) {
+        if (!properties.enabled() || properties.url() == null || properties.url().isBlank()) {
+            return;
+        }
+
+        try {
+            String message = exception.getMessage();
+            String content = """
+                    [Redis Connection Error]
+                    operation: %s
+                    exception: %s
+                    message: %s
+                    """.formatted(
+                    operation,
+                    exception.getClass().getName(),
+                    message == null || message.isBlank() ? "(empty)" : sanitize(message)
+            );
+
+            discordWebhookRestClient.post()
+                    .uri(properties.url())
+                    .body(new DiscordWebhookRequest(truncate(content)))
+                    .retrieve()
+                    .toBodilessEntity();
+        } catch (Exception e) {
+            log.warn("Discord webhook redis alert failed", e);
+        }
+    }
+
     public void sendUnexpectedExceptionAlert(HttpServletRequest request, Exception exception) {
         if (!properties.enabled() || properties.url() == null || properties.url().isBlank()) {
             return;

--- a/src/main/java/com/example/bookiibookii/global/util/RedisUtil.java
+++ b/src/main/java/com/example/bookiibookii/global/util/RedisUtil.java
@@ -14,6 +14,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -34,7 +35,7 @@ public class RedisUtil {
 
     // 연속 Redis 장애 시 Discord 알림 폭주 방지 (1분 쿨다운)
     private static final long ALERT_COOLDOWN_MS = 60_000L;
-    private volatile long lastRedisAlertTime = 0;
+    private final AtomicLong lastRedisAlertTime = new AtomicLong(0);
 
     private String applyPrefix(String key) {
         return (prefix == null ? "" : prefix) + key;
@@ -42,8 +43,8 @@ public class RedisUtil {
 
     private void sendRedisAlertIfNeeded(String operation, Exception e) {
         long now = System.currentTimeMillis();
-        if (now - lastRedisAlertTime >= ALERT_COOLDOWN_MS) {
-            lastRedisAlertTime = now;
+        long last = lastRedisAlertTime.get();
+        if (now - last >= ALERT_COOLDOWN_MS && lastRedisAlertTime.compareAndSet(last, now)) {
             discordWebhookService.sendRedisErrorAlert(operation, e);
         }
     }

--- a/src/main/java/com/example/bookiibookii/global/util/RedisUtil.java
+++ b/src/main/java/com/example/bookiibookii/global/util/RedisUtil.java
@@ -58,6 +58,7 @@ public class RedisUtil {
         } catch (Exception e) {
             log.error("[SET] Redis 연결 에러 : {}", e.getMessage());
             sendRedisAlertIfNeeded("SET", e);
+            throw new RuntimeException("Redis SET 실패", e);
         }
     }
 

--- a/src/main/java/com/example/bookiibookii/global/util/RedisUtil.java
+++ b/src/main/java/com/example/bookiibookii/global/util/RedisUtil.java
@@ -1,8 +1,9 @@
 package com.example.bookiibookii.global.util;
 
+import com.example.bookiibookii.global.notification.DiscordWebhookService;
+import com.example.bookiibookii.global.time.TimeUtils;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.example.bookiibookii.global.time.TimeUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -22,24 +23,33 @@ import java.util.stream.IntStream;
 public class RedisUtil {
 
     private final RedisTemplate<String, String> redisTemplate;
-    private final ObjectMapper objectMapper; // Spring이 기본 제공하는 ObjectMapper 주입
+    private final ObjectMapper objectMapper;
+    private final DiscordWebhookService discordWebhookService;
 
-    // yml에 설정된 prefix 주입 (기본값 빈 문자열)
     @Value("${spring.data.redis.prefix:}")
     private String prefix;
 
     private static final String RANKING_KEY_PREFIX = "search:ranking:";
     private static final String COMBINED_KEY = "search:ranking:combined";
 
-    // 공통 Prefix 적용 메서드
+    // 연속 Redis 장애 시 Discord 알림 폭주 방지 (1분 쿨다운)
+    private static final long ALERT_COOLDOWN_MS = 60_000L;
+    private volatile long lastRedisAlertTime = 0;
+
     private String applyPrefix(String key) {
         return (prefix == null ? "" : prefix) + key;
     }
 
-    // 데이터 저장 (객체를 받아서 JSON String으로 변환 후 저장)
+    private void sendRedisAlertIfNeeded(String operation, Exception e) {
+        long now = System.currentTimeMillis();
+        if (now - lastRedisAlertTime >= ALERT_COOLDOWN_MS) {
+            lastRedisAlertTime = now;
+            discordWebhookService.sendRedisErrorAlert(operation, e);
+        }
+    }
+
     public void set(String key, Object data, int minutes) {
         try {
-            // Object -> JSON String 변환
             String jsonValue = objectMapper.writeValueAsString(data);
             redisTemplate.opsForValue().set(applyPrefix(key), jsonValue, minutes, TimeUnit.MINUTES);
         } catch (JsonProcessingException e) {
@@ -47,46 +57,45 @@ public class RedisUtil {
             throw new RuntimeException("Redis Parsing Error");
         } catch (Exception e) {
             log.error("[SET] Redis 연결 에러 : {}", e.getMessage());
+            sendRedisAlertIfNeeded("SET", e);
         }
     }
 
-    // 데이터 조회 (JSON String을 가져와서 원하는 클래스 타입으로 변환)
     public <T> T get(String key, Class<T> classType) {
         try {
             String jsonValue = redisTemplate.opsForValue().get(applyPrefix(key));
             if (jsonValue == null) return null;
-            // JSON String -> Object 변환
             return objectMapper.readValue(jsonValue, classType);
         } catch (JsonProcessingException e) {
             log.error("Redis 조회 중 JSON 변환 에러: {}", e.getMessage());
             return null;
         } catch (Exception e) {
             log.error("[GET] Redis 연결 에러 : {}", e.getMessage());
+            sendRedisAlertIfNeeded("GET", e);
             return null;
         }
     }
 
-    // 데이터 삭제
     public boolean delete(String key) {
         try {
             return Boolean.TRUE.equals(redisTemplate.delete(applyPrefix(key)));
         } catch (Exception e) {
             log.error("[DELETE] Redis 연결 에러 : {}", e.getMessage());
+            sendRedisAlertIfNeeded("DELETE", e);
             return false;
         }
     }
 
-    // 존재 여부
     public boolean hasKey(String key) {
         try {
             return Boolean.TRUE.equals(redisTemplate.hasKey(applyPrefix(key)));
         } catch (Exception e) {
             log.error("[HAS_KEY] Redis 연결 에러 : {}", e.getMessage());
+            sendRedisAlertIfNeeded("HAS_KEY", e);
             return false;
         }
     }
 
-    // Blacklist 등 유효기간을 밀리초 단위로 설정해야 할 때 사용
     public void setBlackList(String key, Object data, Long milliSeconds) {
         try {
             String jsonValue = objectMapper.writeValueAsString(data);
@@ -96,10 +105,10 @@ public class RedisUtil {
             throw new RuntimeException("Redis Parsing Error", e);
         } catch (Exception e) {
             log.error("[BLACKLIST] Redis 연결 에러 : {}", e.getMessage());
+            sendRedisAlertIfNeeded("BLACKLIST", e);
         }
     }
 
-    //인기검색어
     public void incrementSearchScore(String keyword) {
         if (keyword == null || keyword.isBlank()) return;
 
@@ -109,24 +118,18 @@ public class RedisUtil {
             String todayKey = RANKING_KEY_PREFIX + TimeUtils.todayKst();
             String prefixedKey = applyPrefix(todayKey);
 
-            // 오늘자 키에 점수 1 증가
             redisTemplate.opsForZSet().incrementScore(prefixedKey, cleanKeyword, 1);
-
-            // 해당 날짜 키에 90일 TTL 설정 (자동 삭제)
             redisTemplate.expire(prefixedKey, 90, TimeUnit.DAYS);
-
-            // log.info("인기 검색어 기록 (날짜별): {} -> {}", todayKey, cleanKeyword);
         } catch (Exception e) {
             log.error("[INCREMENT] Redis 연결 에러 : {}", e.getMessage());
+            sendRedisAlertIfNeeded("INCREMENT", e);
         }
     }
 
-    //인기 검색어 조회
     public List<String> getTopKeywords(int limit) {
         try {
             String combinedKeyWithPrefix = applyPrefix(COMBINED_KEY);
 
-            // 합산된 결과(캐시)가 없으면 새로 생성
             if (Boolean.FALSE.equals(redisTemplate.hasKey(combinedKeyWithPrefix))) {
                 // TODO: 검색어 랭킹 기준일도 Clock 주입으로 테스트 가능하게 정리한다.
                 List<String> last90DaysKeys = IntStream.range(0, 90)
@@ -136,12 +139,10 @@ public class RedisUtil {
 
                 if (last90DaysKeys.isEmpty()) return new ArrayList<>();
 
-                // Redis 자체 기능으로 90개 키의 점수를 모두 합산하여 COMBINED_KEY에 저장
                 redisTemplate.opsForZSet().unionAndStore(last90DaysKeys.get(0),
                         last90DaysKeys.subList(1, last90DaysKeys.size()),
                         combinedKeyWithPrefix);
 
-                // 합산 결과는 10분간 유지 (성능 최적화)
                 redisTemplate.expire(combinedKeyWithPrefix, 10, TimeUnit.MINUTES);
             }
 
@@ -149,6 +150,7 @@ public class RedisUtil {
             return range == null ? new ArrayList<>() : new ArrayList<>(range);
         } catch (Exception e) {
             log.error("[GET_TOP_KEYWORDS] Redis 연결 에러 : {}", e.getMessage());
+            sendRedisAlertIfNeeded("GET_TOP_KEYWORDS", e);
             return new ArrayList<>();
         }
     }

--- a/src/main/java/com/example/bookiibookii/global/util/RedisUtil.java
+++ b/src/main/java/com/example/bookiibookii/global/util/RedisUtil.java
@@ -73,7 +73,7 @@ public class RedisUtil {
         } catch (Exception e) {
             log.error("[GET] Redis 연결 에러 : {}", e.getMessage());
             sendRedisAlertIfNeeded("GET", e);
-            return null;
+            throw new RuntimeException("Redis GET 실패", e);
         }
     }
 


### PR DESCRIPTION
## 개요
<!---- 자신이 완료한 이슈를 닫아주세요 -->
- closed #585 //이슈 번호는 추적을 위해 필요합니다!
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
Redis 장애 시 Discord 웹훅 알림 연동 (RedisUtil → DiscordWebhookService)
RT 저장 실패 시 로그인 실패 처리 (정책: 저장 실패 = 500)
운영(v1) Redis SSL 적용 여부 확인
### Redis 장애 시 인증 정책

| 기능 | Redis 장애 시 동작 | 이유 |
|------|-------------------|------|
| 로그인 | **500 Internal Server Error** | Refresh Token 저장에 실패한 상태에서 Access Token만 발급하면 30분 후 토큰 갱신이 불가능해진다. 처음부터 로그인에 실패시키고 재시도하도록 유도하는 것이 더 안전하다. |
| Refresh | **500 Internal Server Error** | Refresh Token 조회 실패를 단순한 토큰 불일치(400)와 구분하여, 서버(Redis) 문제임을 클라이언트에 명확하게 전달한다. |
| 로그아웃 | **200 OK (Best Effort)** | Refresh Token 삭제나 Access Token 블랙리스트 등록이 실패하더라도 클라이언트는 토큰을 삭제하므로 로그아웃은 성공으로 처리한다. Redis 장애는 Discord 알림을 통해 빠르게 감지한다. |
| Access Token 재사용 방지 | **블랙리스트 조회 통과 허용** | 서비스 가용성을 우선한다. Access Token의 만료 시간이 30분으로 짧아 보안 위험이 제한적이라고 판단한다. |

<!---- Resolves: #585  -->

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [X] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [X] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

📣 **To Reviewers**
---
<!-- 전달사항 -->

- Reviewers : 팀 선택
- Labels : 작업 유형, 자기 자신


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redis 오류 발생 시 Discord로 알림을 전송하도록 추가하고, 알림 전송 빈도를 제한해 장애 확인을 빠르게 했습니다.
* **Bug Fixes**
  * 일부 Redis 작업에서 실패해도 조용히 넘어가던 동작을 개선해, 오류가 적절히 전달되거나(재던짐) 일관된 결과(예: 빈 목록)를 반환하도록 수정했습니다.
  * 로그아웃 시 Redis 관련 예외 로그 문구를 더 일반적인 표현으로 변경했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->