### PR TITLE
[Fix]#613 회원탈퇴 후 재로그인 시 유저 데이터 미초기화 버그 수정

### DIFF
--- a/src/main/java/com/example/bookiibookii/domain/user/entity/User.java
+++ b/src/main/java/com/example/bookiibookii/domain/user/entity/User.java
@@ -113,6 +113,7 @@ public class User extends BaseEntity {
         this.lastResetAt = Instant.now();
         this.appleRefreshToken = null;
     }
+    public void clearUserImage() { this.userImage = null; }
     public void updateAppleRefreshToken(String token) { this.appleRefreshToken = token; }
     public void updateName(String name) { this.nickName = name; }
     public void updateIntroduction(String introduction) { this.introduction = introduction; }

--- a/src/main/java/com/example/bookiibookii/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/bookiibookii/domain/user/repository/UserRepository.java
@@ -44,6 +44,12 @@ public interface UserRepository extends JpaRepository<User, Long> {
             @Param("socialType") SocialType socialType
     );
 
+    // 탈퇴 처리: entity dirty checking 에 의존하지 않고 직접 UPDATE
+    // (OSIV 환경에서 JwtAuthFilter가 read-only로 로드한 엔티티는 snapshot 없음 → dirty check 미동작)
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE User u SET u.status = 'WITHDRAWN', u.updatedAt = CURRENT_TIMESTAMP WHERE u.id = :userId")
+    void withdrawUser(@Param("userId") Long userId);
+
     // revoke 재시도 대상: WITHDRAWN + APPLE + appleRefreshToken 있는 유저
     @Query("""
     SELECT u FROM User u

--- a/src/main/java/com/example/bookiibookii/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/bookiibookii/domain/user/repository/UserRepository.java
@@ -46,7 +46,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     // 탈퇴 처리: entity dirty checking 에 의존하지 않고 직접 UPDATE
     // (OSIV 환경에서 JwtAuthFilter가 read-only로 로드한 엔티티는 snapshot 없음 → dirty check 미동작)
-    @Modifying(clearAutomatically = true)
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
     @Query("UPDATE User u SET u.status = 'WITHDRAWN', u.updatedAt = CURRENT_TIMESTAMP WHERE u.id = :userId")
     void withdrawUser(@Param("userId") Long userId);
 

--- a/src/main/java/com/example/bookiibookii/domain/user/service/UserService.java
+++ b/src/main/java/com/example/bookiibookii/domain/user/service/UserService.java
@@ -73,7 +73,7 @@ public class UserService {
     private void resetUserData(User user) {
         userTagRepository.deleteAllByUser(user);
         userBookRepository.deleteAllByUser(user);
-        userImageRepository.deleteByUser_Id(user.getId());
+        user.clearUserImage();
         profileShareTokenRepository.deleteAllByUser_Id(user.getId());
         user.reset();
     }

--- a/src/main/java/com/example/bookiibookii/domain/user/service/UserWithdrawalService.java
+++ b/src/main/java/com/example/bookiibookii/domain/user/service/UserWithdrawalService.java
@@ -11,6 +11,7 @@ import com.example.bookiibookii.domain.user.enums.SocialType;
 import com.example.bookiibookii.domain.user.enums.WithdrawalReason;
 import com.example.bookiibookii.domain.user.exception.UserException;
 import com.example.bookiibookii.domain.user.exception.code.UserErrorCode;
+import com.example.bookiibookii.domain.user.repository.UserRepository;
 import com.example.bookiibookii.domain.user.repository.UserWithdrawalRepository;
 import com.example.bookiibookii.global.auth.social.AppleAuthClient;
 import com.example.bookiibookii.global.util.RedisUtil;
@@ -25,6 +26,7 @@ import java.util.List;
 @Transactional
 public class UserWithdrawalService {
 
+    private final UserRepository userRepository;
     private final UserWithdrawalRepository userWithdrawalRepository;
     private final MatchedMemberRepository matchedMemberRepository;
     private final RedisUtil redisUtil;
@@ -32,7 +34,10 @@ public class UserWithdrawalService {
 
     private static final List<GroupStatus> ACTIVE_GROUP_STATUSES = List.of(GroupStatus.RECRUITING, GroupStatus.MATCHED);
 
-    public void withdraw(User user, WithdrawalReason reason, String customReason) {
+    public void withdraw(User passedUser, WithdrawalReason reason, String customReason) {
+        User user = userRepository.findById(passedUser.getId())
+                .orElseThrow(() -> new UserException(UserErrorCode.NOT_FOUND));
+
         if (matchedMemberRepository.existsByUser_IdAndStatusAndGroup_GroupStatusIn(
                 user.getId(), MemberStatus.JOINED, ACTIVE_GROUP_STATUSES)) {
             throw new UserException(UserErrorCode.ACTIVE_GROUP_EXISTS);
@@ -66,14 +71,17 @@ public class UserWithdrawalService {
         userWithdrawalRepository.save(withdrawal);
         redisUtil.delete("RT:" + user.getId());
 
+        // entity dirty checking 에 의존하지 않고 직접 UPDATE
+        // (OSIV 환경에서 JwtAuthFilter read-only 로드 시 snapshot 없어 dirty check 미동작 문제 방지)
+        userRepository.withdrawUser(user.getId());
+
         // Apple 유저: App Store 심사 지침 준수 — refresh_token revoke (실패해도 탈퇴 진행)
+        // withdrawUser() 이후 호출 → clearAppleRefreshToken의 status='WITHDRAWN' 조건 충족
         if (SocialType.APPLE.equals(user.getSocialType()) && user.getAppleRefreshToken() != null) {
             boolean revoked = appleAuthClient.revokeToken(user.getAppleRefreshToken());
             if (revoked) {
-                user.updateAppleRefreshToken(null);
+                userRepository.clearAppleRefreshToken(user.getId(), user.getAppleRefreshToken());
             }
         }
-
-        user.withdraw();
     }
 }


### PR DESCRIPTION
## 개요
<!---- 자신이 완료한 이슈를 닫아주세요 -->
- closed #613 //이슈 번호는 추적을 위해 필요합니다!
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
`status=WITHDRAWN`이 DB에 저장되지 않고, UserImage가 삭제 후 cascade로 재삽입되는 문제 수정
- `@Modifying @Query`로 탈퇴 status 직접 UPDATE
- clearUserImage()로 참조 해제 후 orphanRemoval 위임하여 CascadeType.PERSIST에 의한 재삽입 방지

<!---- Resolves: #613  -->

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [X] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [X] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

📣 **To Reviewers**
---
<!-- 전달사항 -->

- Reviewers : 팀 선택
- Labels : 작업 유형, 자기 자신


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 회원 탈퇴 처리 시 계정 상태와 변경 시간이 안정적으로 반영됩니다.
  * 탈퇴 과정에서 프로필 이미지 정보가 정상적으로 정리됩니다.
  * Apple 계정 연동 해제 시 저장된 갱신 토큰도 함께 제거됩니다.
  * 탈퇴에 필요한 사용자 데이터와 공유 정보 정리 흐름이 일관되게 처리됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->