### PR TITLE
[Feat] #601 타유저 프로필 조회 API 수정 및 재가입 시 계정 데이터 초기화

### DIFF
--- a/src/main/java/com/example/bookiibookii/domain/review/controller/MypageReviewController.java
+++ b/src/main/java/com/example/bookiibookii/domain/review/controller/MypageReviewController.java
@@ -28,7 +28,7 @@ public class MypageReviewController implements MypageReviewControllerDocs {
     ) {
         return ApiResponse.onSuccess(
                 ReviewSuccessCode.MYPAGE_WRITTEN_REVIEWS_FOUND,
-                mypageReviewService.getWrittenReviews(user.getId(), pageable)
+                mypageReviewService.getWrittenReviews(user.getId(), user.getLastResetAt(), pageable)
         );
     }
 
@@ -40,7 +40,7 @@ public class MypageReviewController implements MypageReviewControllerDocs {
     ) {
         return ApiResponse.onSuccess(
                 ReviewSuccessCode.MYPAGE_RECEIVED_REVIEWS_FOUND,
-                mypageReviewService.getReceivedReviews(user.getId(), pageable)
+                mypageReviewService.getReceivedReviews(user.getId(), user.getLastResetAt(), pageable)
         );
     }
 }

--- a/src/main/java/com/example/bookiibookii/domain/review/repository/BookReviewRepository.java
+++ b/src/main/java/com/example/bookiibookii/domain/review/repository/BookReviewRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 
@@ -65,6 +66,7 @@ public interface BookReviewRepository extends JpaRepository<BookReview, Long> {
                 JOIN br.matchedMember mm
                 WHERE mm.user.id = :userId
                 AND mb.removedAt IS NULL
+                AND (:since IS NULL OR br.createdAt > :since)
                 ORDER BY br.createdAt DESC, br.id DESC
                 """,
             countQuery = """
@@ -73,10 +75,12 @@ public interface BookReviewRepository extends JpaRepository<BookReview, Long> {
                 JOIN br.memberBook mb
                 WHERE mm.user.id = :userId
                 AND mb.removedAt IS NULL
+                AND (:since IS NULL OR br.createdAt > :since)
                 """
     )
     Page<BookReview> findWrittenReviewsByUserId(
             @Param("userId") Long userId,
+            @Param("since") Instant since,
             Pageable pageable
     );
 
@@ -88,9 +92,10 @@ public interface BookReviewRepository extends JpaRepository<BookReview, Long> {
         JOIN FETCH br.matchedMember mm
         WHERE mm.user.id = :userId
         AND mb.removedAt IS NULL
+        AND (:since IS NULL OR br.createdAt > :since)
         ORDER BY br.updatedAt DESC
         """)
-    List<BookReview> findReviewedBooksByUserId(@Param("userId") Long userId, Pageable pageable);
+    List<BookReview> findReviewedBooksByUserId(@Param("userId") Long userId, @Param("since") Instant since, Pageable pageable);
 
     @Query("""
         SELECT COUNT(br) FROM BookReview br
@@ -98,8 +103,9 @@ public interface BookReviewRepository extends JpaRepository<BookReview, Long> {
         JOIN br.memberBook mb
         WHERE mm.user.id = :userId
         AND mb.removedAt IS NULL
+        AND (:since IS NULL OR br.createdAt > :since)
         """)
-    long countReviewedBooksByUserId(@Param("userId") Long userId);
+    long countReviewedBooksByUserId(@Param("userId") Long userId, @Param("since") Instant since);
 
     @Query("""
         SELECT CASE WHEN COUNT(br) > 0 THEN true ELSE false END

--- a/src/main/java/com/example/bookiibookii/domain/review/repository/MemberReviewRepository.java
+++ b/src/main/java/com/example/bookiibookii/domain/review/repository/MemberReviewRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 
@@ -20,9 +21,11 @@ public interface MemberReviewRepository extends JpaRepository<MemberReview, Long
         JOIN mr.target t
         WHERE t.user.id = :userId
           AND mr.reaction = :reaction
+          AND (:since IS NULL OR mr.createdAt > :since)
     """)
     long countByTargetUserIdAndReaction(@Param("userId") Long userId,
-                                        @Param("reaction") MemberReviewReaction reaction);
+                                        @Param("reaction") MemberReviewReaction reaction,
+                                        @Param("since") Instant since);
 
     boolean existsByGroup_IdAndWriter_Id(Long groupId, Long writerMatchedMemberId);
 
@@ -34,16 +37,19 @@ public interface MemberReviewRepository extends JpaRepository<MemberReview, Long
                 LEFT JOIN FETCH wu.userImage
                 JOIN mr.target t
                 WHERE t.user.id = :userId
+                AND (:since IS NULL OR mr.createdAt > :since)
                 ORDER BY mr.createdAt DESC, mr.id DESC
                 """,
             countQuery = """
                 SELECT COUNT(mr) FROM MemberReview mr
                 JOIN mr.target t
                 WHERE t.user.id = :userId
+                AND (:since IS NULL OR mr.createdAt > :since)
                 """
     )
     Page<MemberReview> findReceivedReviewsByUserId(
             @Param("userId") Long userId,
+            @Param("since") Instant since,
             Pageable pageable
     );
 
@@ -54,9 +60,10 @@ public interface MemberReviewRepository extends JpaRepository<MemberReview, Long
         LEFT JOIN FETCH wu.userImage
         JOIN mr.target t
         WHERE t.user.id = :userId
+        AND (:since IS NULL OR mr.createdAt > :since)
         ORDER BY mr.createdAt DESC
     """)
-    List<MemberReview> findLatestReceivedByUserId(@Param("userId") Long userId, Pageable pageable);
+    List<MemberReview> findLatestReceivedByUserId(@Param("userId") Long userId, @Param("since") Instant since, Pageable pageable);
 
     @Query("""
         SELECT mr FROM MemberReview mr

--- a/src/main/java/com/example/bookiibookii/domain/review/service/MypageReviewService.java
+++ b/src/main/java/com/example/bookiibookii/domain/review/service/MypageReviewService.java
@@ -79,7 +79,7 @@ public class MypageReviewService {
         return new MypageReviewResponseDTO.ReceivedReviewItem(
                 review.getId(),
                 reviewer.getId(),
-                reviewer.getNickName(),
+                reviewer.getNickName() != null ? reviewer.getNickName() : "(알 수 없음)",
                 userProfileImageUrlResolver.resolve(reviewer),
                 review.getReaction(),
                 partnerReviewLabel(review.getReaction()),

--- a/src/main/java/com/example/bookiibookii/domain/review/service/MypageReviewService.java
+++ b/src/main/java/com/example/bookiibookii/domain/review/service/MypageReviewService.java
@@ -15,6 +15,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 
 @Service
@@ -28,8 +29,8 @@ public class MypageReviewService {
     private final UserProfileImageUrlResolver userProfileImageUrlResolver;
 
     @Transactional(readOnly = true)
-    public MypageReviewResponseDTO.WrittenReviews getWrittenReviews(Long userId, Pageable pageable) {
-        Page<BookReview> reviews = bookReviewRepository.findWrittenReviewsByUserId(userId, pageable);
+    public MypageReviewResponseDTO.WrittenReviews getWrittenReviews(Long userId, Instant since, Pageable pageable) {
+        Page<BookReview> reviews = bookReviewRepository.findWrittenReviewsByUserId(userId, since, pageable);
 
         return new MypageReviewResponseDTO.WrittenReviews(
                 reviews.getTotalElements(),
@@ -39,11 +40,12 @@ public class MypageReviewService {
     }
 
     @Transactional(readOnly = true)
-    public MypageReviewResponseDTO.ReceivedReviews getReceivedReviews(Long userId, Pageable pageable) {
-        Page<MemberReview> reviews = memberReviewRepository.findReceivedReviewsByUserId(userId, pageable);
+    public MypageReviewResponseDTO.ReceivedReviews getReceivedReviews(Long userId, Instant since, Pageable pageable) {
+        Page<MemberReview> reviews = memberReviewRepository.findReceivedReviewsByUserId(userId, since, pageable);
         long positiveCount = memberReviewRepository.countByTargetUserIdAndReaction(
                 userId,
-                MemberReviewReaction.BOOM_UP
+                MemberReviewReaction.BOOM_UP,
+                since
         );
 
         return new MypageReviewResponseDTO.ReceivedReviews(

--- a/src/main/java/com/example/bookiibookii/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/bookiibookii/domain/user/controller/UserController.java
@@ -107,12 +107,12 @@ public class UserController implements UserControllerDocs{
     // 타 유저 프로필 조회
     @Override
     @GetMapping("/api/profiles/{nickname}")
-    public ApiResponse<UserResponseDTO.UserProfileResDTO> getOtherProfile(
+    public ApiResponse<UserResponseDTO.OtherUserProfileResDTO> getOtherProfile(
             @PathVariable("nickname") String nickname
     ) {
         Long targetUserId = userService.findUserIdByNickname(nickname);
-        UserResponseDTO.UserProfileResDTO result = userService.getProfileInfo(targetUserId);
-        return ApiResponse.onSuccess(GeneralSuccessCode.REQUEST_OK, result);
+        UserResponseDTO.OtherUserProfileResDTO result = userService.getOtherUserProfile(targetUserId);
+        return ApiResponse.onSuccess(UserSuccessCode.GET_OTHER_PROFILE_SUCCESS, result);
     }
 
     // 나의 책장 조회

--- a/src/main/java/com/example/bookiibookii/domain/user/controller/UserControllerDocs.java
+++ b/src/main/java/com/example/bookiibookii/domain/user/controller/UserControllerDocs.java
@@ -100,13 +100,15 @@ public interface UserControllerDocs {
             summary = "타 유저 프로필 조회 API",
             description = """
             타 유저의 프로필을 조회하는 API입니다.
+            - 대표책, 책 후기 수/최근 2개, 받은 BOOM_UP 수/최근 후기 3개를 반환합니다.
             """
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "프로필 조회 성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "프로필 조회 실패")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "탈퇴한 사용자 (USER403_1)"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음 (USER404_1)")
     })
-    ApiResponse<UserResponseDTO.UserProfileResDTO> getOtherProfile(@PathVariable("nickname") String nickname);
+    ApiResponse<UserResponseDTO.OtherUserProfileResDTO> getOtherProfile(@PathVariable("nickname") String nickname);
 
     // api/mypage
     @Operation(

--- a/src/main/java/com/example/bookiibookii/domain/user/dto/res/UserResponseDTO.java
+++ b/src/main/java/com/example/bookiibookii/domain/user/dto/res/UserResponseDTO.java
@@ -54,6 +54,19 @@ public class UserResponseDTO {
     ) {}
 
     @Builder
+    public record OtherUserProfileResDTO(
+            Long userId,
+            String profileImageUrl,
+            String nickname,
+            String introduction,
+            List<UserBookDto> userBooks,
+            Integer bookReviewCount,
+            List<BookReviewSummaryDto> recentBookReviews,
+            Integer boomUpCount,
+            List<ReceivedMemberReviewDto> recentReceivedReviews
+    ) {}
+
+    @Builder
     public record AdminUserListDTO(
             Long id,
             String nickname,

--- a/src/main/java/com/example/bookiibookii/domain/user/entity/User.java
+++ b/src/main/java/com/example/bookiibookii/domain/user/entity/User.java
@@ -97,6 +97,13 @@ public class User extends BaseEntity {
     public void reactivate() {
         this.status = Status.ACTIVE;
     }
+    public void reset() {
+        this.nickName = null;
+        this.introduction = null;
+        this.gender = null;
+        this.birth = null;
+        this.onboardingStatus = OnboardingStatus.NEW;
+    }
     public void updateName(String name) { this.nickName = name; }
     public void updateIntroduction(String introduction) { this.introduction = introduction; }
     public void updateUserInform(Gender gender, LocalDate birth) { this.gender = gender; this.birth = birth; }

--- a/src/main/java/com/example/bookiibookii/domain/user/entity/User.java
+++ b/src/main/java/com/example/bookiibookii/domain/user/entity/User.java
@@ -8,6 +8,7 @@ import lombok.*;
 import org.hibernate.annotations.Filter;
 import org.hibernate.annotations.FilterDef;
 
+import java.time.Instant;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
@@ -79,6 +80,9 @@ public class User extends BaseEntity {
     @Builder.Default
     private OnboardingStatus onboardingStatus = OnboardingStatus.NEW;
 
+    @Column(name = "last_reset_at")
+    private Instant lastResetAt;
+
     // 소셜 로그인 유저 생성
     public static User createSocialUser(
             SocialUserInfo info,
@@ -103,6 +107,7 @@ public class User extends BaseEntity {
         this.gender = null;
         this.birth = null;
         this.onboardingStatus = OnboardingStatus.NEW;
+        this.lastResetAt = Instant.now();
     }
     public void updateName(String name) { this.nickName = name; }
     public void updateIntroduction(String introduction) { this.introduction = introduction; }

--- a/src/main/java/com/example/bookiibookii/domain/user/exception/code/UserSuccessCode.java
+++ b/src/main/java/com/example/bookiibookii/domain/user/exception/code/UserSuccessCode.java
@@ -53,6 +53,9 @@ public enum UserSuccessCode implements BaseCode {
     PUBLIC_PROFILE_FOUND(HttpStatus.OK,
             "USER200_13",
             "공유 프로필을 조회했습니다."),
+    GET_OTHER_PROFILE_SUCCESS(HttpStatus.OK,
+            "USER200_15",
+            "타 유저 프로필 조회에 성공했습니다."),
     ;
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/example/bookiibookii/domain/user/repository/ProfileShareTokenRepository.java
+++ b/src/main/java/com/example/bookiibookii/domain/user/repository/ProfileShareTokenRepository.java
@@ -27,4 +27,6 @@ public interface ProfileShareTokenRepository extends JpaRepository<ProfileShareT
         AND t.revokedAt IS NULL
         """)
     Optional<ProfileShareToken> findActiveByTokenWithUserDetails(@Param("token") String token);
+
+    void deleteAllByUser_Id(Long userId);
 }

--- a/src/main/java/com/example/bookiibookii/domain/user/repository/UserImageRepository.java
+++ b/src/main/java/com/example/bookiibookii/domain/user/repository/UserImageRepository.java
@@ -12,4 +12,5 @@ public interface UserImageRepository extends JpaRepository<UserImage, Long> {
     boolean existsByS3Key(String s3Key);
     boolean existsByS3KeyAndUser_IdNot(String s3Key, Long userId);
     boolean existsByUser_Id(Long userId);
+    void deleteByUser_Id(Long userId);
 }

--- a/src/main/java/com/example/bookiibookii/domain/user/service/UserService.java
+++ b/src/main/java/com/example/bookiibookii/domain/user/service/UserService.java
@@ -1,6 +1,5 @@
 package com.example.bookiibookii.domain.user.service;
 
-import com.example.bookiibookii.domain.review.entity.BookReview;
 import com.example.bookiibookii.domain.review.repository.BookReviewRepository;
 import com.example.bookiibookii.domain.user.dto.req.UserRequestDTO;
 import com.example.bookiibookii.domain.user.dto.res.UserResponseDTO;
@@ -14,7 +13,6 @@ import com.example.bookiibookii.domain.user.exception.UserImageException;
 import com.example.bookiibookii.domain.user.exception.code.UserErrorCode;
 import com.example.bookiibookii.domain.user.exception.code.UserImageErrorCode;
 import com.example.bookiibookii.domain.user.repository.*;
-import com.example.bookiibookii.domain.review.entity.MemberReview;
 import com.example.bookiibookii.domain.review.enums.MemberReviewReaction;
 import com.example.bookiibookii.domain.review.repository.MemberReviewRepository;
 
@@ -164,11 +162,18 @@ public class UserService {
         }
     }
 
-    // 유저 프로필 조회
-    @Transactional(readOnly = true)
-    public UserResponseDTO.UserProfileResDTO getProfileInfo(Long userId) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new UserException(UserErrorCode.NOT_FOUND));
+    private record CommonProfileData(
+            String profileImageUrl,
+            List<UserResponseDTO.UserBookDto> userBooks,
+            int bookReviewCount,
+            List<UserResponseDTO.BookReviewSummaryDto> recentBookReviews,
+            int boomUpCount,
+            List<UserResponseDTO.ReceivedMemberReviewDto> recentReceivedReviews
+    ) {}
+
+    private CommonProfileData buildCommonProfileData(User user) {
+        Long userId = user.getId();
+        Instant since = user.getLastResetAt();
 
         String profileImageUrl = null;
         if (user.getUserImage() != null) {
@@ -176,19 +181,14 @@ public class UserService {
                     user.getUserImage().getS3Key(), PRESIGNED_GET_URL_EXPIRATION_MINUTES);
         }
 
-        Instant since = user.getLastResetAt();
-
-        // 대표책 목록
         List<UserResponseDTO.UserBookDto> userBooks = userBookRepository.findRepresentativeBooks(userId).stream()
                 .map(ub -> new UserResponseDTO.UserBookDto(ub.getBook().getTitle(), ub.getBook().getAuthor(), ub.getBook().getImage()))
                 .toList();
 
-        // 책 후기 개수
-        long bookReviewCount = bookReviewRepository.countReviewedBooksByUserId(userId, since);
+        int bookReviewCount = (int) bookReviewRepository.countReviewedBooksByUserId(userId, since);
 
-        // 최신 후기 2개
-        List<BookReview> recentBookReviews = bookReviewRepository.findReviewedBooksByUserId(userId, since, PageRequest.of(0, 2));
-        List<UserResponseDTO.BookReviewSummaryDto> recentBookReviewSummaries = recentBookReviews.stream()
+        List<UserResponseDTO.BookReviewSummaryDto> recentBookReviews = bookReviewRepository
+                .findReviewedBooksByUserId(userId, since, PageRequest.of(0, 2)).stream()
                 .map(br -> UserResponseDTO.BookReviewSummaryDto.builder()
                         .bookTitle(br.getMemberBook().getBook().getTitle())
                         .bookAuthor(br.getMemberBook().getBook().getAuthor())
@@ -199,12 +199,10 @@ public class UserService {
                         .build())
                 .collect(Collectors.toList());
 
-        // 받은 BOOM_UP 총 개수
-        long boomUpCount = memberReviewRepository.countByTargetUserIdAndReaction(userId, MemberReviewReaction.BOOM_UP, since);
+        int boomUpCount = (int) memberReviewRepository.countByTargetUserIdAndReaction(userId, MemberReviewReaction.BOOM_UP, since);
 
-        // 최신 받은 후기 3개
-        List<MemberReview> receivedReviews = memberReviewRepository.findLatestReceivedByUserId(userId, since, PageRequest.of(0, 3));
-        List<UserResponseDTO.ReceivedMemberReviewDto> recentReceivedReviews = receivedReviews.stream()
+        List<UserResponseDTO.ReceivedMemberReviewDto> recentReceivedReviews = memberReviewRepository
+                .findLatestReceivedByUserId(userId, since, PageRequest.of(0, 3)).stream()
                 .map(mr -> {
                     User writer = mr.getWriter().getUser();
                     String writerProfileUrl = null;
@@ -222,18 +220,28 @@ public class UserService {
                 })
                 .collect(Collectors.toList());
 
+        return new CommonProfileData(profileImageUrl, userBooks, bookReviewCount, recentBookReviews, boomUpCount, recentReceivedReviews);
+    }
+
+    // 유저 프로필 조회
+    @Transactional(readOnly = true)
+    public UserResponseDTO.UserProfileResDTO getProfileInfo(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(UserErrorCode.NOT_FOUND));
+        CommonProfileData data = buildCommonProfileData(user);
+
         return UserResponseDTO.UserProfileResDTO.builder()
                 .userId(userId)
-                .profileImageUrl(profileImageUrl)
+                .profileImageUrl(data.profileImageUrl())
                 .nickname(user.getNickName())
                 .introduction(user.getIntroduction())
                 .gender(user.getGender())
                 .birthDate(user.getBirth() == null ? null : user.getBirth().toString())
-                .userBooks(userBooks)
-                .bookReviewCount((int) bookReviewCount)
-                .recentBookReviews(recentBookReviewSummaries)
-                .boomUpCount((int) boomUpCount)
-                .recentReceivedReviews(recentReceivedReviews)
+                .userBooks(data.userBooks())
+                .bookReviewCount(data.bookReviewCount())
+                .recentBookReviews(data.recentBookReviews())
+                .boomUpCount(data.boomUpCount())
+                .recentReceivedReviews(data.recentReceivedReviews())
                 .build();
     }
 
@@ -260,64 +268,18 @@ public class UserService {
     public UserResponseDTO.OtherUserProfileResDTO getOtherUserProfile(Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserException(UserErrorCode.NOT_FOUND));
-
-        String profileImageUrl = null;
-        if (user.getUserImage() != null) {
-            profileImageUrl = userImageS3Service.generatePresignedGetUrl(
-                    user.getUserImage().getS3Key(), PRESIGNED_GET_URL_EXPIRATION_MINUTES);
-        }
-
-        Instant since = user.getLastResetAt();
-
-        List<UserResponseDTO.UserBookDto> userBooks = userBookRepository.findRepresentativeBooks(userId).stream()
-                .map(ub -> new UserResponseDTO.UserBookDto(ub.getBook().getTitle(), ub.getBook().getAuthor(), ub.getBook().getImage()))
-                .toList();
-
-        long bookReviewCount = bookReviewRepository.countReviewedBooksByUserId(userId, since);
-
-        List<BookReview> recentBookReviews = bookReviewRepository.findReviewedBooksByUserId(userId, since, PageRequest.of(0, 2));
-        List<UserResponseDTO.BookReviewSummaryDto> recentBookReviewSummaries = recentBookReviews.stream()
-                .map(br -> UserResponseDTO.BookReviewSummaryDto.builder()
-                        .bookTitle(br.getMemberBook().getBook().getTitle())
-                        .bookAuthor(br.getMemberBook().getBook().getAuthor())
-                        .tradeType(br.getMemberBook().getGroup().getTradeType())
-                        .rating(br.getStar())
-                        .comment(br.getComment())
-                        .reviewDate(TimeUtils.formatKst(br.getUpdatedAt(), DATE_FMT))
-                        .build())
-                .collect(Collectors.toList());
-
-        long boomUpCount = memberReviewRepository.countByTargetUserIdAndReaction(userId, MemberReviewReaction.BOOM_UP, since);
-
-        List<MemberReview> receivedReviews = memberReviewRepository.findLatestReceivedByUserId(userId, since, PageRequest.of(0, 3));
-        List<UserResponseDTO.ReceivedMemberReviewDto> recentReceivedReviews = receivedReviews.stream()
-                .map(mr -> {
-                    User writer = mr.getWriter().getUser();
-                    String writerProfileUrl = null;
-                    if (writer.getUserImage() != null) {
-                        writerProfileUrl = userImageS3Service.generatePresignedGetUrl(
-                                writer.getUserImage().getS3Key(), PRESIGNED_GET_URL_EXPIRATION_MINUTES);
-                    }
-                    return UserResponseDTO.ReceivedMemberReviewDto.builder()
-                            .reviewerNickname(writer.getNickName() != null ? writer.getNickName() : "(알 수 없음)")
-                            .reviewerProfileUrl(writerProfileUrl)
-                            .reaction(mr.getReaction())
-                            .comment(mr.getComment())
-                            .createdAt(TimeUtils.formatKst(mr.getCreatedAt(), DATE_FMT))
-                            .build();
-                })
-                .collect(Collectors.toList());
+        CommonProfileData data = buildCommonProfileData(user);
 
         return UserResponseDTO.OtherUserProfileResDTO.builder()
                 .userId(userId)
-                .profileImageUrl(profileImageUrl)
+                .profileImageUrl(data.profileImageUrl())
                 .nickname(user.getNickName())
                 .introduction(user.getIntroduction())
-                .userBooks(userBooks)
-                .bookReviewCount((int) bookReviewCount)
-                .recentBookReviews(recentBookReviewSummaries)
-                .boomUpCount((int) boomUpCount)
-                .recentReceivedReviews(recentReceivedReviews)
+                .userBooks(data.userBooks())
+                .bookReviewCount(data.bookReviewCount())
+                .recentBookReviews(data.recentBookReviews())
+                .boomUpCount(data.boomUpCount())
+                .recentReceivedReviews(data.recentReceivedReviews())
                 .build();
     }
 

--- a/src/main/java/com/example/bookiibookii/domain/user/service/UserService.java
+++ b/src/main/java/com/example/bookiibookii/domain/user/service/UserService.java
@@ -234,9 +234,76 @@ public class UserService {
 
     // 닉네임으로 유저 ID 찾기 (타 유저 프로필 조회용)
     public Long findUserIdByNickname(String nickname) {
-        return userRepository.findByNickName(nickname)
-                .orElseThrow(() -> new UserException(UserErrorCode.NOT_FOUND))
-                .getId();
+        User user = userRepository.findByNickName(nickname)
+                .orElseThrow(() -> new UserException(UserErrorCode.NOT_FOUND));
+        if (user.getStatus() == Status.WITHDRAWN) {
+            throw new UserException(UserErrorCode.USER_WITHDRAWN);
+        }
+        return user.getId();
+    }
+
+    // 타 유저 프로필 조회
+    @Transactional(readOnly = true)
+    public UserResponseDTO.OtherUserProfileResDTO getOtherUserProfile(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(UserErrorCode.NOT_FOUND));
+
+        String profileImageUrl = null;
+        if (user.getUserImage() != null) {
+            profileImageUrl = userImageS3Service.generatePresignedGetUrl(
+                    user.getUserImage().getS3Key(), PRESIGNED_GET_URL_EXPIRATION_MINUTES);
+        }
+
+        List<UserResponseDTO.UserBookDto> userBooks = userBookRepository.findRepresentativeBooks(userId).stream()
+                .map(ub -> new UserResponseDTO.UserBookDto(ub.getBook().getTitle(), ub.getBook().getAuthor(), ub.getBook().getImage()))
+                .toList();
+
+        long bookReviewCount = bookReviewRepository.countReviewedBooksByUserId(userId);
+
+        List<BookReview> recentBookReviews = bookReviewRepository.findReviewedBooksByUserId(userId, PageRequest.of(0, 2));
+        List<UserResponseDTO.BookReviewSummaryDto> recentBookReviewSummaries = recentBookReviews.stream()
+                .map(br -> UserResponseDTO.BookReviewSummaryDto.builder()
+                        .bookTitle(br.getMemberBook().getBook().getTitle())
+                        .bookAuthor(br.getMemberBook().getBook().getAuthor())
+                        .tradeType(br.getMemberBook().getGroup().getTradeType())
+                        .rating(br.getStar())
+                        .comment(br.getComment())
+                        .reviewDate(TimeUtils.formatKst(br.getUpdatedAt(), DATE_FMT))
+                        .build())
+                .collect(Collectors.toList());
+
+        long boomUpCount = memberReviewRepository.countByTargetUserIdAndReaction(userId, MemberReviewReaction.BOOM_UP);
+
+        List<MemberReview> receivedReviews = memberReviewRepository.findLatestReceivedByUserId(userId, PageRequest.of(0, 3));
+        List<UserResponseDTO.ReceivedMemberReviewDto> recentReceivedReviews = receivedReviews.stream()
+                .map(mr -> {
+                    User writer = mr.getWriter().getUser();
+                    String writerProfileUrl = null;
+                    if (writer.getUserImage() != null) {
+                        writerProfileUrl = userImageS3Service.generatePresignedGetUrl(
+                                writer.getUserImage().getS3Key(), PRESIGNED_GET_URL_EXPIRATION_MINUTES);
+                    }
+                    return UserResponseDTO.ReceivedMemberReviewDto.builder()
+                            .reviewerNickname(writer.getNickName())
+                            .reviewerProfileUrl(writerProfileUrl)
+                            .reaction(mr.getReaction())
+                            .comment(mr.getComment())
+                            .createdAt(TimeUtils.formatKst(mr.getCreatedAt(), DATE_FMT))
+                            .build();
+                })
+                .collect(Collectors.toList());
+
+        return UserResponseDTO.OtherUserProfileResDTO.builder()
+                .userId(userId)
+                .profileImageUrl(profileImageUrl)
+                .nickname(user.getNickName())
+                .introduction(user.getIntroduction())
+                .userBooks(userBooks)
+                .bookReviewCount((int) bookReviewCount)
+                .recentBookReviews(recentBookReviewSummaries)
+                .boomUpCount((int) boomUpCount)
+                .recentReceivedReviews(recentReceivedReviews)
+                .build();
     }
 
     // 마이페이지 설정

--- a/src/main/java/com/example/bookiibookii/domain/user/service/UserService.java
+++ b/src/main/java/com/example/bookiibookii/domain/user/service/UserService.java
@@ -48,6 +48,7 @@ public class UserService {
     private final UserBookRepository userBookRepository;
     private final BookshelfService bookshelfService;
     private final MemberReviewRepository memberReviewRepository;
+    private final ProfileShareTokenRepository profileShareTokenRepository;
 
     // 소셜 유저 조회 or 생성
     public User findOrCreateSocialUser(
@@ -58,6 +59,7 @@ public class UserService {
             return userRepository.findBySocialIdAndSocialType(info.getSocialId(), socialType)
                     .map(user -> {
                         if (user.getStatus() == Status.WITHDRAWN) {
+                            resetUserData(user);
                             user.reactivate();
                         }
                         return user;
@@ -67,6 +69,14 @@ public class UserService {
             return userRepository.findBySocialIdAndSocialType(info.getSocialId(), socialType)
                     .orElseThrow(() -> new UserException(UserErrorCode.SOCIAL_USER_CREATE_RACE_CONDITION));
         }
+    }
+
+    private void resetUserData(User user) {
+        userTagRepository.deleteAllByUser(user);
+        userBookRepository.deleteAllByUser(user);
+        userImageRepository.deleteByUser_Id(user.getId());
+        profileShareTokenRepository.deleteAllByUser_Id(user.getId());
+        user.reset();
     }
 
     @Transactional

--- a/src/main/java/com/example/bookiibookii/domain/user/service/UserService.java
+++ b/src/main/java/com/example/bookiibookii/domain/user/service/UserService.java
@@ -26,6 +26,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
@@ -175,16 +176,18 @@ public class UserService {
                     user.getUserImage().getS3Key(), PRESIGNED_GET_URL_EXPIRATION_MINUTES);
         }
 
+        Instant since = user.getLastResetAt();
+
         // 대표책 목록
         List<UserResponseDTO.UserBookDto> userBooks = userBookRepository.findRepresentativeBooks(userId).stream()
                 .map(ub -> new UserResponseDTO.UserBookDto(ub.getBook().getTitle(), ub.getBook().getAuthor(), ub.getBook().getImage()))
                 .toList();
 
         // 책 후기 개수
-        long bookReviewCount = bookReviewRepository.countReviewedBooksByUserId(userId);
+        long bookReviewCount = bookReviewRepository.countReviewedBooksByUserId(userId, since);
 
         // 최신 후기 2개
-        List<BookReview> recentBookReviews = bookReviewRepository.findReviewedBooksByUserId(userId, PageRequest.of(0, 2));
+        List<BookReview> recentBookReviews = bookReviewRepository.findReviewedBooksByUserId(userId, since, PageRequest.of(0, 2));
         List<UserResponseDTO.BookReviewSummaryDto> recentBookReviewSummaries = recentBookReviews.stream()
                 .map(br -> UserResponseDTO.BookReviewSummaryDto.builder()
                         .bookTitle(br.getMemberBook().getBook().getTitle())
@@ -197,10 +200,10 @@ public class UserService {
                 .collect(Collectors.toList());
 
         // 받은 BOOM_UP 총 개수
-        long boomUpCount = memberReviewRepository.countByTargetUserIdAndReaction(userId, MemberReviewReaction.BOOM_UP);
+        long boomUpCount = memberReviewRepository.countByTargetUserIdAndReaction(userId, MemberReviewReaction.BOOM_UP, since);
 
         // 최신 받은 후기 3개
-        List<MemberReview> receivedReviews = memberReviewRepository.findLatestReceivedByUserId(userId, PageRequest.of(0, 3));
+        List<MemberReview> receivedReviews = memberReviewRepository.findLatestReceivedByUserId(userId, since, PageRequest.of(0, 3));
         List<UserResponseDTO.ReceivedMemberReviewDto> recentReceivedReviews = receivedReviews.stream()
                 .map(mr -> {
                     User writer = mr.getWriter().getUser();
@@ -210,7 +213,7 @@ public class UserService {
                                 writer.getUserImage().getS3Key(), PRESIGNED_GET_URL_EXPIRATION_MINUTES);
                     }
                     return UserResponseDTO.ReceivedMemberReviewDto.builder()
-                            .reviewerNickname(writer.getNickName())
+                            .reviewerNickname(writer.getNickName() != null ? writer.getNickName() : "(알 수 없음)")
                             .reviewerProfileUrl(writerProfileUrl)
                             .reaction(mr.getReaction())
                             .comment(mr.getComment())
@@ -264,13 +267,15 @@ public class UserService {
                     user.getUserImage().getS3Key(), PRESIGNED_GET_URL_EXPIRATION_MINUTES);
         }
 
+        Instant since = user.getLastResetAt();
+
         List<UserResponseDTO.UserBookDto> userBooks = userBookRepository.findRepresentativeBooks(userId).stream()
                 .map(ub -> new UserResponseDTO.UserBookDto(ub.getBook().getTitle(), ub.getBook().getAuthor(), ub.getBook().getImage()))
                 .toList();
 
-        long bookReviewCount = bookReviewRepository.countReviewedBooksByUserId(userId);
+        long bookReviewCount = bookReviewRepository.countReviewedBooksByUserId(userId, since);
 
-        List<BookReview> recentBookReviews = bookReviewRepository.findReviewedBooksByUserId(userId, PageRequest.of(0, 2));
+        List<BookReview> recentBookReviews = bookReviewRepository.findReviewedBooksByUserId(userId, since, PageRequest.of(0, 2));
         List<UserResponseDTO.BookReviewSummaryDto> recentBookReviewSummaries = recentBookReviews.stream()
                 .map(br -> UserResponseDTO.BookReviewSummaryDto.builder()
                         .bookTitle(br.getMemberBook().getBook().getTitle())
@@ -282,9 +287,9 @@ public class UserService {
                         .build())
                 .collect(Collectors.toList());
 
-        long boomUpCount = memberReviewRepository.countByTargetUserIdAndReaction(userId, MemberReviewReaction.BOOM_UP);
+        long boomUpCount = memberReviewRepository.countByTargetUserIdAndReaction(userId, MemberReviewReaction.BOOM_UP, since);
 
-        List<MemberReview> receivedReviews = memberReviewRepository.findLatestReceivedByUserId(userId, PageRequest.of(0, 3));
+        List<MemberReview> receivedReviews = memberReviewRepository.findLatestReceivedByUserId(userId, since, PageRequest.of(0, 3));
         List<UserResponseDTO.ReceivedMemberReviewDto> recentReceivedReviews = receivedReviews.stream()
                 .map(mr -> {
                     User writer = mr.getWriter().getUser();
@@ -294,7 +299,7 @@ public class UserService {
                                 writer.getUserImage().getS3Key(), PRESIGNED_GET_URL_EXPIRATION_MINUTES);
                     }
                     return UserResponseDTO.ReceivedMemberReviewDto.builder()
-                            .reviewerNickname(writer.getNickName())
+                            .reviewerNickname(writer.getNickName() != null ? writer.getNickName() : "(알 수 없음)")
                             .reviewerProfileUrl(writerProfileUrl)
                             .reaction(mr.getReaction())
                             .comment(mr.getComment())


### PR DESCRIPTION
## 개요
<!---- 자신이 완료한 이슈를 닫아주세요 -->
- closed #601 //이슈 번호는 추적을 위해 필요합니다!
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
타유저 프로필 조회 API를 현재 마이페이지 DTO에 맞춰 수정
탈퇴한 유저의 프로필은 조회할 수 없도록 차단 
재가입 시 계정 데이터를 초기화하여 기존에 탈퇴 후 재가입 시 이전 데이터가 그대로 복원되는 문제 수정 

  - 
<!---- Resolves: #601 -->

## PR 유형
어떤 변경 사항이 있나요?

- [X] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [X] 코드 리팩토링
- [X] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

📣 **To Reviewers**
---
<!-- 전달사항 -->

- Reviewers : 팀 선택
- Labels : 작업 유형, 자기 자신


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새 기능**
  - 다른 사용자의 프로필에서 대표 책, 책 리뷰 수/최근 리뷰, 받은 BOOM_UP 수/최근 후기까지 확인할 수 있습니다.
  - 다른 사용자 프로필 조회 API의 응답 형식과 성공 안내가 개선되었습니다.
- **버그 수정**
  - 탈퇴한 사용자의 프로필 조회 시 적절한 오류가 안내됩니다.
  - 소셜 로그인으로 재가입할 때 이전 프로필 및 관련 데이터가 리셋된 상태로 복구됩니다.
  - 마이페이지의 작성/받은 리뷰 목록·집계가 마지막 리셋 시점을 기준으로 갱신됩니다.
- **문서**
  - 타 유저 프로필 조회 API의 Swagger/OpenAPI 응답 코드와 항목이 최신 상태로 반영되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->