### PR TITLE
[Feat] #593 관리자용 API 추가 구현

### DIFF
--- a/src/main/java/com/example/bookiibookii/domain/group/controller/AdminGroupController.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/controller/AdminGroupController.java
@@ -1,0 +1,28 @@
+package com.example.bookiibookii.domain.group.controller;
+
+import com.example.bookiibookii.domain.group.service.AdminGroupService;
+import com.example.bookiibookii.global.apiPayload.ApiResponse;
+import com.example.bookiibookii.global.apiPayload.code.GeneralSuccessCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Validated
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin/groups")
+@PreAuthorize("hasRole('ADMIN')")
+public class AdminGroupController implements AdminGroupControllerDocs {
+
+    private final AdminGroupService adminGroupService;
+
+    @PatchMapping("/{groupId}/force-close")
+    public ApiResponse<Void> forceCloseGroup(@PathVariable Long groupId) {
+        adminGroupService.forceCloseGroup(groupId);
+        return ApiResponse.onSuccess(GeneralSuccessCode.REQUEST_OK, null);
+    }
+}

--- a/src/main/java/com/example/bookiibookii/domain/group/controller/AdminGroupControllerDocs.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/controller/AdminGroupControllerDocs.java
@@ -1,0 +1,27 @@
+package com.example.bookiibookii.domain.group.controller;
+
+import com.example.bookiibookii.global.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@Tag(name = "Admin", description = "관리자용 API")
+public interface AdminGroupControllerDocs {
+
+    @Operation(
+            summary = "그룹 강제 종료 API",
+            description = """
+            관리자가 그룹을 강제 종료합니다.
+            - RECRUITING: PENDING 신청 거절 후 그룹 삭제. 호스트 및 신청자에게 알림 발송.
+            - MATCHED: MatchedMember 완료 처리 후 그룹 삭제. 멤버에게 알림 발송.
+            - COMPLETED / DELETED: 400 에러 반환.
+            """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "그룹 강제 종료 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "이미 종료된 그룹"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "그룹을 찾을 수 없음")
+    })
+    ApiResponse<Void> forceCloseGroup(@PathVariable Long groupId);
+}

--- a/src/main/java/com/example/bookiibookii/domain/group/enums/GroupNotiType.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/enums/GroupNotiType.java
@@ -49,6 +49,13 @@ public enum GroupNotiType {
             "호스트가 그룹을 삭제했어요",
             "[{nickname}]님이 {bookTitle} 그룹을 삭제했어요. 호스트와 협의되지 않았다면 문의를 남겨주세요.",
             RedirectType.EXPLORE_HOME
+    ),
+
+    GROUP_FORCE_CLOSED(
+            NotificationType.GROUP_FORCE_CLOSED,
+            "그룹이 강제 종료됐어요",
+            "{groupTitle} 그룹이 관리자에 의해 강제 종료됐어요.",
+            RedirectType.EXPLORE_HOME
     );
 
     private final NotificationType notificationType;

--- a/src/main/java/com/example/bookiibookii/domain/group/exception/code/GroupErrorCode.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/exception/code/GroupErrorCode.java
@@ -57,8 +57,9 @@ public enum GroupErrorCode implements BaseCode {
     // 404 Not Found
     GROUP_SELECTED_PLACE_NOT_FOUND(HttpStatus.NOT_FOUND, "GROUP404_7", "그룹 생성 시 선택한 장소를 찾을 수 없습니다."),
     DIRECT_EXCHANGE_PLACE_NOT_FOUND(HttpStatus.NOT_FOUND, "GROUP404_8", "직접교환 장소를 먼저 등록해주세요."),
-    DELIVERY_ADDRESS_NOT_FOUND(HttpStatus.NOT_FOUND, "GROUP404_9", "배송지를 먼저 등록해주세요.")
+    DELIVERY_ADDRESS_NOT_FOUND(HttpStatus.NOT_FOUND, "GROUP404_9", "배송지를 먼저 등록해주세요."),
 
+    GROUP_ALREADY_CLOSED(HttpStatus.BAD_REQUEST, "GROUP400_29", "이미 종료된 그룹입니다.")
 ;
 
     private final HttpStatus status;

--- a/src/main/java/com/example/bookiibookii/domain/group/repository/GroupsRepository.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/repository/GroupsRepository.java
@@ -104,6 +104,16 @@ public interface GroupsRepository extends JpaRepository<Groups, Long> {
             @Param("deletedStatus") GroupStatus deletedStatus
     );
 
+    // 어드민 강제 종료용 — DELETED 포함 모든 상태에서 락으로 조회
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("""
+        select g from Groups g
+        join fetch g.book
+        join fetch g.host
+        where g.id = :groupId
+    """)
+    Optional<Groups> findByIdForUpdateAllStatuses(@Param("groupId") Long groupId);
+
     // PARTNER_REVIEWING 진입 후 14일 이상 파트너 후기 미작성 그룹 조회
     // partner_reviewing_started_at이 NULL인 기존 데이터는 updated_at을 기준으로 처리
     @Query(value = """

--- a/src/main/java/com/example/bookiibookii/domain/group/service/AdminGroupService.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/service/AdminGroupService.java
@@ -1,0 +1,83 @@
+package com.example.bookiibookii.domain.group.service;
+
+import com.example.bookiibookii.domain.group.entity.Groups;
+import com.example.bookiibookii.domain.group.entity.MatchedMember;
+import com.example.bookiibookii.domain.group.enums.ApplicationStatus;
+import com.example.bookiibookii.domain.group.enums.GroupStatus;
+import com.example.bookiibookii.domain.group.event.GroupNotificationEvent;
+import com.example.bookiibookii.domain.group.exception.GroupException;
+import com.example.bookiibookii.domain.group.exception.code.GroupErrorCode;
+import com.example.bookiibookii.domain.group.repository.ApplicationRepository;
+import com.example.bookiibookii.domain.group.repository.GroupsRepository;
+import com.example.bookiibookii.domain.group.repository.MatchedMemberRepository;
+import com.example.bookiibookii.domain.notification.enums.ExchangeType;
+import com.example.bookiibookii.domain.notification.publisher.DomainEventPublisher;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.example.bookiibookii.domain.group.enums.GroupNotiType.GROUP_FORCE_CLOSED;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AdminGroupService {
+
+    private final GroupsRepository groupsRepository;
+    private final MatchedMemberRepository matchedMemberRepository;
+    private final ApplicationRepository applicationRepository;
+    private final DomainEventPublisher publisher;
+    private final Clock clock;
+
+    public void forceCloseGroup(Long groupId) {
+        Groups group = groupsRepository.findByIdForUpdateAllStatuses(groupId)
+                .orElseThrow(() -> new GroupException(GroupErrorCode.GROUP_NOT_FOUND));
+
+        GroupStatus currentStatus = group.getGroupStatus();
+        if (currentStatus == GroupStatus.COMPLETED || currentStatus == GroupStatus.DELETED) {
+            throw new GroupException(GroupErrorCode.GROUP_ALREADY_CLOSED);
+        }
+
+        String title = groupTitle(group);
+
+        // PENDING 신청 일괄 거절
+        List<Long> pendingUserIds = applicationRepository.findPendingUserIdsByGroupId(groupId);
+        if (!pendingUserIds.isEmpty()) {
+            applicationRepository.updatePendingToRejectedByGroupId(groupId, ApplicationStatus.REJECTED);
+        }
+
+        if (currentStatus == GroupStatus.RECRUITING) {
+            // 호스트 + 신청자 모두에게 알림
+            List<Long> receiverIds = new ArrayList<>(pendingUserIds);
+            receiverIds.add(group.getHost().getId());
+            publisher.publish(new GroupNotificationEvent(
+                    GROUP_FORCE_CLOSED, null, title, null, receiverIds, groupId, null, null
+            ));
+        } else {
+            // MATCHED: MatchedMember 완료 처리 후 멤버에게 알림
+            Instant now = clock.instant();
+            List<MatchedMember> members = matchedMemberRepository.findAllByGroup_Id(groupId);
+            members.forEach(member -> member.completeReading(now));
+
+            List<Long> memberIds = members.stream().map(mm -> mm.getUser().getId()).toList();
+            publisher.publish(new GroupNotificationEvent(
+                    GROUP_FORCE_CLOSED, null, title, null, memberIds, groupId, null,
+                    ExchangeType.from(group.getTradeType())
+            ));
+        }
+
+        group.markAsDELETED();
+    }
+
+    private String groupTitle(Groups group) {
+        if (group.getGroupName() != null && !group.getGroupName().isBlank()) {
+            return group.getGroupName();
+        }
+        return group.getBook().getTitle();
+    }
+}

--- a/src/main/java/com/example/bookiibookii/domain/group/service/AdminGroupService.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/service/AdminGroupService.java
@@ -44,34 +44,41 @@ public class AdminGroupService {
         }
 
         String title = groupTitle(group);
+        Long hostId = group.getHost().getId();
+        ExchangeType exchangeType = ExchangeType.from(group.getTradeType());
 
-        // PENDING 신청 일괄 거절
+        // MATCHED: bulk update 전에 MatchedMember 완료 처리
+        List<Long> memberIds = List.of();
+        if (currentStatus == GroupStatus.MATCHED) {
+            Instant now = clock.instant();
+            List<MatchedMember> members = matchedMemberRepository.findAllByGroup_Id(groupId);
+            members.forEach(member -> member.completeReading(now));
+            memberIds = members.stream().map(mm -> mm.getUser().getId()).toList();
+        }
+
+        // 그룹 상태 변경 후 flush — bulk update(clearAutomatically=true)로 컨텍스트가
+        // 초기화되기 전에 DB에 반영해 detached 문제 방지
+        group.markAsDELETED();
+        groupsRepository.flush();
+
+        // PENDING 신청 일괄 거절 (flush 이후 실행)
         List<Long> pendingUserIds = applicationRepository.findPendingUserIdsByGroupId(groupId);
         if (!pendingUserIds.isEmpty()) {
             applicationRepository.updatePendingToRejectedByGroupId(groupId, ApplicationStatus.REJECTED);
         }
 
+        // 알림 발송
         if (currentStatus == GroupStatus.RECRUITING) {
-            // 호스트 + 신청자 모두에게 알림
             List<Long> receiverIds = new ArrayList<>(pendingUserIds);
-            receiverIds.add(group.getHost().getId());
+            receiverIds.add(hostId);
             publisher.publish(new GroupNotificationEvent(
                     GROUP_FORCE_CLOSED, null, title, null, receiverIds, groupId, null, null
             ));
         } else {
-            // MATCHED: MatchedMember 완료 처리 후 멤버에게 알림
-            Instant now = clock.instant();
-            List<MatchedMember> members = matchedMemberRepository.findAllByGroup_Id(groupId);
-            members.forEach(member -> member.completeReading(now));
-
-            List<Long> memberIds = members.stream().map(mm -> mm.getUser().getId()).toList();
             publisher.publish(new GroupNotificationEvent(
-                    GROUP_FORCE_CLOSED, null, title, null, memberIds, groupId, null,
-                    ExchangeType.from(group.getTradeType())
+                    GROUP_FORCE_CLOSED, null, title, null, memberIds, groupId, null, exchangeType
             ));
         }
-
-        group.markAsDELETED();
     }
 
     private String groupTitle(Groups group) {

--- a/src/main/java/com/example/bookiibookii/domain/notification/enums/NotificationType.java
+++ b/src/main/java/com/example/bookiibookii/domain/notification/enums/NotificationType.java
@@ -17,6 +17,7 @@ public enum NotificationType {
     GROUP_COMMENT_CREATED(NotificationCategory.SYSTEM),       // GRP-010 (그룹 상세/댓글)
     GROUP_COMMENT_REPLIED(NotificationCategory.SYSTEM),
     GROUP_DELETED(NotificationCategory.SYSTEM),               // 문의하기 or GRP-001
+    GROUP_FORCE_CLOSED(NotificationCategory.SYSTEM),          // 어드민 강제 종료
     GROUP_MATCH_FAILED_BY_EXPIRE(NotificationCategory.SYSTEM),// GRP-001 (리스트)
     GROUP_MATCH_FAILED_BY_CAPACITY(NotificationCategory.SYSTEM), // GRP-001 (리스트)
 

--- a/src/main/java/com/example/bookiibookii/domain/support/notice/service/NoticeService.java
+++ b/src/main/java/com/example/bookiibookii/domain/support/notice/service/NoticeService.java
@@ -2,7 +2,6 @@ package com.example.bookiibookii.domain.support.notice.service;
 
 import com.example.bookiibookii.domain.support.notice.dto.res.NoticeResponseDTO;
 import com.example.bookiibookii.domain.support.notice.entity.Notice;
-import com.example.bookiibookii.domain.support.notice.entity.UserNoticeRead;
 import com.example.bookiibookii.domain.support.notice.repository.NoticeRepository;
 import com.example.bookiibookii.domain.support.notice.repository.UserNoticeReadRepository;
 import com.example.bookiibookii.domain.user.entity.User;
@@ -11,7 +10,6 @@ import com.example.bookiibookii.domain.user.service.UserImageS3Service;
 import com.example.bookiibookii.global.apiPayload.code.GeneralErrorCode;
 import com.example.bookiibookii.global.apiPayload.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -30,6 +28,7 @@ public class NoticeService {
 
     private final NoticeRepository noticeRepository;
     private final UserNoticeReadRepository userNoticeReadRepository;
+    private final UserNoticeReadService userNoticeReadService;
     private final UserRepository userRepository;
     private final UserImageS3Service userImageS3Service;
 
@@ -76,14 +75,7 @@ public class NoticeService {
                 .orElseThrow(() -> new GeneralException(GeneralErrorCode.NOT_FOUND));
 
         if (userId != null) {
-            try {
-                userNoticeReadRepository.save(UserNoticeRead.builder()
-                        .userId(userId)
-                        .noticeId(noticeId)
-                        .build());
-            } catch (DataIntegrityViolationException ignored) {
-                // 동시 요청 무시
-            }
+            userNoticeReadService.markAsRead(userId, noticeId);
         }
 
         User author = notice.getUserId() != null

--- a/src/main/java/com/example/bookiibookii/domain/support/notice/service/UserNoticeReadService.java
+++ b/src/main/java/com/example/bookiibookii/domain/support/notice/service/UserNoticeReadService.java
@@ -1,0 +1,29 @@
+package com.example.bookiibookii.domain.support.notice.service;
+
+import com.example.bookiibookii.domain.support.notice.entity.UserNoticeRead;
+import com.example.bookiibookii.domain.support.notice.repository.UserNoticeReadRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserNoticeReadService {
+
+    private final UserNoticeReadRepository userNoticeReadRepository;
+
+    // REQUIRES_NEW로 독립 트랜잭션 실행 — 중복 저장 실패 시 외부 트랜잭션에 영향 없음
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void markAsRead(Long userId, Long noticeId) {
+        try {
+            userNoticeReadRepository.save(UserNoticeRead.builder()
+                    .userId(userId)
+                    .noticeId(noticeId)
+                    .build());
+        } catch (DataIntegrityViolationException ignored) {
+            // 이미 읽은 공지 — 정상 케이스
+        }
+    }
+}

--- a/src/main/java/com/example/bookiibookii/domain/user/controller/AdminUserController.java
+++ b/src/main/java/com/example/bookiibookii/domain/user/controller/AdminUserController.java
@@ -1,0 +1,29 @@
+package com.example.bookiibookii.domain.user.controller;
+
+import com.example.bookiibookii.domain.user.dto.res.UserResponseDTO;
+import com.example.bookiibookii.domain.user.service.AdminUserService;
+import com.example.bookiibookii.global.apiPayload.ApiResponse;
+import com.example.bookiibookii.global.apiPayload.code.GeneralSuccessCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Validated
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin/admins")
+@PreAuthorize("hasRole('ADMIN')")
+public class AdminUserController implements AdminUserControllerDocs {
+
+    private final AdminUserService adminUserService;
+
+    @GetMapping
+    public ApiResponse<List<UserResponseDTO.AdminUserListDTO>> getAdminUsers() {
+        return ApiResponse.onSuccess(GeneralSuccessCode.REQUEST_OK, adminUserService.getAdminUsers());
+    }
+}

--- a/src/main/java/com/example/bookiibookii/domain/user/controller/AdminUserControllerDocs.java
+++ b/src/main/java/com/example/bookiibookii/domain/user/controller/AdminUserControllerDocs.java
@@ -1,0 +1,27 @@
+package com.example.bookiibookii.domain.user.controller;
+
+import com.example.bookiibookii.domain.user.dto.res.UserResponseDTO;
+import com.example.bookiibookii.global.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+import java.util.List;
+
+@Tag(name = "Admin", description = "관리자용 API")
+public interface AdminUserControllerDocs {
+
+    @Operation(
+            summary = "관리자 계정 목록 조회 API",
+            description = """
+            ADMIN 권한을 가진 계정 목록을 조회합니다.
+            - id: 계정 고유 ID
+            - nickname: 닉네임
+            - introduction: 이메일 정보
+            """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "관리자 계정 목록 조회 성공")
+    })
+    ApiResponse<List<UserResponseDTO.AdminUserListDTO>> getAdminUsers();
+}

--- a/src/main/java/com/example/bookiibookii/domain/user/dto/res/UserResponseDTO.java
+++ b/src/main/java/com/example/bookiibookii/domain/user/dto/res/UserResponseDTO.java
@@ -54,6 +54,13 @@ public class UserResponseDTO {
     ) {}
 
     @Builder
+    public record AdminUserListDTO(
+            Long id,
+            String nickname,
+            String introduction
+    ) {}
+
+    @Builder
     public record NicknameValidationDTO(
             boolean isAvailable,
             String code,

--- a/src/main/java/com/example/bookiibookii/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/bookiibookii/domain/user/repository/UserRepository.java
@@ -102,5 +102,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
     @Query("select u.nickName from User u where u.id = :userId")
     Optional<String> findNickNameById(@Param("userId") Long userId);
 
-    List<User> findAllByRole(Role role);
+    List<User> findAllByRoleOrderByIdAsc(Role role);
 }

--- a/src/main/java/com/example/bookiibookii/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/bookiibookii/domain/user/repository/UserRepository.java
@@ -2,6 +2,7 @@ package com.example.bookiibookii.domain.user.repository;
 
 import com.example.bookiibookii.domain.group.enums.GroupStatus;
 import com.example.bookiibookii.domain.user.entity.User;
+import com.example.bookiibookii.domain.user.enums.Role;
 import com.example.bookiibookii.domain.user.enums.SocialType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
@@ -100,4 +101,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     @Query("select u.nickName from User u where u.id = :userId")
     Optional<String> findNickNameById(@Param("userId") Long userId);
+
+    List<User> findAllByRole(Role role);
 }

--- a/src/main/java/com/example/bookiibookii/domain/user/service/AdminUserService.java
+++ b/src/main/java/com/example/bookiibookii/domain/user/service/AdminUserService.java
@@ -17,7 +17,7 @@ public class AdminUserService {
     private final UserRepository userRepository;
 
     public List<UserResponseDTO.AdminUserListDTO> getAdminUsers() {
-        return userRepository.findAllByRole(Role.ADMIN).stream()
+        return userRepository.findAllByRoleOrderByIdAsc(Role.ADMIN).stream()
                 .map(user -> UserResponseDTO.AdminUserListDTO.builder()
                         .id(user.getId())
                         .nickname(user.getNickName())

--- a/src/main/java/com/example/bookiibookii/domain/user/service/AdminUserService.java
+++ b/src/main/java/com/example/bookiibookii/domain/user/service/AdminUserService.java
@@ -1,0 +1,28 @@
+package com.example.bookiibookii.domain.user.service;
+
+import com.example.bookiibookii.domain.user.dto.res.UserResponseDTO;
+import com.example.bookiibookii.domain.user.enums.Role;
+import com.example.bookiibookii.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminUserService {
+
+    private final UserRepository userRepository;
+
+    public List<UserResponseDTO.AdminUserListDTO> getAdminUsers() {
+        return userRepository.findAllByRole(Role.ADMIN).stream()
+                .map(user -> UserResponseDTO.AdminUserListDTO.builder()
+                        .id(user.getId())
+                        .nickname(user.getNickName())
+                        .introduction(user.getIntroduction())
+                        .build())
+                .toList();
+    }
+}


### PR DESCRIPTION
## 개요
<!---- 자신이 완료한 이슈를 닫아주세요 -->
- closed #593 //이슈 번호는 추적을 위해 필요합니다!
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
관리자 계정 목록 조회 API 추가 구현 (GET /api/admin/admins)
공지 상세 조회 시 에러 해결
그룹 강제 종료 API 추가 구현 (PATCH /{groupId}/force-close)

<!---- Resolves: #593  -->

## PR 유형
어떤 변경 사항이 있나요?

- [X] 새로운 기능 추가
- [X] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [X] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

📣 **To Reviewers**
---
<!-- 전달사항 -->

- Reviewers : 팀 선택
- Labels : 작업 유형, 자기 자신


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 관리자 페이지에서 관리자 계정 목록을 조회할 수 있게 되었습니다.
  * 관리자 권한으로 그룹을 강제 종료하는 기능이 추가되었습니다.
  * 그룹 강제 종료 시 관련 알림이 새로 발송됩니다.
* **Bug Fixes**
  * 공지 상세 조회 시 읽음 처리 안정성이 개선되었습니다.
  * 이미 종료된 그룹에 대한 강제 종료 요청은 명확한 오류로 처리됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->