### PR TITLE
Fix/#605 프로필 기본 이미지 초기화 불가 문제 및 카드 리액션 타입 수정

### DIFF
--- a/src/main/java/com/example/bookiibookii/domain/memberbook/controller/MemberBookCardControllerDocs.java
+++ b/src/main/java/com/example/bookiibookii/domain/memberbook/controller/MemberBookCardControllerDocs.java
@@ -177,7 +177,7 @@ public interface MemberBookCardControllerDocs {
             그룹 MatchedMember(본인 포함)가 독서카드에 리액션을 남기거나 취소합니다.
 
             - **엔드포인트**: `PATCH /api/member-books/cards/{cardId}/reactions`
-            - **요청 body**: `{ "reaction": "LIKE" }` — `CardReactionType` (LIKE, SAD, CHEERUP, FEELYOU, AWESOME, FUN)
+            - **요청 body**: `{ "reaction": "LIKE" }` — `CardReactionType` (LIKE, SAD, FEELYOU, ANGRY, FUN)
             - 동일 리액션을 다시 누르면 취소됩니다(토글). 응답 `active`: true = 적용, false = 취소.
             - 카드 소유자이거나 같은 그룹 멤버만 가능합니다.
             - 내 화면에서 숨긴 카드(`hidden=true`)는 404로 처리됩니다(상세 조회와 동일).

--- a/src/main/java/com/example/bookiibookii/domain/memberbook/enums/CardReactionType.java
+++ b/src/main/java/com/example/bookiibookii/domain/memberbook/enums/CardReactionType.java
@@ -3,8 +3,7 @@ package com.example.bookiibookii.domain.memberbook.enums;
 public enum CardReactionType {
     LIKE,
     SAD,
-    CHEERUP,
     FEELYOU,
-    AWESOME,
-    FUN
+    FUN,
+    ANGRY
 }

--- a/src/main/java/com/example/bookiibookii/domain/user/controller/UserControllerDocs.java
+++ b/src/main/java/com/example/bookiibookii/domain/user/controller/UserControllerDocs.java
@@ -130,7 +130,10 @@ public interface UserControllerDocs {
             summary = "마이페이지 정보 수정 API",
             description = """
             닉네임, 성별, 생년월일, 프로필 이미지를 수정합니다.
-            - 프로필 이미지: /api/users/me/image/presigned-url로 Presigned URL 발급 후 업로드하고, s3Key를 전달합니다. null이면 변경 없음.
+            - 프로필 이미지 변경: /api/users/me/image/presigned-url로 Presigned URL 발급 후 업로드하고, s3Key를 전달합니다.
+            - s3Key: null → 프로필 이미지 변경 없음
+            - s3Key: "DEFAULT" → 기본 이미지로 초기화 (기존 프로필 이미지 삭제)
+            - s3Key: 실제 S3 키 → 해당 이미지로 업데이트
             """
     )
     @ApiResponses({

--- a/src/main/java/com/example/bookiibookii/domain/user/dto/req/UserRequestDTO.java
+++ b/src/main/java/com/example/bookiibookii/domain/user/dto/req/UserRequestDTO.java
@@ -52,7 +52,11 @@ public class UserRequestDTO {
 
             LocalDate birth,
 
-            /** Presigned URL로 업로드 후 받은 s3Key. null이면 프로필 이미지 변경 안 함. */
+            /**
+             * Presigned URL로 업로드 후 받은 s3Key.
+             * null이면 프로필 이미지 변경 안 함.
+             * "DEFAULT"이면 기본 이미지로 초기화 (기존 이미지 삭제).
+             */
             String s3Key
     ){}
 

--- a/src/main/java/com/example/bookiibookii/domain/user/entity/UserImage.java
+++ b/src/main/java/com/example/bookiibookii/domain/user/entity/UserImage.java
@@ -12,6 +12,9 @@ import lombok.*;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class UserImage extends BaseEntity {
 
+    /** 기본 이미지로 초기화를 요청할 때 클라이언트가 s3Key 필드에 전달하는 센티넬 값 */
+    public static final String DEFAULT_IMAGE_SENTINEL = "DEFAULT";
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "user_image_id")

--- a/src/main/java/com/example/bookiibookii/domain/user/service/UserService.java
+++ b/src/main/java/com/example/bookiibookii/domain/user/service/UserService.java
@@ -294,8 +294,11 @@ public class UserService {
             user.updateName(request.nickname());
         }
 
-        if (request.s3Key() != null && !request.s3Key().isBlank()) {
-            saveOrUpdateUserImage(user, request.s3Key());
+        String s3Key = request.s3Key();
+        if (UserImage.DEFAULT_IMAGE_SENTINEL.equals(s3Key)) {
+            userImageRepository.findByUser_Id(user.getId()).ifPresent(userImageRepository::delete);
+        } else if (s3Key != null && !s3Key.isBlank()) {
+            saveOrUpdateUserImage(user, s3Key);
         }
 
         if (request.gender() != null || request.birth() != null) {


### PR DESCRIPTION
## 개요
<!---- 자신이 완료한 이슈를 닫아주세요 -->
- closed #605 //이슈 번호는 추적을 위해 필요합니다!
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
카드 리액션 enum값에 CHERRUP, AWESOME을 빼고 ANGRY 추가
클라이언트가 기본 이미지 선택 시 s3Key: "DEFAULT"를 전달하면 UserImage 레코드를 삭제하도록 처리

<!---- Resolves: #605  -->

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [X] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [X] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

📣 **To Reviewers**
---
<!-- 전달사항 -->

- Reviewers : 팀 선택
- Labels : 작업 유형, 자기 자신


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 마이페이지에서 프로필 이미지를 기본 이미지로 초기화할 수 있습니다.
  - 기본 이미지로 초기화하면 기존 프로필 이미지가 삭제됩니다.
  - 카드 반응 유형에 ‘화남’ 반응이 추가되었습니다.

- **변경 사항**
  - 기존 ‘응원’ 및 ‘최고예요’ 카드 반응이 제거되었습니다.
  - 프로필 이미지 업로드, 유지, 기본값 초기화 동작이 구분되어 처리됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->