### PR TITLE
[Feat] Apple 소셜 로그인 token revoke 구현 및 기능 보강

### DIFF
--- a/src/main/java/com/example/bookiibookii/domain/user/entity/User.java
+++ b/src/main/java/com/example/bookiibookii/domain/user/entity/User.java
@@ -83,6 +83,9 @@ public class User extends BaseEntity {
     @Column(name = "last_reset_at")
     private Instant lastResetAt;
 
+    @Column(name = "apple_refresh_token", length = 1000)
+    private String appleRefreshToken;
+
     // 소셜 로그인 유저 생성
     public static User createSocialUser(
             SocialUserInfo info,
@@ -108,7 +111,9 @@ public class User extends BaseEntity {
         this.birth = null;
         this.onboardingStatus = OnboardingStatus.NEW;
         this.lastResetAt = Instant.now();
+        this.appleRefreshToken = null;
     }
+    public void updateAppleRefreshToken(String token) { this.appleRefreshToken = token; }
     public void updateName(String name) { this.nickName = name; }
     public void updateIntroduction(String introduction) { this.introduction = introduction; }
     public void updateUserInform(Gender gender, LocalDate birth) { this.gender = gender; this.birth = birth; }

--- a/src/main/java/com/example/bookiibookii/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/bookiibookii/domain/user/repository/UserRepository.java
@@ -44,6 +44,15 @@ public interface UserRepository extends JpaRepository<User, Long> {
             @Param("socialType") SocialType socialType
     );
 
+    @Query("""
+    SELECT u FROM User u
+    WHERE u.status = 'WITHDRAWN'
+    AND u.updatedAt <= :deleteBefore
+    AND u.socialType = 'APPLE'
+    AND u.appleRefreshToken IS NOT NULL
+    """)
+    List<User> findWithdrawnAppleUsersWithTokenBefore(@Param("deleteBefore") Instant deleteBefore);
+
     @Modifying
     @Query("""
     DELETE FROM User u

--- a/src/main/java/com/example/bookiibookii/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/bookiibookii/domain/user/repository/UserRepository.java
@@ -44,20 +44,28 @@ public interface UserRepository extends JpaRepository<User, Long> {
             @Param("socialType") SocialType socialType
     );
 
+    // revoke 재시도 대상: WITHDRAWN + APPLE + appleRefreshToken 있는 유저
     @Query("""
-    SELECT u.appleRefreshToken FROM User u
+    SELECT u FROM User u
     WHERE u.status = 'WITHDRAWN'
     AND u.updatedAt <= :deleteBefore
     AND u.socialType = 'APPLE'
     AND u.appleRefreshToken IS NOT NULL
     """)
-    List<String> findAppleRefreshTokensForDeletion(@Param("deleteBefore") Instant deleteBefore);
+    List<User> findWithdrawnAppleUsersForRevoke(@Param("deleteBefore") Instant deleteBefore);
 
+    // revoke 성공 후 토큰 제거 (다음 삭제 대상에 포함되도록)
+    @Modifying
+    @Query("UPDATE User u SET u.appleRefreshToken = null WHERE u.id = :userId")
+    void clearAppleRefreshToken(@Param("userId") Long userId);
+
+    // appleRefreshToken이 남아있는 APPLE 유저는 revoke 미완료이므로 삭제 제외
     @Modifying
     @Query("""
     DELETE FROM User u
     WHERE u.status = 'WITHDRAWN'
     AND u.updatedAt <= :deleteBefore
+    AND (u.socialType != 'APPLE' OR u.appleRefreshToken IS NULL)
     """)
     int deleteWithdrawnUsersBefore(@Param("deleteBefore") Instant deleteBefore);
 

--- a/src/main/java/com/example/bookiibookii/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/bookiibookii/domain/user/repository/UserRepository.java
@@ -55,9 +55,17 @@ public interface UserRepository extends JpaRepository<User, Long> {
     List<User> findWithdrawnAppleUsersForRevoke(@Param("deleteBefore") Instant deleteBefore);
 
     // revoke 성공 후 토큰 제거 (다음 삭제 대상에 포함되도록)
+    // 토큰값·WITHDRAWN 상태 일치 조건: 조회 후 재가입한 유저의 새 토큰을 덮어쓰지 않도록 방어
     @Modifying
-    @Query("UPDATE User u SET u.appleRefreshToken = null WHERE u.id = :userId")
-    void clearAppleRefreshToken(@Param("userId") Long userId);
+    @Query("""
+    UPDATE User u SET u.appleRefreshToken = null
+    WHERE u.id = :userId
+      AND u.appleRefreshToken = :expectedToken
+      AND u.status = 'WITHDRAWN'
+    """)
+    int clearAppleRefreshToken(
+            @Param("userId") Long userId,
+            @Param("expectedToken") String expectedToken);
 
     // appleRefreshToken이 남아있는 APPLE 유저는 revoke 미완료이므로 삭제 제외
     @Modifying

--- a/src/main/java/com/example/bookiibookii/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/bookiibookii/domain/user/repository/UserRepository.java
@@ -45,13 +45,13 @@ public interface UserRepository extends JpaRepository<User, Long> {
     );
 
     @Query("""
-    SELECT u FROM User u
+    SELECT u.appleRefreshToken FROM User u
     WHERE u.status = 'WITHDRAWN'
     AND u.updatedAt <= :deleteBefore
     AND u.socialType = 'APPLE'
     AND u.appleRefreshToken IS NOT NULL
     """)
-    List<User> findWithdrawnAppleUsersWithTokenBefore(@Param("deleteBefore") Instant deleteBefore);
+    List<String> findAppleRefreshTokensForDeletion(@Param("deleteBefore") Instant deleteBefore);
 
     @Modifying
     @Query("""

--- a/src/main/java/com/example/bookiibookii/domain/user/service/UserWithdrawalService.java
+++ b/src/main/java/com/example/bookiibookii/domain/user/service/UserWithdrawalService.java
@@ -7,10 +7,12 @@ import com.example.bookiibookii.domain.user.entity.User;
 import com.example.bookiibookii.domain.user.entity.UserWithdrawal;
 import com.example.bookiibookii.domain.user.enums.AgeGroup;
 import com.example.bookiibookii.domain.user.enums.Gender;
+import com.example.bookiibookii.domain.user.enums.SocialType;
 import com.example.bookiibookii.domain.user.enums.WithdrawalReason;
 import com.example.bookiibookii.domain.user.exception.UserException;
 import com.example.bookiibookii.domain.user.exception.code.UserErrorCode;
 import com.example.bookiibookii.domain.user.repository.UserWithdrawalRepository;
+import com.example.bookiibookii.global.auth.social.AppleAuthClient;
 import com.example.bookiibookii.global.util.RedisUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -26,6 +28,7 @@ public class UserWithdrawalService {
     private final UserWithdrawalRepository userWithdrawalRepository;
     private final MatchedMemberRepository matchedMemberRepository;
     private final RedisUtil redisUtil;
+    private final AppleAuthClient appleAuthClient;
 
     private static final List<GroupStatus> ACTIVE_GROUP_STATUSES = List.of(GroupStatus.RECRUITING, GroupStatus.MATCHED);
 
@@ -62,6 +65,12 @@ public class UserWithdrawalService {
 
         userWithdrawalRepository.save(withdrawal);
         redisUtil.delete("RT:" + user.getId());
+
+        // Apple 유저: App Store 심사 지침 준수 — refresh_token revoke
+        if (SocialType.APPLE.equals(user.getSocialType()) && user.getAppleRefreshToken() != null) {
+            appleAuthClient.revokeToken(user.getAppleRefreshToken());
+        }
+
         user.withdraw();
     }
 }

--- a/src/main/java/com/example/bookiibookii/domain/user/service/UserWithdrawalService.java
+++ b/src/main/java/com/example/bookiibookii/domain/user/service/UserWithdrawalService.java
@@ -66,9 +66,12 @@ public class UserWithdrawalService {
         userWithdrawalRepository.save(withdrawal);
         redisUtil.delete("RT:" + user.getId());
 
-        // Apple 유저: App Store 심사 지침 준수 — refresh_token revoke
+        // Apple 유저: App Store 심사 지침 준수 — refresh_token revoke (실패해도 탈퇴 진행)
         if (SocialType.APPLE.equals(user.getSocialType()) && user.getAppleRefreshToken() != null) {
-            appleAuthClient.revokeToken(user.getAppleRefreshToken());
+            boolean revoked = appleAuthClient.revokeToken(user.getAppleRefreshToken());
+            if (revoked) {
+                user.updateAppleRefreshToken(null);
+            }
         }
 
         user.withdraw();

--- a/src/main/java/com/example/bookiibookii/global/auth/controller/AuthController.java
+++ b/src/main/java/com/example/bookiibookii/global/auth/controller/AuthController.java
@@ -23,7 +23,7 @@ public class AuthController implements AuthControllerDocs{
     ) {
         return ApiResponse.onSuccess(
                 GeneralSuccessCode.REQUEST_OK,
-                authService.socialLogin(request.getSocialType(),request.getToken()));
+                authService.socialLogin(request));
     }
 
 

--- a/src/main/java/com/example/bookiibookii/global/auth/controller/AuthControllerDocs.java
+++ b/src/main/java/com/example/bookiibookii/global/auth/controller/AuthControllerDocs.java
@@ -15,7 +15,7 @@ public interface AuthControllerDocs {
     @Operation(
             summary = "소셜 로그인",
             description = """
-            Android 앱에서 소셜 SDK 로그인 성공 후 호출하는 API입니다.
+            앱에서 소셜 SDK 로그인 성공 후 호출하는 API입니다.
 
             - socialType: KAKAO | GOOGLE | APPLE
             - token:
@@ -23,6 +23,10 @@ public interface AuthControllerDocs {
                 Test: https://kauth.kakao.com/oauth/authorize?client_id=1d55fc7fcf8b8f41295f87d737babee3&redirect_uri=https://bookii.gyeonseo.com/kakao/callback&response_type=code
               - GOOGLE → ID Token
               - APPLE → Identity Token (Sign in with Apple 성공 후 Apple이 발급한 JWT)
+            - authorizationCode (APPLE 전용, 선택):
+              - ASAuthorizationAppleIDCredential.authorizationCode (String)
+              - 최초 로그인 시 전달하면 서버가 Apple refresh_token을 교환·저장
+              - 탈퇴 시 Apple token revoke에 사용됨 (App Store 심사 지침)
 
             인증 성공 시 Access Token, Refresh Token을 반환합니다.
             """

--- a/src/main/java/com/example/bookiibookii/global/auth/controller/OAuthTestController.java
+++ b/src/main/java/com/example/bookiibookii/global/auth/controller/OAuthTestController.java
@@ -2,6 +2,7 @@ package com.example.bookiibookii.global.auth.controller;
 
 import com.example.bookiibookii.global.apiPayload.ApiResponse;
 import com.example.bookiibookii.global.apiPayload.code.GeneralSuccessCode;
+import com.example.bookiibookii.global.auth.dto.req.AuthRequestDTO;
 import com.example.bookiibookii.global.auth.dto.res.AuthResponseDTO;
 import com.example.bookiibookii.global.auth.exception.AuthException;
 import com.example.bookiibookii.global.auth.exception.code.AuthErrorCode;
@@ -46,12 +47,12 @@ public class OAuthTestController {
         String accessToken = getKakaoAccessToken(code);
         return ApiResponse.onSuccess(
                 GeneralSuccessCode.REQUEST_OK,
-                authService.socialLogin("KAKAO", accessToken));
+                authService.socialLogin(AuthRequestDTO.of("KAKAO", accessToken)));
     }
 
     @GetMapping("/google/callback")
     public AuthResponseDTO.LoginResponse googleCallback(@RequestParam String code) {
-        return authService.socialLogin("GOOGLE", code);
+        return authService.socialLogin(AuthRequestDTO.of("GOOGLE", code));
     }
 
     private String getKakaoAccessToken(String code) {

--- a/src/main/java/com/example/bookiibookii/global/auth/dto/req/AuthRequestDTO.java
+++ b/src/main/java/com/example/bookiibookii/global/auth/dto/req/AuthRequestDTO.java
@@ -7,6 +7,14 @@ import lombok.Getter;
 public class AuthRequestDTO {
     private String socialType;
     private String token;
+    private String authorizationCode; // Apple 전용: refresh_token 교환 및 탈퇴 시 revoke에 사용
+
+    public static AuthRequestDTO of(String socialType, String token) {
+        AuthRequestDTO dto = new AuthRequestDTO();
+        dto.socialType = socialType;
+        dto.token = token;
+        return dto;
+    }
 
     public record RefreshRequest(String refreshToken) {}
 

--- a/src/main/java/com/example/bookiibookii/global/auth/exception/code/AuthErrorCode.java
+++ b/src/main/java/com/example/bookiibookii/global/auth/exception/code/AuthErrorCode.java
@@ -38,6 +38,10 @@ public enum AuthErrorCode implements BaseCode {
             "AUTH404_3",
             "토큰에 저장된 해당 사용자를 찾을 수 없습니다."),
 
+    MISSING_AUTHORIZATION_CODE(HttpStatus.BAD_REQUEST,
+            "AUTH400_5",
+            "Apple 로그인에는 authorizationCode가 필요합니다."),
+
     ;
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/example/bookiibookii/global/auth/service/AuthService.java
+++ b/src/main/java/com/example/bookiibookii/global/auth/service/AuthService.java
@@ -65,7 +65,10 @@ public class AuthService {
 
         // Apple: authorizationCode → refresh_token 교환 후 저장 (탈퇴 시 revoke에 사용)
         // 교환 실패 시 로그인 자체를 중단 — revoke 불가 상태로 계정을 만들지 않기 위해
-        if (social == SocialType.APPLE && request.getAuthorizationCode() != null) {
+        if (social == SocialType.APPLE) {
+            if (request.getAuthorizationCode() == null || request.getAuthorizationCode().isBlank()) {
+                throw new AuthException(AuthErrorCode.MISSING_AUTHORIZATION_CODE);
+            }
             String appleRefreshToken = appleAuthClient.exchangeAuthCode(
                     request.getAuthorizationCode(), socialUserInfo.getSocialId());
             user.updateAppleRefreshToken(appleRefreshToken);

--- a/src/main/java/com/example/bookiibookii/global/auth/service/AuthService.java
+++ b/src/main/java/com/example/bookiibookii/global/auth/service/AuthService.java
@@ -64,13 +64,10 @@ public class AuthService {
         User user = userService.findOrCreateSocialUser(socialUserInfo, social);
 
         // Apple: authorizationCode → refresh_token 교환 후 저장 (탈퇴 시 revoke에 사용)
+        // 교환 실패 시 로그인 자체를 중단 — revoke 불가 상태로 계정을 만들지 않기 위해
         if (social == SocialType.APPLE && request.getAuthorizationCode() != null) {
-            try {
-                String appleRefreshToken = appleAuthClient.exchangeAuthCode(request.getAuthorizationCode());
-                user.updateAppleRefreshToken(appleRefreshToken);
-            } catch (Exception e) {
-                log.warn("Apple refresh token 교환 실패 (userId: {}) — 향후 revoke 불가", user.getId(), e);
-            }
+            String appleRefreshToken = appleAuthClient.exchangeAuthCode(request.getAuthorizationCode());
+            user.updateAppleRefreshToken(appleRefreshToken);
         }
 
         return issueLoginToken(user);

--- a/src/main/java/com/example/bookiibookii/global/auth/service/AuthService.java
+++ b/src/main/java/com/example/bookiibookii/global/auth/service/AuthService.java
@@ -2,6 +2,7 @@ package com.example.bookiibookii.global.auth.service;
 
 import com.example.bookiibookii.domain.user.entity.User;
 import com.example.bookiibookii.domain.user.enums.SocialType;
+import com.example.bookiibookii.domain.user.enums.Status;
 import com.example.bookiibookii.domain.user.exception.UserException;
 import com.example.bookiibookii.domain.user.exception.code.UserErrorCode;
 import com.example.bookiibookii.domain.user.repository.UserRepository;
@@ -12,6 +13,7 @@ import com.example.bookiibookii.global.auth.exception.code.AuthErrorCode;
 import com.example.bookiibookii.global.auth.exception.AuthException;
 import com.example.bookiibookii.global.auth.jwt.JwtProvider;
 import com.example.bookiibookii.global.auth.jwt.JwtTokenResolver;
+import com.example.bookiibookii.global.auth.social.AppleAuthClient;
 import com.example.bookiibookii.global.auth.social.SocialTokenVerifier;
 import com.example.bookiibookii.global.auth.social.SocialUserInfo;
 import com.example.bookiibookii.global.util.RedisUtil;
@@ -37,13 +39,14 @@ public class AuthService {
 
     // social Type기준으로 분기 처리
     private final List<SocialTokenVerifier> tokenVerifiers;
+    private final AppleAuthClient appleAuthClient;
 
     // 소셜 로그인
-    public AuthResponseDTO.LoginResponse socialLogin(String socialType, String token) {
+    public AuthResponseDTO.LoginResponse socialLogin(AuthRequestDTO request) {
 
         final SocialType social;
         try {
-            social = SocialType.valueOf(socialType);
+            social = SocialType.valueOf(request.getSocialType());
         } catch(IllegalArgumentException | NullPointerException e) {
             throw new AuthException(AuthErrorCode.UNSUPPORTED_SOCIAL_TYPE);
         }
@@ -55,10 +58,20 @@ public class AuthService {
                 .orElseThrow(() -> new AuthException(AuthErrorCode.UNSUPPORTED_SOCIAL_TYPE));
 
         // 소셜 토큰 검증 → 사용자 정보 획득
-        SocialUserInfo socialUserInfo = verifier.verify(token);
+        SocialUserInfo socialUserInfo = verifier.verify(request.getToken());
 
         // 유저 조회 or 생성
         User user = userService.findOrCreateSocialUser(socialUserInfo, social);
+
+        // Apple: authorizationCode → refresh_token 교환 후 저장 (탈퇴 시 revoke에 사용)
+        if (social == SocialType.APPLE && request.getAuthorizationCode() != null) {
+            try {
+                String appleRefreshToken = appleAuthClient.exchangeAuthCode(request.getAuthorizationCode());
+                user.updateAppleRefreshToken(appleRefreshToken);
+            } catch (Exception e) {
+                log.warn("Apple refresh token 교환 실패 (userId: {}) — 향후 revoke 불가", user.getId(), e);
+            }
+        }
 
         return issueLoginToken(user);
     }
@@ -116,6 +129,10 @@ public class AuthService {
         // 사용자 존재 확인 및 권한 획득
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new AuthException(AuthErrorCode.NOT_FOUND));
+
+        if (user.getStatus() == Status.WITHDRAWN) {
+            throw new AuthException(AuthErrorCode.NOT_FOUND);
+        }
 
         // 신규 토큰 생성 및 Redis 갱신
         String newAT = jwtProvider.createAccessToken(userId, user.getRole().name());

--- a/src/main/java/com/example/bookiibookii/global/auth/service/AuthService.java
+++ b/src/main/java/com/example/bookiibookii/global/auth/service/AuthService.java
@@ -66,7 +66,8 @@ public class AuthService {
         // Apple: authorizationCode → refresh_token 교환 후 저장 (탈퇴 시 revoke에 사용)
         // 교환 실패 시 로그인 자체를 중단 — revoke 불가 상태로 계정을 만들지 않기 위해
         if (social == SocialType.APPLE && request.getAuthorizationCode() != null) {
-            String appleRefreshToken = appleAuthClient.exchangeAuthCode(request.getAuthorizationCode());
+            String appleRefreshToken = appleAuthClient.exchangeAuthCode(
+                    request.getAuthorizationCode(), socialUserInfo.getSocialId());
             user.updateAppleRefreshToken(appleRefreshToken);
         }
 

--- a/src/main/java/com/example/bookiibookii/global/auth/social/AppleAuthClient.java
+++ b/src/main/java/com/example/bookiibookii/global/auth/social/AppleAuthClient.java
@@ -38,16 +38,16 @@ public class AppleAuthClient {
      * authorizationCode를 Apple refresh_token으로 교환
      */
     public String exchangeAuthCode(String authorizationCode) {
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
-
-        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
-        params.add("client_id", bundleId);
-        params.add("client_secret", clientSecretGenerator.generate());
-        params.add("code", authorizationCode);
-        params.add("grant_type", "authorization_code");
-
         try {
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+            MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+            params.add("client_id", bundleId);
+            params.add("client_secret", clientSecretGenerator.generate());
+            params.add("code", authorizationCode);
+            params.add("grant_type", "authorization_code");
+
             Map<?, ?> response = restTemplate.postForObject(
                     TOKEN_URL, new HttpEntity<>(params, headers), Map.class);
             if (response == null || !response.containsKey("refresh_token")) {
@@ -63,23 +63,25 @@ public class AppleAuthClient {
     }
 
     /**
-     * Apple refresh_token을 revoke
+     * Apple refresh_token을 revoke. 성공 여부를 반환한다.
      */
-    public void revokeToken(String refreshToken) {
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
-
-        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
-        params.add("client_id", bundleId);
-        params.add("client_secret", clientSecretGenerator.generate());
-        params.add("token", refreshToken);
-        params.add("token_type_hint", "refresh_token");
-
+    public boolean revokeToken(String refreshToken) {
         try {
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+            MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+            params.add("client_id", bundleId);
+            params.add("client_secret", clientSecretGenerator.generate());
+            params.add("token", refreshToken);
+            params.add("token_type_hint", "refresh_token");
+
             restTemplate.postForObject(REVOKE_URL, new HttpEntity<>(params, headers), String.class);
             log.info("Apple token revoke 완료");
+            return true;
         } catch (Exception e) {
-            log.error("Apple token revoke 실패 — 탈퇴는 계속 진행", e);
+            log.error("Apple token revoke 실패", e);
+            return false;
         }
     }
 }

--- a/src/main/java/com/example/bookiibookii/global/auth/social/AppleAuthClient.java
+++ b/src/main/java/com/example/bookiibookii/global/auth/social/AppleAuthClient.java
@@ -1,0 +1,85 @@
+package com.example.bookiibookii.global.auth.social;
+
+import com.example.bookiibookii.global.auth.exception.AuthException;
+import com.example.bookiibookii.global.auth.exception.code.AuthErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
+
+/**
+ * Apple 서버에 HTTP 요청을 보내는 클라이언트.
+ * - exchangeAuthCode(): 로그인 시 authorizationCode → refresh_token 교환
+ * - revokeToken(): 탈퇴 시 refresh_token revoke (App Store 심사 지침)
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AppleAuthClient {
+
+    private static final String TOKEN_URL = "https://appleid.apple.com/auth/token";
+    private static final String REVOKE_URL = "https://appleid.apple.com/auth/revoke";
+
+    @Value("${oauth.apple.bundle-id}")
+    private String bundleId;
+
+    private final RestTemplate restTemplate;
+    private final AppleClientSecretGenerator clientSecretGenerator;
+
+    /**
+     * authorizationCode를 Apple refresh_token으로 교환
+     */
+    public String exchangeAuthCode(String authorizationCode) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("client_id", bundleId);
+        params.add("client_secret", clientSecretGenerator.generate());
+        params.add("code", authorizationCode);
+        params.add("grant_type", "authorization_code");
+
+        try {
+            Map<?, ?> response = restTemplate.postForObject(
+                    TOKEN_URL, new HttpEntity<>(params, headers), Map.class);
+            if (response == null || !response.containsKey("refresh_token")) {
+                throw new AuthException(AuthErrorCode.INVALID_SOCIAL_TOKEN);
+            }
+            return (String) response.get("refresh_token");
+        } catch (AuthException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("Apple authorizationCode 교환 실패", e);
+            throw new AuthException(AuthErrorCode.INVALID_SOCIAL_TOKEN);
+        }
+    }
+
+    /**
+     * Apple refresh_token을 revoke
+     */
+    public void revokeToken(String refreshToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("client_id", bundleId);
+        params.add("client_secret", clientSecretGenerator.generate());
+        params.add("token", refreshToken);
+        params.add("token_type_hint", "refresh_token");
+
+        try {
+            restTemplate.postForObject(REVOKE_URL, new HttpEntity<>(params, headers), String.class);
+            log.info("Apple token revoke 완료");
+        } catch (Exception e) {
+            log.error("Apple token revoke 실패 — 탈퇴는 계속 진행", e);
+        }
+    }
+}

--- a/src/main/java/com/example/bookiibookii/global/auth/social/AppleAuthClient.java
+++ b/src/main/java/com/example/bookiibookii/global/auth/social/AppleAuthClient.java
@@ -2,6 +2,7 @@ package com.example.bookiibookii.global.auth.social;
 
 import com.example.bookiibookii.global.auth.exception.AuthException;
 import com.example.bookiibookii.global.auth.exception.code.AuthErrorCode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -13,6 +14,7 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 
+import java.util.Base64;
 import java.util.Map;
 
 /**
@@ -35,9 +37,11 @@ public class AppleAuthClient {
     private final AppleClientSecretGenerator clientSecretGenerator;
 
     /**
-     * authorizationCode를 Apple refresh_token으로 교환
+     * authorizationCode를 Apple refresh_token으로 교환.
+     * 응답의 id_token.sub가 identityToken에서 확인한 expectedSub와 일치하는지 검증하여
+     * 서로 다른 Apple 유저의 authorizationCode가 혼입되는 것을 방지한다.
      */
-    public String exchangeAuthCode(String authorizationCode) {
+    public String exchangeAuthCode(String authorizationCode, String expectedSub) {
         try {
             HttpHeaders headers = new HttpHeaders();
             headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
@@ -53,11 +57,32 @@ public class AppleAuthClient {
             if (response == null || !response.containsKey("refresh_token")) {
                 throw new AuthException(AuthErrorCode.INVALID_SOCIAL_TOKEN);
             }
+
+            String idToken = (String) response.get("id_token");
+            String responseSub = extractSubFromIdToken(idToken);
+            if (!expectedSub.equals(responseSub)) {
+                log.warn("Apple authorizationCode sub 불일치 — identityToken sub: {}, authorizationCode sub: {}",
+                        expectedSub, responseSub);
+                throw new AuthException(AuthErrorCode.INVALID_SOCIAL_TOKEN);
+            }
+
             return (String) response.get("refresh_token");
         } catch (AuthException e) {
             throw e;
         } catch (Exception e) {
             log.error("Apple authorizationCode 교환 실패", e);
+            throw new AuthException(AuthErrorCode.INVALID_SOCIAL_TOKEN);
+        }
+    }
+
+    private String extractSubFromIdToken(String idToken) {
+        try {
+            String payload = idToken.split("\\.")[1];
+            byte[] decoded = Base64.getUrlDecoder().decode(payload);
+            Map<?, ?> claims = new ObjectMapper().readValue(decoded, Map.class);
+            return (String) claims.get("sub");
+        } catch (Exception e) {
+            log.error("Apple id_token payload 파싱 실패", e);
             throw new AuthException(AuthErrorCode.INVALID_SOCIAL_TOKEN);
         }
     }

--- a/src/main/java/com/example/bookiibookii/global/auth/social/AppleAuthClient.java
+++ b/src/main/java/com/example/bookiibookii/global/auth/social/AppleAuthClient.java
@@ -54,19 +54,27 @@ public class AppleAuthClient {
 
             Map<?, ?> response = restTemplate.postForObject(
                     TOKEN_URL, new HttpEntity<>(params, headers), Map.class);
-            if (response == null || !response.containsKey("refresh_token")) {
+            if (response == null) {
                 throw new AuthException(AuthErrorCode.INVALID_SOCIAL_TOKEN);
             }
 
-            String idToken = (String) response.get("id_token");
+            Object rawRefreshToken = response.get("refresh_token");
+            if (!(rawRefreshToken instanceof String refreshToken) || refreshToken.isBlank()) {
+                throw new AuthException(AuthErrorCode.INVALID_SOCIAL_TOKEN);
+            }
+
+            Object rawIdToken = response.get("id_token");
+            if (!(rawIdToken instanceof String idToken) || idToken.isBlank()) {
+                throw new AuthException(AuthErrorCode.INVALID_SOCIAL_TOKEN);
+            }
+
             String responseSub = extractSubFromIdToken(idToken);
             if (!expectedSub.equals(responseSub)) {
-                log.warn("Apple authorizationCode sub 불일치 — identityToken sub: {}, authorizationCode sub: {}",
-                        expectedSub, responseSub);
+                log.warn("Apple authorizationCode sub 불일치 — identityToken 발급 유저와 authorizationCode 발급 유저가 다름");
                 throw new AuthException(AuthErrorCode.INVALID_SOCIAL_TOKEN);
             }
 
-            return (String) response.get("refresh_token");
+            return refreshToken;
         } catch (AuthException e) {
             throw e;
         } catch (Exception e) {

--- a/src/main/java/com/example/bookiibookii/global/auth/social/AppleClientSecretGenerator.java
+++ b/src/main/java/com/example/bookiibookii/global/auth/social/AppleClientSecretGenerator.java
@@ -1,0 +1,63 @@
+package com.example.bookiibookii.global.auth.social;
+
+import io.jsonwebtoken.Jwts;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.security.KeyFactory;
+import java.security.interfaces.ECPrivateKey;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.util.Base64;
+import java.util.Date;
+
+/**
+ * Apple API 호출 시 필요한 client_secret을 생성 (Apple은 고정 문자열 대신 .p8 개인키로 ES256 서명한 JWT를 client_secret으로 요구하기 때문)
+ * AppleAuthClient가 /auth/token, /auth/revoke 호출할 때마다 사용
+ */
+@Slf4j
+@Component
+public class AppleClientSecretGenerator {
+
+    private static final String APPLE_AUDIENCE = "https://appleid.apple.com";
+    private static final long EXPIRY_MILLIS = 15_777_000_000L; // 약 6개월
+
+    @Value("${oauth.apple.team-id}")
+    private String teamId;
+
+    @Value("${oauth.apple.key-id}")
+    private String keyId;
+
+    @Value("${oauth.apple.bundle-id}")
+    private String bundleId;
+
+    @Value("${oauth.apple.private-key}")
+    private String privateKeyPem;
+
+    public String generate() {
+        try {
+            ECPrivateKey privateKey = parsePrivateKey(privateKeyPem);
+            long now = System.currentTimeMillis();
+            return Jwts.builder()
+                    .header().add("kid", keyId).and()
+                    .issuer(teamId)
+                    .issuedAt(new Date(now))
+                    .expiration(new Date(now + EXPIRY_MILLIS))
+                    .audience().add(APPLE_AUDIENCE).and()
+                    .subject(bundleId)
+                    .signWith(privateKey, Jwts.SIG.ES256)
+                    .compact();
+        } catch (Exception e) {
+            throw new RuntimeException("Apple client_secret 생성 실패", e);
+        }
+    }
+
+    private ECPrivateKey parsePrivateKey(String pem) throws Exception {
+        String base64 = pem
+                .replace("-----BEGIN PRIVATE KEY-----", "")
+                .replace("-----END PRIVATE KEY-----", "")
+                .replaceAll("\\s+", "");
+        byte[] keyBytes = Base64.getDecoder().decode(base64);
+        return (ECPrivateKey) KeyFactory.getInstance("EC").generatePrivate(new PKCS8EncodedKeySpec(keyBytes));
+    }
+}

--- a/src/main/java/com/example/bookiibookii/global/auth/social/AppleTokenVerifier.java
+++ b/src/main/java/com/example/bookiibookii/global/auth/social/AppleTokenVerifier.java
@@ -180,5 +180,8 @@ public class AppleTokenVerifier implements SocialTokenVerifier {
         if (!claims.getAudience().contains(bundleId)) {
             throw new AuthException(AuthErrorCode.INVALID_SOCIAL_TOKEN);
         }
+        if (claims.getSubject() == null || claims.getSubject().isBlank()) {
+            throw new AuthException(AuthErrorCode.INVALID_SOCIAL_TOKEN);
+        }
     }
 }

--- a/src/main/java/com/example/bookiibookii/global/scheduler/WithdrawnUserCleanupScheduler.java
+++ b/src/main/java/com/example/bookiibookii/global/scheduler/WithdrawnUserCleanupScheduler.java
@@ -1,5 +1,6 @@
 package com.example.bookiibookii.global.scheduler;
 
+import com.example.bookiibookii.domain.user.entity.User;
 import com.example.bookiibookii.domain.user.repository.UserRepository;
 import com.example.bookiibookii.global.auth.social.AppleAuthClient;
 import lombok.RequiredArgsConstructor;
@@ -28,11 +29,21 @@ public class WithdrawnUserCleanupScheduler {
     public void deleteExpiredWithdrawnUsers() {
         Instant deleteBefore = clock.instant().minus(Duration.ofDays(30));
 
-        // 탈퇴 시 revoke 실패했던 Apple 유저에 대해 재시도 (App Store 심사 지침)
-        List<String> tokens = userRepository.findAppleRefreshTokensForDeletion(deleteBefore);
-        tokens.forEach(appleAuthClient::revokeToken);
-        if (!tokens.isEmpty()) {
-            log.info("Apple token revoke 재시도: {}건", tokens.size());
+        // 탈퇴 시 revoke 실패했던 Apple 유저 재시도
+        // revoke 성공한 유저만 토큰을 null로 초기화해 삭제 대상에 포함
+        // revoke 실패한 유저는 토큰이 남아있으므로 이번 삭제에서 제외되어 다음 실행 시 재시도
+        List<User> appleUsers = userRepository.findWithdrawnAppleUsersForRevoke(deleteBefore);
+        int successCount = 0;
+        for (User user : appleUsers) {
+            boolean revoked = appleAuthClient.revokeToken(user.getAppleRefreshToken());
+            if (revoked) {
+                userRepository.clearAppleRefreshToken(user.getId());
+                successCount++;
+            }
+        }
+        if (!appleUsers.isEmpty()) {
+            log.info("Apple token revoke 재시도: {}건 시도, {}건 성공, {}건 다음 회차로 이월",
+                    appleUsers.size(), successCount, appleUsers.size() - successCount);
         }
 
         int deleted = userRepository.deleteWithdrawnUsersBefore(deleteBefore);

--- a/src/main/java/com/example/bookiibookii/global/scheduler/WithdrawnUserCleanupScheduler.java
+++ b/src/main/java/com/example/bookiibookii/global/scheduler/WithdrawnUserCleanupScheduler.java
@@ -35,10 +35,16 @@ public class WithdrawnUserCleanupScheduler {
         List<User> appleUsers = userRepository.findWithdrawnAppleUsersForRevoke(deleteBefore);
         int successCount = 0;
         for (User user : appleUsers) {
-            boolean revoked = appleAuthClient.revokeToken(user.getAppleRefreshToken());
+            String token = user.getAppleRefreshToken();
+            boolean revoked = appleAuthClient.revokeToken(token);
             if (revoked) {
-                userRepository.clearAppleRefreshToken(user.getId());
-                successCount++;
+                int updated = userRepository.clearAppleRefreshToken(user.getId(), token);
+                if (updated > 0) {
+                    successCount++;
+                } else {
+                    // revoke 성공했으나 DB 상태 불일치 — 재가입 등으로 상태 변경됨, 새 토큰 보존
+                    log.warn("Apple token revoke 완료했으나 DB 초기화 스킵 (userId: {})", user.getId());
+                }
             }
         }
         if (!appleUsers.isEmpty()) {

--- a/src/main/java/com/example/bookiibookii/global/scheduler/WithdrawnUserCleanupScheduler.java
+++ b/src/main/java/com/example/bookiibookii/global/scheduler/WithdrawnUserCleanupScheduler.java
@@ -1,6 +1,5 @@
 package com.example.bookiibookii.global.scheduler;
 
-import com.example.bookiibookii.domain.user.entity.User;
 import com.example.bookiibookii.domain.user.repository.UserRepository;
 import com.example.bookiibookii.global.auth.social.AppleAuthClient;
 import lombok.RequiredArgsConstructor;
@@ -30,12 +29,10 @@ public class WithdrawnUserCleanupScheduler {
         Instant deleteBefore = clock.instant().minus(Duration.ofDays(30));
 
         // 탈퇴 시 revoke 실패했던 Apple 유저에 대해 재시도 (App Store 심사 지침)
-        List<User> appleUsers = userRepository.findWithdrawnAppleUsersWithTokenBefore(deleteBefore);
-        for (User user : appleUsers) {
-            appleAuthClient.revokeToken(user.getAppleRefreshToken());
-        }
-        if (!appleUsers.isEmpty()) {
-            log.info("Apple token revoke 재시도: {}건", appleUsers.size());
+        List<String> tokens = userRepository.findAppleRefreshTokensForDeletion(deleteBefore);
+        tokens.forEach(appleAuthClient::revokeToken);
+        if (!tokens.isEmpty()) {
+            log.info("Apple token revoke 재시도: {}건", tokens.size());
         }
 
         int deleted = userRepository.deleteWithdrawnUsersBefore(deleteBefore);

--- a/src/main/java/com/example/bookiibookii/global/scheduler/WithdrawnUserCleanupScheduler.java
+++ b/src/main/java/com/example/bookiibookii/global/scheduler/WithdrawnUserCleanupScheduler.java
@@ -1,8 +1,8 @@
 package com.example.bookiibookii.global.scheduler;
 
-import com.example.bookiibookii.domain.group.enums.GroupStatus;
-import com.example.bookiibookii.domain.group.repository.GroupsRepository;
+import com.example.bookiibookii.domain.user.entity.User;
 import com.example.bookiibookii.domain.user.repository.UserRepository;
+import com.example.bookiibookii.global.auth.social.AppleAuthClient;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -12,6 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.List;
 
 @Slf4j
 @Component
@@ -19,14 +20,25 @@ import java.time.Instant;
 public class WithdrawnUserCleanupScheduler {
 
     private final UserRepository userRepository;
+    private final AppleAuthClient appleAuthClient;
     private final Clock clock;
 
     // 매일 새벽 3시 실행
     @Scheduled(cron = "0 0 3 * * *", zone = "Asia/Seoul")
     @Transactional
     public void deleteExpiredWithdrawnUsers() {
-
         Instant deleteBefore = clock.instant().minus(Duration.ofDays(30));
-        userRepository.deleteWithdrawnUsersBefore(deleteBefore);
+
+        // 탈퇴 시 revoke 실패했던 Apple 유저에 대해 재시도 (App Store 심사 지침)
+        List<User> appleUsers = userRepository.findWithdrawnAppleUsersWithTokenBefore(deleteBefore);
+        for (User user : appleUsers) {
+            appleAuthClient.revokeToken(user.getAppleRefreshToken());
+        }
+        if (!appleUsers.isEmpty()) {
+            log.info("Apple token revoke 재시도: {}건", appleUsers.size());
+        }
+
+        int deleted = userRepository.deleteWithdrawnUsersBefore(deleteBefore);
+        log.info("탈퇴 유저 하드삭제: {}건", deleted);
     }
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -45,6 +45,9 @@ oauth:
     redirect-uri: ${KAKAO_REDIRECT_URI}
   apple:
     bundle-id: ${APPLE_BUNDLE_ID}
+    team-id: ${APPLE_TEAM_ID}
+    key-id: ${APPLE_KEY_ID}
+    private-key: ${APPLE_PRIVATE_KEY}
 
 aladin:
   ttbkey: ${ALADIN_TTB_KEY}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -57,6 +57,9 @@ oauth:
     redirect-uri: ${KAKAO_REDIRECT_URI}
   apple:
     bundle-id: ${APPLE_BUNDLE_ID}
+    team-id: ${APPLE_TEAM_ID}
+    key-id: ${APPLE_KEY_ID}
+    private-key: ${APPLE_PRIVATE_KEY}
 
 aladin:
   ttbkey: ${ALADIN_TTB_KEY}

--- a/src/main/resources/application-v1.yml
+++ b/src/main/resources/application-v1.yml
@@ -46,6 +46,9 @@ oauth:
     redirect-uri: ${KAKAO_REDIRECT_URI}
   apple:
     bundle-id: ${APPLE_BUNDLE_ID}
+    team-id: ${APPLE_TEAM_ID}
+    key-id: ${APPLE_KEY_ID}
+    private-key: ${APPLE_PRIVATE_KEY}
 
 aladin:
   ttbkey: ${ALADIN_TTB_KEY}


### PR DESCRIPTION
## 개요
<!---- 자신이 완료한 이슈를 닫아주세요 -->
- closed #608 //이슈 번호는 추적을 위해 필요합니다!
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
### Token revoke 구현
- `AppleClientSecretGenerator`: Apple API 호출용 ES256 JWT(client_secret) 생성
- `AppleAuthClient`: Apple `/auth/token`, `/auth/revoke` HTTP 클라이언트
- 로그인 시 `authorizationCode` → Apple refresh_token 교환 후 DB 저장
- 탈퇴 시 저장된 refresh_token으로 Apple revoke API 호출
- `WithdrawnUserCleanupScheduler`: 30일 후 하드삭제 전 revoke 재시도

### JWKS 캐시 보강
- TTL(24h), 원자적 캐시 교체, 단일비행(single-flight), 미등록 kid DoS 방어

### 리뷰 후 보완
- `User.reset()`: 재가입 시 `appleRefreshToken` null 초기화 누락 수정
- `AuthService.refresh()`: WITHDRAWN 유저 토큰 재발급 명시적 차단

### 배포 전 필수
- [ ] DB 마이그레이션 실행 (v1, prod)
```sql
ALTER TABLE users ADD COLUMN last_reset_at DATETIME(6) NULL;
ALTER TABLE users ADD COLUMN apple_refresh_token VARCHAR(1000) NULL;
```
- 환경변수 추가: APPLE_TEAM_ID, APPLE_KEY_ID, APPLE_PRIVATE_KEY

<!---- Resolves: #(Isuue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [X] 새로운 기능 추가
- [X] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [X] 코드 리팩토링
- [X] 주석 추가 및 수정
- [X] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

📣 **To Reviewers**
---
<!-- 전달사항 -->

- Reviewers : 팀 선택
- Labels : 작업 유형, 자기 자신


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새 기능**
  - Apple 소셜 로그인 시 인증 코드를 토큰과 연동해 사용자에 안전하게 저장합니다.
  - 회원 탈퇴 시 Apple refresh 토큰이 자동으로 철회되도록 개선했습니다.
  - 만료된 탈퇴 계정 정리 시 Apple 토큰 철회 후, 성공한 항목만 정리되도록 처리 흐름을 확장했습니다.
- **버그 수정**
  - 탈퇴 상태 사용자의 토큰 갱신이 다시 인증으로 이어지지 않도록 차단했습니다.
- **문서**
  - Apple 로그인 요청에서 authorizationCode 전달 조건과 처리 흐름을 더 명확히 안내했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->