### PR TITLE
[Feat] #607 iOS 개발중 발생한 버그 수정

### DIFF
--- a/src/main/java/com/example/bookiibookii/domain/memberbook/controller/MemberBookCardControllerDocs.java
+++ b/src/main/java/com/example/bookiibookii/domain/memberbook/controller/MemberBookCardControllerDocs.java
@@ -38,8 +38,9 @@ public interface MemberBookCardControllerDocs {
             - 그룹 멤버만 조회 가능합니다.
             - 생성일 기준 오름차순으로 반환합니다.
             - 목록 조회 전 `member_card`에서 현재 사용자·그룹 기준 `hidden=true`인 카드를 먼저 조회하고 제외합니다(소프트 삭제).
-            - 각 카드에 책 제목(`bookTitle`), 작성자(`creatorName`, `creatorProfileImageUrl`), 본인 책 여부(`isMine`), 북마크 여부(`isBookmarked`),
+            - 각 카드에 책 제목(`bookTitle`), 작성자(`creatorName`, `creatorProfileImageUrl`), 본인 작성 여부(`isMine`), 북마크 여부(`isBookmarked`),
               리액션 집계(`reactionCounts`), 내 리액션(`myReactions`)이 포함됩니다.
+            - `isMine`: 조회자가 작성한 카드이면 true. (`MemberBook.isMine`=내가 가져온 책 여부와는 다름)
             """
     )
     @ApiResponses({

--- a/src/main/java/com/example/bookiibookii/domain/memberbook/controller/MemberBookLibraryControllerDocs.java
+++ b/src/main/java/com/example/bookiibookii/domain/memberbook/controller/MemberBookLibraryControllerDocs.java
@@ -77,10 +77,13 @@ public interface MemberBookLibraryControllerDocs {
             - **제거 단위**: `memberBookId` 1건 (그룹당 최대 2권이면 책마다 각각 제거)
             - **권한**: 본인 MatchedMember에 연결된 MemberBook만 제거 가능
             - **그룹 내 다른 멤버**: 해당 그룹·카드·자신의 다른 MemberBook은 계속 조회 가능
+            - **북마크 제약**: 해당 MemberBook 소속 독서카드 중 본인이 북마크한 카드가 있으면 제거할 수 없습니다 (`MB400_11`).
+              독서카드 삭제(`MB400_8`)와 동일하게, 북마크를 해제한 뒤 다시 시도해야 합니다.
             """
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "제거 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "북마크된 독서카드 존재 (MB400_11)"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 필요"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "MemberBook 없음 또는 소유자가 아님")
     })

--- a/src/main/java/com/example/bookiibookii/domain/memberbook/dto/res/MemberCardResponseDTO.java
+++ b/src/main/java/com/example/bookiibookii/domain/memberbook/dto/res/MemberCardResponseDTO.java
@@ -23,6 +23,7 @@ public class MemberCardResponseDTO {
     private Integer totalPages;
     private String genre;
     private Instant completedAt;
+    /** 조회자가 작성한 카드 여부 (MemberBook 소유자 == 조회자) */
     private Boolean isMine;
     private Boolean isBookmarked;
     private String creatorName;

--- a/src/main/java/com/example/bookiibookii/domain/memberbook/exception/code/MemberBookErrorCode.java
+++ b/src/main/java/com/example/bookiibookii/domain/memberbook/exception/code/MemberBookErrorCode.java
@@ -24,6 +24,11 @@ public enum MemberBookErrorCode implements BaseCode {
     MEMBER_CARD_STATE_CONFLICT(HttpStatus.CONFLICT, "MB409_1", "일시적인 충돌이 발생했습니다. 다시 시도해주세요."),
     CARD_REACTION_STATE_CONFLICT(HttpStatus.CONFLICT, "MB409_2", "일시적인 충돌이 발생했습니다. 다시 시도해주세요."),
     CARD_NOT_SHAREABLE(HttpStatus.BAD_REQUEST, "MB400_10", "공유할 수 없는 독서카드입니다."),
+    BOOKMARKED_CARD_CANNOT_REMOVE_FROM_LIBRARY(
+            HttpStatus.BAD_REQUEST,
+            "MB400_11",
+            "북마크된 독서카드가 있습니다. 북마크를 취소하고 서재를 삭제해주세요."
+    ),
     SHARE_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "MB404_4", "공유 링크를 찾을 수 없거나 만료되었습니다.");
 
     private final HttpStatus status;

--- a/src/main/java/com/example/bookiibookii/domain/memberbook/repository/MemberBookRepository.java
+++ b/src/main/java/com/example/bookiibookii/domain/memberbook/repository/MemberBookRepository.java
@@ -1,7 +1,9 @@
 package com.example.bookiibookii.domain.memberbook.repository;
 
 import com.example.bookiibookii.domain.memberbook.entity.MemberBook;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -13,6 +15,27 @@ import java.util.Optional;
 public interface MemberBookRepository extends JpaRepository<MemberBook, Long> {
 
     Optional<MemberBook> findByIdAndMatchedMember_User_Id(Long id, Long userId);
+
+    /**
+     * 서재 제거 시 북마크 검사와 markRemoved를 직렬화하기 위한 비관적 락.
+     * {@code toggleBookmark}의 {@link #findByIdForUpdate}와 동일한 MemberBook 행 락을 공유합니다.
+     */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("""
+        SELECT mb FROM MemberBook mb
+        WHERE mb.id = :id AND mb.matchedMember.user.id = :userId
+        """)
+    Optional<MemberBook> findByIdAndMatchedMember_User_IdForUpdate(
+            @Param("id") Long id,
+            @Param("userId") Long userId
+    );
+
+    /**
+     * 북마크 토글 시 대상 카드의 MemberBook을 잠가 서재 제거와 직렬화합니다.
+     */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT mb FROM MemberBook mb WHERE mb.id = :id")
+    Optional<MemberBook> findByIdForUpdate(@Param("id") Long id);
 
     @Query("""
         SELECT mb FROM MemberBook mb

--- a/src/main/java/com/example/bookiibookii/domain/memberbook/repository/MemberCardRepository.java
+++ b/src/main/java/com/example/bookiibookii/domain/memberbook/repository/MemberCardRepository.java
@@ -79,4 +79,23 @@ public interface MemberCardRepository extends JpaRepository<MemberCard, Long> {
     @Modifying(clearAutomatically = true)
     @Query("DELETE FROM MemberCard mc WHERE mc.matchedMember.id = :matchedMemberId")
     void deleteByMatchedMember_Id(@Param("matchedMemberId") Long matchedMemberId);
+
+    /**
+     * 서재(MemberBook) 삭제 전 검사: 해당 MemberBook 소속 카드 중
+     * 요청자 MatchedMember가 북마크한(삭제되지 않은) 카드가 있는지 여부.
+     * 독서카드 삭제({@code BOOKMARKED_CARD_CANNOT_DELETE})와 동일한 북마크 제약.
+     */
+    @Query("""
+        SELECT CASE WHEN COUNT(mc) > 0 THEN true ELSE false END
+        FROM MemberCard mc
+        JOIN mc.card c
+        WHERE c.memberBook.id = :memberBookId
+          AND mc.matchedMember.id = :matchedMemberId
+          AND mc.bookmarked = true
+          AND c.deletedAt IS NULL
+        """)
+    boolean existsBookmarkedCardByMatchedMemberAndMemberBook(
+            @Param("matchedMemberId") Long matchedMemberId,
+            @Param("memberBookId") Long memberBookId
+    );
 }

--- a/src/main/java/com/example/bookiibookii/domain/memberbook/service/MemberBookCardService.java
+++ b/src/main/java/com/example/bookiibookii/domain/memberbook/service/MemberBookCardService.java
@@ -224,6 +224,10 @@ public class MemberBookCardService {
     public boolean toggleBookmark(Long cardId, Long userId) {
         Cards card = getCardForDetail(cardId, userId);
         Long groupId = card.getMemberBook().getGroup().getId();
+        // 서재 제거(removeFromLibrary)와 동일 MemberBook 행 락으로 직렬화.
+        // 북마크 검사 → markRemoved 사이에 bookmarked=true 커밋이 끼어들지 못하게 함.
+        memberBookRepository.findByIdForUpdate(card.getMemberBook().getId())
+                .orElseThrow(() -> new MemberBookException(MemberBookErrorCode.MEMBER_BOOK_NOT_FOUND));
 
         MatchedMember matchedMember = matchedMemberRepository.findByGroup_IdAndUser_Id(groupId, userId)
                 .orElseThrow(() -> new MemberBookException(MemberBookErrorCode.MATCHED_MEMBER_NOT_FOUND));

--- a/src/main/java/com/example/bookiibookii/domain/memberbook/service/MemberBookCardService.java
+++ b/src/main/java/com/example/bookiibookii/domain/memberbook/service/MemberBookCardService.java
@@ -641,7 +641,7 @@ public class MemberBookCardService {
                 .totalPages(totalPages)
                 .genre(genre)
                 .completedAt(completedAt)
-                .isMine(isMyBookForViewer(memberBook, viewer))
+                .isMine(isMyCardForViewer(memberBook, viewer))
                 .isBookmarked(isBookmarked)
                 .creatorName(creatorName)
                 .creatorProfileImageUrl(creatorProfileImageUrl)
@@ -731,14 +731,18 @@ public class MemberBookCardService {
     }
 
     /**
-     * 조회자 기준 본인 책 여부. MemberBook.isMine은 카드 작성자 MatchedMember 기준이므로
-     * 그룹 카드 목록처럼 상대 카드를 함께 볼 때는 조회자 MatchedMember로 변환합니다.
+     * 조회자 기준 본인 작성 카드 여부.
+     * 카드는 MemberBook(=작성자 MatchedMember)에 달리므로, 조회자가 그 MemberBook 소유자인지만 보면 됩니다.
+     *
+     * <p>주의: {@code MemberBook.isMine}은 "내가 가져온 원본 책인지" 플래그라서
+     * {@code isMine == isOwnedBy(viewer)} 로 계산하면 상대 책을 읽으며 쓴 내 카드가 false가 되고,
+     * 상대가 내 원본 책에 쓴 카드가 true가 되어 "내 독서카드만 보기"가 반대로 동작합니다.
      */
-    private boolean isMyBookForViewer(MemberBook memberBook, MatchedMember viewer) {
+    private boolean isMyCardForViewer(MemberBook memberBook, MatchedMember viewer) {
         if (memberBook == null || viewer == null) {
             return false;
         }
-        return memberBook.isMine() == memberBook.isOwnedBy(viewer);
+        return memberBook.isOwnedBy(viewer);
     }
 
     private String resolveCreatorName(MemberBook memberBook) {

--- a/src/main/java/com/example/bookiibookii/domain/memberbook/service/MemberBookLibraryService.java
+++ b/src/main/java/com/example/bookiibookii/domain/memberbook/service/MemberBookLibraryService.java
@@ -39,10 +39,14 @@ public class MemberBookLibraryService {
      * 서재에서만 제거(소프트 삭제). 그룹·카드·상대 MemberBook은 삭제되지 않습니다.
      * 본인 MatchedMember에 속한 MemberBook만 제거할 수 있습니다.
      * 해당 MemberBook 소속 카드 중 본인이 북마크한 카드가 있으면 제거할 수 없습니다.
+     * <p>
+     * 북마크 존재 검사와 {@code markRemoved} 사이에 {@code toggleBookmark}가 끼어드는
+     * TOCTOU를 막기 위해 MemberBook에 비관적 락을 잡고, 북마크 토글 경로와 동일 락을 공유합니다.
      */
     @Transactional
     public void removeFromLibrary(Long memberBookId, Long userId) {
-        MemberBook memberBook = memberBookRepository.findByIdAndMatchedMember_User_Id(memberBookId, userId)
+        MemberBook memberBook = memberBookRepository
+                .findByIdAndMatchedMember_User_IdForUpdate(memberBookId, userId)
                 .orElseThrow(() -> new MemberBookException(MemberBookErrorCode.MEMBER_BOOK_NOT_FOUND));
 
         MatchedMember matchedMember = memberBook.getMatchedMember();

--- a/src/main/java/com/example/bookiibookii/domain/memberbook/service/MemberBookLibraryService.java
+++ b/src/main/java/com/example/bookiibookii/domain/memberbook/service/MemberBookLibraryService.java
@@ -1,11 +1,13 @@
 package com.example.bookiibookii.domain.memberbook.service;
 
+import com.example.bookiibookii.domain.group.entity.MatchedMember;
 import com.example.bookiibookii.domain.group.util.ReadingPeriodDateCalculator;
 import com.example.bookiibookii.domain.memberbook.dto.res.LibraryMemberBookResponseDTO;
 import com.example.bookiibookii.domain.memberbook.entity.MemberBook;
 import com.example.bookiibookii.domain.memberbook.exception.MemberBookException;
 import com.example.bookiibookii.domain.memberbook.exception.code.MemberBookErrorCode;
 import com.example.bookiibookii.domain.memberbook.repository.MemberBookRepository;
+import com.example.bookiibookii.domain.memberbook.repository.MemberCardRepository;
 import com.example.bookiibookii.domain.review.entity.BookReview;
 import com.example.bookiibookii.domain.review.repository.BookReviewRepository;
 import com.example.bookiibookii.domain.user.service.UserImageS3Service;
@@ -26,6 +28,7 @@ import java.util.stream.Collectors;
 public class MemberBookLibraryService {
 
     private final MemberBookRepository memberBookRepository;
+    private final MemberCardRepository memberCardRepository;
     private final BookReviewRepository bookReviewRepository;
     private final UserImageS3Service userImageS3Service;
     private final Clock clock;
@@ -35,11 +38,22 @@ public class MemberBookLibraryService {
     /**
      * 서재에서만 제거(소프트 삭제). 그룹·카드·상대 MemberBook은 삭제되지 않습니다.
      * 본인 MatchedMember에 속한 MemberBook만 제거할 수 있습니다.
+     * 해당 MemberBook 소속 카드 중 본인이 북마크한 카드가 있으면 제거할 수 없습니다.
      */
     @Transactional
     public void removeFromLibrary(Long memberBookId, Long userId) {
         MemberBook memberBook = memberBookRepository.findByIdAndMatchedMember_User_Id(memberBookId, userId)
                 .orElseThrow(() -> new MemberBookException(MemberBookErrorCode.MEMBER_BOOK_NOT_FOUND));
+
+        MatchedMember matchedMember = memberBook.getMatchedMember();
+        if (matchedMember != null
+                && memberCardRepository.existsBookmarkedCardByMatchedMemberAndMemberBook(
+                matchedMember.getId(),
+                memberBook.getId()
+        )) {
+            throw new MemberBookException(MemberBookErrorCode.BOOKMARKED_CARD_CANNOT_REMOVE_FROM_LIBRARY);
+        }
+
         memberBook.markRemoved(clock.instant());
     }
 


### PR DESCRIPTION
## 개요
<!---- 자신이 완료한 이슈를 닫아주세요 -->
- closed #607 
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
서재 삭제할 때 해당 서재에 북마크한 독서카드 여부 확인하는 로직 추가
내 독서카드만 보기 로직 수정
<!---- Resolves: #(Isuue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

📣 **To Reviewers**
---
<!-- 전달사항 -->

- Reviewers : 팀 선택
- Labels : 작업 유형, 자기 자신


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **기능 개선**
  * 서재에서 북마크된 독서카드가 포함된 서재는 삭제할 수 없도록 제한했습니다.
  * 삭제 시 관련 오류 코드와 안내를 제공하며, 북마크 해제 후 재시도할 수 있습니다.
* **버그 수정**
  * 독서카드 목록의 `isMine` 표시 기준을 ‘본인이 작성한 카드 여부’로 바로잡았습니다.
* **문서**
  * 서재 삭제 제한 조건과 `isMine` 필드의 의미를 API 문서에 명확히 반영했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->