### PR TITLE
[Feat] 그룹 스케줄러 웹훅 추가

### DIFF
--- a/src/main/java/com/example/bookiibookii/domain/group/scheduler/GroupScheduler.java
+++ b/src/main/java/com/example/bookiibookii/domain/group/scheduler/GroupScheduler.java
@@ -3,11 +3,13 @@ package com.example.bookiibookii.domain.group.scheduler;
 import com.example.bookiibookii.domain.group.entity.Groups;
 import com.example.bookiibookii.domain.group.repository.GroupsRepository;
 import com.example.bookiibookii.domain.group.service.GroupCompletionService;
+import com.example.bookiibookii.global.notification.DiscordWebhookService;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StopWatch;
 
 import java.time.Clock;
 import java.time.Duration;
@@ -19,28 +21,57 @@ import java.util.List;
 @RequiredArgsConstructor
 public class GroupScheduler {
 
+    private static final String SCHEDULER_NAME = "그룹 강제 종료";
+
     private final GroupsRepository groupsRepository;
     private final GroupCompletionService groupCompletionService;
+    private final DiscordWebhookService discordWebhookService;
     private final Clock clock;
 
     @Scheduled(cron = "0 0 3 * * *", zone="Asia/Seoul")
     public void forceCompleteGroups() {
         log.info("[Scheduler] 파트너 후기 미작성 그룹 강제 종료 프로세스 시작");
 
-        Instant cutoff = clock.instant().minus(Duration.ofDays(14));
-        List<Groups> timeoutGroups = groupsRepository.findGroupsForForceComplete(cutoff);
+        StopWatch stopWatch = new StopWatch();
+        stopWatch.start();
 
-        for (Groups group : timeoutGroups) {
-            try {
-                // 3. 방금 만든 서비스 호출 (각 호출마다 독립적인 트랜잭션 생성)
-                groupCompletionService.forceCompleteSingleGroup(group.getId());
-                log.info("[Scheduler] 그룹 강제 종료 성공");
-            } catch (Exception e) {
-                // 4. 하나가 실패해도 catch문에서 잡히므로 다음 그룹 루프는 계속 돌아감!
-                log.error("[Scheduler] 그룹 처리 중 오류 발생");
+        int totalCount;
+        int successCount = 0;
+        int failCount = 0;
+
+        try {
+            Instant cutoff = clock.instant().minus(Duration.ofDays(14));
+            List<Groups> timeoutGroups = groupsRepository.findGroupsForForceComplete(cutoff);
+            totalCount = timeoutGroups.size();
+
+            for (Groups group : timeoutGroups) {
+                try {
+                    // 3. 방금 만든 서비스 호출 (각 호출마다 독립적인 트랜잭션 생성)
+                    groupCompletionService.forceCompleteSingleGroup(group.getId());
+                    successCount++;
+                    log.info("[Scheduler] 그룹 강제 종료 성공: groupId={}", group.getId());
+                } catch (Exception e) {
+                    // 4. 하나가 실패해도 catch문에서 잡히므로 다음 그룹 루프는 계속 돌아감!
+                    failCount++;
+                    log.error("[Scheduler] 그룹 처리 중 오류 발생: groupId={}", group.getId(), e);
+                }
             }
+
+            log.info("[Scheduler] 리뷰 기간 만료 그룹 강제 종료 프로세스 완료 (처리 대상: {}건)", totalCount);
+        } catch (Exception e) {
+            stopWatch.stop();
+            log.error("[Scheduler] 그룹 강제 종료 프로세스 전체 실패", e);
+            discordWebhookService.sendSchedulerError(SCHEDULER_NAME, e);
+            return;
         }
 
-        log.info("[Scheduler] 리뷰 기간 만료 그룹 강제 종료 프로세스 완료 (처리 대상: {}건)", timeoutGroups.size());
+        stopWatch.stop();
+        discordWebhookService.sendSchedulerResult(
+                SCHEDULER_NAME,
+                totalCount,
+                successCount,
+                failCount,
+                stopWatch.getTotalTimeMillis()
+        );
     }
 }

--- a/src/main/java/com/example/bookiibookii/global/notification/DiscordWebhookService.java
+++ b/src/main/java/com/example/bookiibookii/global/notification/DiscordWebhookService.java
@@ -57,6 +57,63 @@ public class DiscordWebhookService {
         }
     }
 
+    public void sendSchedulerResult(String schedulerName, int totalCount, int successCount, int failCount, long elapsedMillis) {
+        if (!properties.enabled() || properties.url() == null || properties.url().isBlank()) {
+            return;
+        }
+
+        try {
+            String content = """
+                    [Scheduler Result] %s
+                    처리 건수: %d
+                    성공: %d
+                    실패: %d
+                    실행 시간: %dms
+                    """.formatted(
+                    schedulerName,
+                    totalCount,
+                    successCount,
+                    failCount,
+                    elapsedMillis
+            );
+
+            discordWebhookRestClient.post()
+                    .uri(properties.url())
+                    .body(new DiscordWebhookRequest(truncate(content)))
+                    .retrieve()
+                    .toBodilessEntity();
+        } catch (Exception e) {
+            log.warn("Discord webhook scheduler result alert failed", e);
+        }
+    }
+
+    public void sendSchedulerError(String schedulerName, Exception exception) {
+        if (!properties.enabled() || properties.url() == null || properties.url().isBlank()) {
+            return;
+        }
+
+        try {
+            String message = exception.getMessage();
+            String content = """
+                    [Scheduler Error] %s
+                    exception: %s
+                    message: %s
+                    """.formatted(
+                    schedulerName,
+                    exception.getClass().getName(),
+                    message == null || message.isBlank() ? "(empty)" : sanitize(message)
+            );
+
+            discordWebhookRestClient.post()
+                    .uri(properties.url())
+                    .body(new DiscordWebhookRequest(truncate(content)))
+                    .retrieve()
+                    .toBodilessEntity();
+        } catch (Exception e) {
+            log.warn("Discord webhook scheduler error alert failed", e);
+        }
+    }
+
     public void sendUnexpectedExceptionAlert(HttpServletRequest request, Exception exception) {
         if (!properties.enabled() || properties.url() == null || properties.url().isBlank()) {
             return;


### PR DESCRIPTION
## 개요
- closed #587 
- 그룹 강제 종료 스케줄러(`GroupScheduler`) 실행 결과를 Discord 웹훅으로 발송하도록 개선했습니다.
.


<!---- Resolves: #(Isuue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

📣 **To Reviewers**
---
<!-- 전달사항 -->

- Reviewers : 팀 선택
- Labels : 작업 유형, 자기 자신


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 그룹 자동 처리 스케줄러의 실행 결과가 디스코드 웹훅으로 전송됩니다.
  * 전체 처리 건수, 성공·실패 건수 및 소요 시간이 포함됩니다.
  * 예기치 않은 스케줄러 오류도 디스코드 알림으로 확인할 수 있습니다.
  * 오류 메시지는 민감한 정보가 노출되지 않도록 정리되어 전송됩니다.

* **버그 수정**
  * 개별 그룹 처리 실패가 전체 스케줄러 실행을 중단하지 않도록 개선했습니다.
  * 웹훅 전송 중 문제가 발생해도 주요 처리 결과에는 영향을 주지 않습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->